### PR TITLE
Stat panel details, category filter, slower zoom, typing effects, log…

### DIFF
--- a/src/components/stats/StatsPanel.jsx
+++ b/src/components/stats/StatsPanel.jsx
@@ -1,16 +1,49 @@
 import React from 'react'
-import { relativeLabel } from '../../utils/dates'
+import { formatDateDisplay, relativeLabel } from '../../utils/dates'
+import TypewriterText from '../ui/TypewriterText'
+
+function StatMilestone({ m, align }) {
+  const dateStr = formatDateDisplay(m.date, m.date_precision)
+  const relStr  = relativeLabel(m.date, m.date_precision)
+  // key includes updated_at so edits re-trigger the typewriter
+  const k = m.id + (m.updated_at || '')
+
+  return (
+    <div className={`stat-milestone ${align === 'right' ? 'stat-milestone-right' : ''}`}>
+      <div className="stat-milestone-title">
+        <TypewriterText
+          key={k + 'title'}
+          text={m.title}
+          options={{ delay: 18, jitter: 10 }}
+          showCursor={false}
+        />
+      </div>
+      <div className="stat-milestone-date">
+        <TypewriterText
+          key={k + 'date'}
+          text={dateStr}
+          options={{ delay: 14, jitter: 6, startDelay: 180 }}
+          showCursor={false}
+        />
+      </div>
+      <div className="stat-milestone-rel">
+        <TypewriterText
+          key={k + 'rel'}
+          text={relStr}
+          options={{ delay: 14, jitter: 6, startDelay: 320 }}
+          showCursor={false}
+        />
+      </div>
+    </div>
+  )
+}
 
 export default function StatsPanel({ milestones }) {
-  const now = new Date()
-
+  const now    = new Date()
   const past   = milestones.filter(m => new Date(m.date) < now)
-    .sort((a, b) => new Date(b.date) - new Date(a.date)) // most recent first
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
   const future = milestones.filter(m => new Date(m.date) >= now)
-    .sort((a, b) => new Date(a.date) - new Date(b.date)) // soonest first
-
-  const nearest = past[0]
-  const next    = future[0]
+    .sort((a, b) => new Date(a.date) - new Date(b.date))
 
   return (
     <div className="stat-panels">
@@ -20,13 +53,7 @@ export default function StatsPanel({ milestones }) {
         <div className="stat-panel-count">
           {past.length} milestone{past.length !== 1 ? 's' : ''}
         </div>
-        {nearest && (
-          <div className="stat-panel-item" title={nearest.title}>
-            {nearest.title.length > 18 ? nearest.title.slice(0, 18) + '…' : nearest.title}
-            {' · '}
-            {relativeLabel(nearest.date, nearest.date_precision)}
-          </div>
-        )}
+        {past[0] && <StatMilestone m={past[0]} align="left" />}
       </div>
 
       {/* Right — future */}
@@ -35,13 +62,7 @@ export default function StatsPanel({ milestones }) {
         <div className="stat-panel-count">
           {future.length} milestone{future.length !== 1 ? 's' : ''}
         </div>
-        {next && (
-          <div className="stat-panel-item" title={next.title}>
-            {next.title.length > 18 ? next.title.slice(0, 18) + '…' : next.title}
-            {' · '}
-            {relativeLabel(next.date, next.date_precision)}
-          </div>
-        )}
+        {future[0] && <StatMilestone m={future[0]} align="right" />}
       </div>
     </div>
   )

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -3,7 +3,9 @@ import Timeline          from './Timeline'
 import StatsPanel        from '../stats/StatsPanel'
 import AddMilestoneSheet from '../milestone/AddMilestoneSheet'
 import MilestoneDetail   from '../milestone/MilestoneDetail'
+import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS }   from '../../utils/timeline'
+import { CATEGORIES }    from '../../utils/colors'
 import { addMilestone, updateMilestone, deleteMilestone } from '../../data/milestones'
 
 const ZOOM_RANK = { decades: 4, years: 3, months: 2, weeks: 1 }
@@ -15,18 +17,22 @@ const TEXT_SIZES = {
   bigger: '30px',
 }
 
+// Zoom animation duration must match CSS transition duration
+const ZOOM_ANIM_MS = 380
+
 export default function TimelineView({ milestones, setMilestones }) {
-  const [zoom,        setZoom]      = useState('years')
-  const [zoomAnim,    setZoomAnim]  = useState('')
-  const [addOpen,     setAddOpen]   = useState(false)
-  const [editTarget,  setEditTarget] = useState(null)
-  const [detail,      setDetail]    = useState(null)
-  const [textSize,    setTextSize]  = useState(
+  const [zoom,       setZoom]      = useState('years')
+  const [zoomAnim,   setZoomAnim]  = useState('')
+  const [filter,     setFilter]    = useState('all')
+  const [addOpen,    setAddOpen]   = useState(false)
+  const [editTarget, setEditTarget] = useState(null)
+  const [detail,     setDetail]    = useState(null)
+  const [textSize,   setTextSize]  = useState(
     () => localStorage.getItem('lifeglance-text-size') || 'normal'
   )
   const timelineRef = useRef(null)
 
-  // Apply font size to root whenever it changes
+  // Apply font size globally
   useEffect(() => {
     document.documentElement.style.fontSize = TEXT_SIZES[textSize]
     localStorage.setItem('lifeglance-text-size', textSize)
@@ -40,8 +46,17 @@ export default function TimelineView({ milestones, setMilestones }) {
     setTimeout(() => {
       setZoom(newZoom)
       setZoomAnim('')
-    }, 130)
+    }, ZOOM_ANIM_MS)
   }, [zoom])
+
+  // ── Filter ───────────────────────────────────────────────────────────────────
+  // Only show filter chips for categories that appear in the data
+  const presentCategories = CATEGORIES.filter(cat =>
+    milestones.some(m => m.category === cat.id)
+  )
+  const filteredMilestones = filter === 'all'
+    ? milestones
+    : milestones.filter(m => m.category === filter)
 
   // ── CRUD ─────────────────────────────────────────────────────────────────────
   async function handleSave(data, existing) {
@@ -59,17 +74,10 @@ export default function TimelineView({ milestones, setMilestones }) {
     setMilestones(prev => prev.filter(m => m.id !== id))
   }
 
-  function openEdit(m) {
-    setEditTarget(m)
-    setAddOpen(true)
-  }
+  function openEdit(m) { setEditTarget(m); setAddOpen(true) }
+  function closeSheet() { setAddOpen(false); setEditTarget(null) }
 
-  function closeSheet() {
-    setAddOpen(false)
-    setEditTarget(null)
-  }
-
-  const isEmpty = milestones.length === 0
+  const isEmpty = filteredMilestones.length === 0 && milestones.length === 0
 
   return (
     <div className="timeline-view">
@@ -80,58 +88,97 @@ export default function TimelineView({ milestones, setMilestones }) {
           <span className="logo-glance">GLANCE</span>
         </div>
 
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-          {/* Text size controls */}
-          <div className="zoom-tabs">
-            {Object.keys(TEXT_SIZES).map(s => (
-              <button
-                key={s}
-                className={`zoom-tab ${textSize === s ? 'active' : ''}`}
-                onClick={() => setTextSize(s)}
-                title={`Text size: ${s}`}
-              >
-                {s}
-              </button>
-            ))}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.25rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            {/* Text size */}
+            <div className="zoom-tabs">
+              {Object.keys(TEXT_SIZES).map(s => (
+                <button
+                  key={s}
+                  className={`zoom-tab ${textSize === s ? 'active' : ''}`}
+                  onClick={() => setTextSize(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+
+            {/* Zoom level */}
+            <div className="zoom-tabs">
+              {ZOOM_LEVELS.map(z => (
+                <button
+                  key={z}
+                  className={`zoom-tab ${zoom === z ? 'active' : ''}`}
+                  onClick={() => handleZoom(z)}
+                >
+                  {z}
+                </button>
+              ))}
+            </div>
           </div>
 
-          {/* Zoom level controls */}
-          <div className="zoom-tabs">
-            {ZOOM_LEVELS.map(z => (
-              <button
-                key={z}
-                className={`zoom-tab ${zoom === z ? 'active' : ''}`}
-                onClick={() => handleZoom(z)}
-              >
-                {z}
-              </button>
-            ))}
+          {/* Typed zoom indicator */}
+          <div className="zoom-indicator">
+            <TypewriterText
+              key={zoom}
+              text={`viewing: ${zoom}`}
+              options={{ delay: 38, jitter: 18 }}
+              showCursor={false}
+              hideCursorWhenDone
+            />
           </div>
         </div>
       </div>
 
+      {/* ── Filter bar ─────────────────────────────────────────────────────── */}
+      {presentCategories.length > 0 && (
+        <div className="filter-bar">
+          <button
+            className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
+            onClick={() => setFilter('all')}
+          >
+            all
+          </button>
+          {presentCategories.map(cat => (
+            <button
+              key={cat.id}
+              className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
+              onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}
+            >
+              <span className="filter-dot" style={{ background: cat.color }} />
+              {cat.label}
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* ── Body ───────────────────────────────────────────────────────────── */}
       <div className="timeline-body">
-        {/* Stat panels overlay (top corners) */}
-        {!isEmpty && <StatsPanel milestones={milestones} />}
+        {!isEmpty && <StatsPanel milestones={filteredMilestones} />}
 
-        {/* Timeline with zoom animation wrapper */}
         <div className={`timeline-zoom-wrap ${zoomAnim}`}>
           <Timeline
             ref={timelineRef}
-            milestones={milestones}
+            milestones={filteredMilestones}
             zoom={zoom}
             textSize={textSize}
             onMilestoneClick={setDetail}
           />
         </div>
 
-        {/* Empty state */}
         {isEmpty && (
           <div className="empty-state">
             <div className="empty-state-label">
               no milestones yet.<br />
               add one to start your timeline.
+            </div>
+          </div>
+        )}
+
+        {!isEmpty && filteredMilestones.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-state-label">
+              no milestones in this category.
             </div>
           </div>
         )}
@@ -142,23 +189,15 @@ export default function TimelineView({ milestones, setMilestones }) {
         <button className="add-milestone-btn" onClick={() => setAddOpen(true)}>
           + add milestone
         </button>
-        <button
-          className="today-btn"
-          onClick={() => timelineRef.current?.resetPan()}
-        >
+        <button className="today-btn" onClick={() => timelineRef.current?.resetPan()}>
           jump to today
         </button>
       </div>
 
       {/* ── Sheets ─────────────────────────────────────────────────────────── */}
       {addOpen && (
-        <AddMilestoneSheet
-          onSave={handleSave}
-          onClose={closeSheet}
-          existing={editTarget}
-        />
+        <AddMilestoneSheet onSave={handleSave} onClose={closeSheet} existing={editTarget} />
       )}
-
       {detail && (
         <MilestoneDetail
           milestone={detail}

--- a/src/index.css
+++ b/src/index.css
@@ -90,15 +90,14 @@ button, input, select, textarea {
   letter-spacing: -0.02em;
 }
 .logo-glance {
-  font-size: 2.6rem;
+  font-size: 2.8rem;
   font-weight: 700;
+  font-style: italic;
   color: var(--indigo);
   letter-spacing: -0.02em;
 }
-.logo-sm .logo-life,
-.logo-sm .logo-glance {
-  font-size: 1.25rem;
-}
+.logo-sm .logo-life   { font-size: 1.2rem; }
+.logo-sm .logo-glance { font-size: 1.3rem; }
 .logo-tagline {
   font-size: 0.9rem;
   color: var(--text-muted);
@@ -365,7 +364,7 @@ button, input, select, textarea {
   flex: 1;
   display: flex;
   flex-direction: column;
-  transition: transform 0.18s ease-out;
+  transition: transform 0.42s cubic-bezier(0.25, 0.46, 0.45, 0.94);
   transform-origin: center center;
 }
 .timeline-zoom-wrap.zooming-out {
@@ -415,6 +414,44 @@ button, input, select, textarea {
 }
 .today-btn:hover { color: var(--amber); border-color: var(--amber-dim); }
 
+/* ─── Zoom indicator ───────────────────────────────────────────────────────── */
+.zoom-indicator {
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  letter-spacing: 0.07em;
+  min-height: 0.8rem;
+}
+
+/* ─── Filter bar ───────────────────────────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.4rem 1.1rem;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  align-items: center;
+  flex-shrink: 0;
+  background: var(--bg);
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 0.68rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  letter-spacing: 0.03em;
+}
+.filter-chip:hover { color: var(--text-dim); border-color: var(--amber-dim); }
+.filter-chip.active { color: var(--amber); border-color: var(--amber); }
+.filter-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+
 /* ─── Stat panels ──────────────────────────────────────────────────────────── */
 .stat-panels {
   pointer-events: none;
@@ -441,17 +478,14 @@ button, input, select, textarea {
   font-size: 0.65rem;
   text-transform: lowercase;
 }
-.stat-panel-count {
-  color: var(--text-dim);
-}
-.stat-panel-item {
-  color: var(--text-muted);
-  margin-top: 0.15rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.stat-panel-count { color: var(--text-dim); }
 .stat-panel-right { text-align: right; }
+
+.stat-milestone { margin-top: 0.5rem; line-height: 1.45; }
+.stat-milestone-right { text-align: right; }
+.stat-milestone-title { font-size: 0.72rem; color: var(--text-dim); }
+.stat-milestone-date  { font-size: 0.63rem; color: var(--text-muted); margin-top: 0.1rem; }
+.stat-milestone-rel   { font-size: 0.63rem; color: var(--amber);      margin-top: 0.08rem; }
 
 /* ─── Sheet / Drawer ───────────────────────────────────────────────────────── */
 .sheet-overlay {


### PR DESCRIPTION
…o fix

Stat panels:
- Full title with wrapping (no truncation)
- Date and relative time shown below title
- Each field types in via TypewriterText on mount/change (key includes updated_at so edits re-trigger)

Category filter bar:
- Appears below header when milestones exist
- Shows only categories present in current data
- Defaults to "all"; click active chip to deselect back to all
- Filtered milestones flow to both Timeline and StatsPanel

Zoom transition:
- CSS duration 0.18s → 0.42s with cubic-bezier ease
- Snap timeout 130ms → 380ms (matches animation)
- "viewing: <zoom>" indicator types itself when zoom changes

Logo (header):
- GLANCE is now slightly larger (1.3rem vs life's 1.2rem) and italic
- Full logo: GLANCE bumped to 2.8rem, italic

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY