### PR TITLE
Fix text size controls to scale SVG timeline text

### DIFF
--- a/src/components/onboarding/TimelinePreview.jsx
+++ b/src/components/onboarding/TimelinePreview.jsx
@@ -22,7 +22,7 @@ export default function TimelinePreview({ milestones = [] }) {
 
   return (
     <div className="timeline-preview" ref={ref}>
-      <svg width={width} height={HEIGHT} style={{ display: 'block' }}>
+      <svg width={width} height={HEIGHT} style={{ display: 'block', fontSize: '1rem' }}>
         <defs>
           <linearGradient id="prev-left"  x1="0" x2="1" y1="0" y2="0">
             <stop offset="0"   stopColor="#0F1117" stopOpacity="1" />
@@ -49,7 +49,7 @@ export default function TimelinePreview({ milestones = [] }) {
           x={todayX} y={6}
           textAnchor="middle"
           fill="#C8A96E"
-          fontSize={8}
+          fontSize="0.5em"
           fontFamily="'Courier Prime', monospace"
           opacity={0.7}
         >
@@ -75,7 +75,7 @@ export default function TimelinePreview({ milestones = [] }) {
                 x={x} y={above ? y - 7 : y + 13}
                 textAnchor="middle"
                 fill="rgba(232,224,208,0.7)"
-                fontSize={7}
+                fontSize="0.44em"
                 fontFamily="'Courier Prime', monospace"
               >
                 {m.title.length > 14 ? m.title.slice(0, 14) + '…' : m.title}

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -74,7 +74,7 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, onMilestoneCli
         width={w}
         height={h}
         viewBox={`0 0 ${w} ${h}`}
-        style={{ display: 'block' }}
+        style={{ display: 'block', fontSize: '1rem' }}
       >
         <defs>
           <linearGradient id="tl-left" x1="0" x2="1" y1="0" y2="0">
@@ -101,7 +101,7 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, onMilestoneCli
                 x={tick.x} y={axisY + 20}
                 textAnchor="middle"
                 fill={tick.major ? 'rgba(232,224,208,0.35)' : 'rgba(232,224,208,0.18)'}
-                fontSize={tick.major ? 11 : 9}
+                fontSize={tick.major ? '0.69em' : '0.56em'}
                 fontFamily="'Courier Prime', monospace"
               >
                 {tick.label}
@@ -128,7 +128,7 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, onMilestoneCli
             <text
               x={todayX} y={16}
               textAnchor="middle"
-              fill="#C8A96E" fontSize={9}
+              fill="#C8A96E" fontSize="0.56em"
               fontFamily="'Courier Prime', monospace"
               opacity={0.75}
             >
@@ -177,7 +177,7 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, onMilestoneCli
                 x={x} y={labelY}
                 textAnchor="middle"
                 fill="rgba(232,224,208,0.82)"
-                fontSize={9.5}
+                fontSize="0.59em"
                 fontFamily="'Courier Prime', monospace"
               >
                 {label}


### PR DESCRIPTION
SVG fontSize attributes are pixel-absolute and ignore the root font-size. Switch all SVG text elements to em units (relative to the SVG's font-size:1rem), so the small/normal/big/bigger buttons now affect the timeline labels too.

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY