### PR TITLE
Add 30yr zoom level and custom year-range view

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -39,7 +39,7 @@ function wrapTitle(text, maxChars) {
   return line2 ? [line1, line2] : [line1]
 }
 
-const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'normal', onMilestoneClick }, ref) {
+const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0 }, ref) {
   // All card geometry derived from the current rem size so cards scale with text
   const remPx = REM_PX[textSize] || 22
 
@@ -82,10 +82,10 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
   const axisY     = Math.round(h * 0.5)
   const today     = new Date()
   const centerMs  = today.getTime() + panMs
-  const { startMs, endMs } = getTimeRange(zoom, centerMs)
+  const { startMs, endMs } = getTimeRange(zoom, centerMs, customHalfMs)
   const ticks        = getTickMarks(zoom, startMs, endMs, w)
   const todayX       = dateToX(today.getTime(), startMs, endMs, w)
-  const msPerPx      = getMsPerPx(zoom, w)
+  const msPerPx      = getMsPerPx(zoom, w, customHalfMs)
   // Max lanes that fit between axis and container edge (16px safety margin)
   const maxLane      = Math.max(0, Math.floor((axisY - CONN_LEN - CARD_H2 - 16) / CARD_STEP))
   // Only bump to a higher lane when cards would actually overlap horizontally

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -8,7 +8,7 @@ import { ZOOM_LEVELS }   from '../../utils/timeline'
 import { CATEGORIES }    from '../../utils/colors'
 import { addMilestone, updateMilestone, deleteMilestone } from '../../data/milestones'
 
-const ZOOM_RANK = { decades: 4, years: 3, months: 2, weeks: 1 }
+const ZOOM_RANK = { decades: 5, '30yr': 4, years: 3, months: 2, weeks: 1, custom: 3.5 }
 
 const TEXT_SIZES = {
   small:  '19px',
@@ -30,6 +30,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [textSize,   setTextSize]  = useState(
     () => localStorage.getItem('lifeglance-text-size') || 'normal'
   )
+  const [customYears, setCustomYears] = useState(15)   // ±15 yr = 30-year window
   const timelineRef  = useRef(null)
   const zoomWrapRef  = useRef(null)
   const zoomRef      = useRef('years')   // mirrors zoom state, readable in event handlers
@@ -145,18 +146,42 @@ export default function TimelineView({ milestones, setMilestones }) {
                   {z}
                 </button>
               ))}
+              <button
+                className={`zoom-tab ${zoom === 'custom' ? 'active' : ''}`}
+                onClick={() => handleZoom('custom')}
+              >
+                custom
+              </button>
             </div>
           </div>
 
-          {/* Typed zoom indicator */}
+          {/* Zoom indicator / custom range input */}
           <div className="zoom-indicator">
-            <TypewriterText
-              key={zoom}
-              text={`viewing: ${zoom}`}
-              options={{ delay: 38, jitter: 18 }}
-              showCursor={false}
-              hideCursorWhenDone
-            />
+            {zoom === 'custom' ? (
+              <div className="custom-zoom-row">
+                <span>±</span>
+                <input
+                  className="custom-zoom-input"
+                  type="number"
+                  min="1"
+                  max="200"
+                  value={customYears}
+                  onChange={e => {
+                    const v = parseInt(e.target.value, 10)
+                    if (!isNaN(v)) setCustomYears(Math.max(1, Math.min(200, v)))
+                  }}
+                />
+                <span>yr</span>
+              </div>
+            ) : (
+              <TypewriterText
+                key={zoom}
+                text={`viewing: ${zoom}`}
+                options={{ delay: 38, jitter: 18 }}
+                showCursor={false}
+                hideCursorWhenDone
+              />
+            )}
           </div>
         </div>
       </div>
@@ -171,6 +196,7 @@ export default function TimelineView({ milestones, setMilestones }) {
             milestones={filteredMilestones}
             zoom={zoom}
             textSize={textSize}
+            customHalfMs={customYears * 365.25 * 24 * 3600 * 1000}
             onMilestoneClick={setDetail}
           />
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -422,6 +422,29 @@ button, input, select, textarea {
   min-height: 0.8rem;
 }
 
+.custom-zoom-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--amber);
+}
+
+.custom-zoom-input {
+  width: 3.2rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--amber-dim);
+  color: var(--amber);
+  font-family: var(--font);
+  font-size: 0.6rem;
+  text-align: center;
+  outline: none;
+  padding: 0 0.1rem;
+  -moz-appearance: textfield;
+}
+.custom-zoom-input::-webkit-outer-spin-button,
+.custom-zoom-input::-webkit-inner-spin-button { -webkit-appearance: none; }
+
 /* ─── Filter chips (inline in bottom bar) ──────────────────────────────────── */
 .filter-chips-inline {
   display: flex;

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -1,19 +1,18 @@
-export const ZOOM_LEVELS = ['decades', 'years', 'months', 'weeks']
+export const ZOOM_LEVELS = ['decades', '30yr', 'years', 'months', 'weeks']
 
-// Half-range in milliseconds for each zoom level (total range = 2×)
+// Half-range in milliseconds for each named zoom level (total range = 2×)
 const HALF_RANGE_MS = {
   decades: 50  * 365.25 * 24 * 3600 * 1000,
+  '30yr':  30  * 365.25 * 24 * 3600 * 1000,
   years:   10  * 365.25 * 24 * 3600 * 1000,
   months:  18  *  30.44 * 24 * 3600 * 1000,
   weeks:   13  *   7    * 24 * 3600 * 1000,
 }
 
-export function getTimeRange(zoom, centerMs) {
-  const half = HALF_RANGE_MS[zoom]
-  return {
-    startMs: centerMs - half,
-    endMs:   centerMs + half,
-  }
+// customHalfMs is only used when zoom === 'custom'
+export function getTimeRange(zoom, centerMs, customHalfMs = 0) {
+  const half = zoom === 'custom' ? customHalfMs : HALF_RANGE_MS[zoom]
+  return { startMs: centerMs - half, endMs: centerMs + half }
 }
 
 export function dateToX(dateMs, startMs, endMs, width) {
@@ -26,17 +25,32 @@ export function xToMs(x, startMs, endMs, width) {
   return startMs + (x / width) * (endMs - startMs)
 }
 
-export function getMsPerPx(zoom, width) {
-  return (HALF_RANGE_MS[zoom] * 2) / width
+export function getMsPerPx(zoom, width, customHalfMs = 0) {
+  const half = zoom === 'custom' ? customHalfMs : HALF_RANGE_MS[zoom]
+  return (half * 2) / width
+}
+
+// Pick the best tick-mark visual style for a given span
+function autoStyle(startMs, endMs) {
+  const spanYears = (endMs - startMs) / (365.25 * 24 * 3600 * 1000)
+  if (spanYears > 15)  return 'decades'
+  if (spanYears > 2)   return 'years'
+  if (spanYears > 0.4) return 'months'
+  return 'weeks'
 }
 
 // Generate tick marks for the current view
 export function getTickMarks(zoom, startMs, endMs, width) {
-  const ticks = []
+  // 'custom' auto-selects its visual style; '30yr' uses the same style as 'decades'
+  const style = zoom === 'custom' ? autoStyle(startMs, endMs)
+              : zoom === '30yr'   ? 'decades'
+              : zoom
+
+  const ticks     = []
   const startDate = new Date(startMs)
   const endDate   = new Date(endMs)
 
-  if (zoom === 'decades') {
+  if (style === 'decades') {
     const startYear = Math.floor(startDate.getFullYear() / 10) * 10
     for (let y = startYear; y <= endDate.getFullYear(); y++) {
       const x = dateToX(new Date(y, 0, 1).getTime(), startMs, endMs, width)
@@ -44,13 +58,13 @@ export function getTickMarks(zoom, startMs, endMs, width) {
       const major = y % 10 === 0
       ticks.push({ x, label: major ? String(y) : (y % 5 === 0 ? String(y) : ''), major })
     }
-  } else if (zoom === 'years') {
+  } else if (style === 'years') {
     for (let y = startDate.getFullYear(); y <= endDate.getFullYear(); y++) {
       const x = dateToX(new Date(y, 0, 1).getTime(), startMs, endMs, width)
       if (x < -2 || x > width + 2) continue
       ticks.push({ x, label: String(y), major: true })
     }
-  } else if (zoom === 'months') {
+  } else if (style === 'months') {
     let d = new Date(startDate.getFullYear(), startDate.getMonth(), 1)
     while (d <= endDate) {
       const x = dateToX(d.getTime(), startMs, endMs, width)
@@ -63,7 +77,7 @@ export function getTickMarks(zoom, startMs, endMs, width) {
       }
       d = new Date(d.getFullYear(), d.getMonth() + 1, 1)
     }
-  } else if (zoom === 'weeks') {
+  } else if (style === 'weeks') {
     let d = new Date(startDate)
     d.setDate(d.getDate() - d.getDay()) // align to Sunday
     while (d <= endDate) {


### PR DESCRIPTION
- New '30yr' level (±30yr = 60-year window) bridges years→decades gap: weeks → months → years → 30yr → decades
- 'custom' zoom: shows ± N yr input in the indicator area; tick marks auto-select style (decades/years/months/weeks) based on actual span
- getTimeRange/getMsPerPx/getTickMarks all accept customHalfMs param
- Spinner hidden on the number input for clean terminal look

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY