### PR TITLE
Fix off-screen cards and move filters to bottom bar

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -130,28 +130,6 @@ export default function TimelineView({ milestones, setMilestones }) {
         </div>
       </div>
 
-      {/* ── Filter bar ─────────────────────────────────────────────────────── */}
-      {presentCategories.length > 0 && (
-        <div className="filter-bar">
-          <button
-            className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
-            onClick={() => setFilter('all')}
-          >
-            all
-          </button>
-          {presentCategories.map(cat => (
-            <button
-              key={cat.id}
-              className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
-              onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}
-            >
-              <span className="filter-dot" style={{ background: cat.color }} />
-              {cat.label}
-            </button>
-          ))}
-        </div>
-      )}
-
       {/* ── Body ───────────────────────────────────────────────────────────── */}
       <div className="timeline-body">
         {!isEmpty && <StatsPanel milestones={filteredMilestones} />}
@@ -189,6 +167,28 @@ export default function TimelineView({ milestones, setMilestones }) {
         <button className="add-milestone-btn" onClick={() => setAddOpen(true)}>
           + add milestone
         </button>
+
+        {presentCategories.length > 0 && (
+          <div className="filter-chips-inline">
+            <button
+              className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
+              onClick={() => setFilter('all')}
+            >
+              all
+            </button>
+            {presentCategories.map(cat => (
+              <button
+                key={cat.id}
+                className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
+                onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}
+              >
+                <span className="filter-dot" style={{ background: cat.color }} />
+                {cat.label}
+              </button>
+            ))}
+          </div>
+        )}
+
         <button className="today-btn" onClick={() => timelineRef.current?.resetPan()}>
           jump to today
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -422,16 +422,14 @@ button, input, select, textarea {
   min-height: 0.8rem;
 }
 
-/* ─── Filter bar ───────────────────────────────────────────────────────────── */
-.filter-bar {
+/* ─── Filter chips (inline in bottom bar) ──────────────────────────────────── */
+.filter-chips-inline {
   display: flex;
   gap: 0.35rem;
-  padding: 0.4rem 1.1rem;
-  border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
   align-items: center;
-  flex-shrink: 0;
-  background: var(--bg);
+  flex: 1;
+  justify-content: center;
 }
 
 .filter-chip {

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -91,6 +91,6 @@ export function assignLanes(milestones) {
   return sorted.map((m, i) => ({
     ...m,
     above: i % 2 === 0,
-    lane: Math.floor(i / 2),
+    lane: 0,
   }))
 }


### PR DESCRIPTION
- assignLanes: always use lane 0 so cards stay adjacent to the axis
- Move category filter chips from standalone bar into timeline-bottom, centered between the add and today buttons
- Replace .filter-bar CSS with .filter-chips-inline for the new layout

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY