### PR TITLE
Use time-proximity collision detection for lane assignment

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -83,12 +83,13 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
   const today     = new Date()
   const centerMs  = today.getTime() + panMs
   const { startMs, endMs } = getTimeRange(zoom, centerMs)
-  const ticks     = getTickMarks(zoom, startMs, endMs, w)
-  const todayX    = dateToX(today.getTime(), startMs, endMs, w)
-  // How many lanes fit between the axis and the top/bottom edge (with 16px margin)
-  const maxLane   = Math.max(0, Math.floor((axisY - CONN_LEN - CARD_H2 - 16) / CARD_STEP))
-  const withLanes = assignLanes(milestones, maxLane)
-  const msPerPx   = getMsPerPx(zoom, w)
+  const ticks        = getTickMarks(zoom, startMs, endMs, w)
+  const todayX       = dateToX(today.getTime(), startMs, endMs, w)
+  const msPerPx      = getMsPerPx(zoom, w)
+  // Max lanes that fit between axis and container edge (16px safety margin)
+  const maxLane      = Math.max(0, Math.floor((axisY - CONN_LEN - CARD_H2 - 16) / CARD_STEP))
+  // Only bump to a higher lane when cards would actually overlap horizontally
+  const withLanes    = assignLanes(milestones, maxLane, msPerPx * CARD_W)
 
   // ── Pan ─────────────────────────────────────────────────────────────────────
   const startDrag = useCallback((clientX) => {

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -83,15 +83,38 @@ export function getTickMarks(zoom, startMs, endMs, width) {
 }
 
 // Assign above/below lanes to sorted milestones.
-// maxLane caps how far cards can stray from the axis (caller computes from geometry).
-// Returns array of milestones with { above: bool, lane: number (0-based) }
-export function assignLanes(milestones, maxLane = 0) {
+//   maxLane      – max lane index that fits in the container (caller computes)
+//   cardTimeSpan – ms equivalent of one card width at current zoom (for overlap detection)
+//
+// Algorithm: greedy by time proximity. For each milestone try lane 0; only bump
+// to a higher lane if another card on the same side is within one card-width of
+// time. This means sparse milestones always stay at lane 0 regardless of sort
+// order, and only genuinely clustered milestones spread outward.
+export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0) {
   const sorted = [...milestones].sort(
     (a, b) => new Date(a.date) - new Date(b.date)
   )
-  return sorted.map((m, i) => ({
-    ...m,
-    above: i % 2 === 0,
-    lane: Math.min(Math.floor(i / 2), maxLane),
-  }))
+
+  // Track placed cards per side: [{ ms, lane }]
+  const placed = { above: [], below: [] }
+
+  return sorted.map((m, i) => {
+    const above = i % 2 === 0
+    const side  = above ? 'above' : 'below'
+    const mMs   = new Date(m.date).getTime()
+
+    let lane = 0
+    if (cardTimeSpan > 0) {
+      while (lane < maxLane) {
+        const conflict = placed[side].some(
+          p => p.lane === lane && Math.abs(p.ms - mMs) < cardTimeSpan
+        )
+        if (!conflict) break
+        lane++
+      }
+    }
+
+    placed[side].push({ ms: mMs, lane })
+    return { ...m, above, lane }
+  })
 }


### PR DESCRIPTION
Instead of bumping every pair of milestones to a new lane by index, only push to a higher lane when two cards on the same side are within one card-width of time of each other (cardTimeSpan = msPerPx * CARD_W).

Sparse milestones always sit at lane 0. Clustered milestones spread outward only as needed, capped at maxLane so nothing goes off-screen.

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY