### PR TITLE
Four UX improvements: randomness, backup, nav arrows, smooth pan

### DIFF
--- a/src/components/stats/StatsPanel.jsx
+++ b/src/components/stats/StatsPanel.jsx
@@ -5,46 +5,40 @@ import TypewriterText from '../ui/TypewriterText'
 function StatMilestone({ m, align }) {
   const dateStr = formatDateDisplay(m.date, m.date_precision)
   const relStr  = relativeLabel(m.date, m.date_precision)
-  // key includes updated_at so edits re-trigger the typewriter
   const k = m.id + (m.updated_at || '')
 
   return (
     <div className={`stat-milestone ${align === 'right' ? 'stat-milestone-right' : ''}`}>
       <div className="stat-milestone-title">
-        <TypewriterText
-          key={k + 'title'}
-          text={m.title}
-          options={{ delay: 18, jitter: 10 }}
-          showCursor={false}
-        />
+        <TypewriterText key={k + 'title'} text={m.title}
+          options={{ delay: 18, jitter: 10 }} showCursor={false} />
       </div>
       <div className="stat-milestone-date">
-        <TypewriterText
-          key={k + 'date'}
-          text={dateStr}
-          options={{ delay: 14, jitter: 6, startDelay: 180 }}
-          showCursor={false}
-        />
+        <TypewriterText key={k + 'date'} text={dateStr}
+          options={{ delay: 14, jitter: 6, startDelay: 180 }} showCursor={false} />
       </div>
       <div className="stat-milestone-rel">
-        <TypewriterText
-          key={k + 'rel'}
-          text={relStr}
-          options={{ delay: 14, jitter: 6, startDelay: 320 }}
-          showCursor={false}
-        />
+        <TypewriterText key={k + 'rel'} text={relStr}
+          options={{ delay: 14, jitter: 6, startDelay: 320 }} showCursor={false} />
       </div>
     </div>
   )
 }
 
-export default function StatsPanel({ milestones }) {
-  const now    = new Date()
-  const past   = milestones.filter(m => new Date(m.date) < now)
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-  const future = milestones.filter(m => new Date(m.date) >= now)
-    .sort((a, b) => new Date(a.date) - new Date(b.date))
+function NavRow({ idx, total, onChange, align }) {
+  if (total <= 1) return null
+  const atStart = idx <= 0
+  const atEnd   = idx >= total - 1
+  return (
+    <div className={`stat-nav-row ${align === 'right' ? 'stat-nav-row-right' : ''}`}>
+      <button className="stat-nav-btn" onClick={() => onChange(idx - 1)} disabled={atStart}>←</button>
+      <span className="stat-nav-pos">{idx + 1}/{total}</span>
+      <button className="stat-nav-btn" onClick={() => onChange(idx + 1)} disabled={atEnd}>→</button>
+    </div>
+  )
+}
 
+export default function StatsPanel({ past, future, pastIdx, futureIdx, onPastChange, onFutureChange }) {
   return (
     <div className="stat-panels">
       {/* Left — past */}
@@ -53,7 +47,9 @@ export default function StatsPanel({ milestones }) {
         <div className="stat-panel-count">
           {past.length} milestone{past.length !== 1 ? 's' : ''}
         </div>
-        {past[0] && <StatMilestone m={past[0]} align="left" />}
+        {/* navigate further-back (←) and back-toward-now (→) */}
+        <NavRow idx={pastIdx} total={past.length} onChange={onPastChange} align="left" />
+        {past[pastIdx] && <StatMilestone m={past[pastIdx]} align="left" />}
       </div>
 
       {/* Right — future */}
@@ -62,7 +58,9 @@ export default function StatsPanel({ milestones }) {
         <div className="stat-panel-count">
           {future.length} milestone{future.length !== 1 ? 's' : ''}
         </div>
-        {future[0] && <StatMilestone m={future[0]} align="right" />}
+        {/* navigate closer (←) and further-ahead (→) */}
+        <NavRow idx={futureIdx} total={future.length} onChange={onFutureChange} align="right" />
+        {future[futureIdx] && <StatMilestone m={future[futureIdx]} align="right" />}
       </div>
     </div>
   )

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -12,60 +12,74 @@ const REM_PX = { small: 19, normal: 22, big: 26, bigger: 30 }
 // Courier Prime is monospace so char-count is a reliable width proxy.
 function wrapTitle(text, maxChars) {
   if (text.length <= maxChars) return [text]
-
-  // Walk words, filling line 1 then line 2
   const words = text.split(' ')
   let line1 = '', line2 = ''
-
   for (const word of words) {
     const candidate = line1 ? line1 + ' ' + word : word
     if (!line1 || candidate.length <= maxChars) {
       line1 = candidate
     } else if (!line2) {
-      // Start line 2
       line2 = word.length > maxChars ? word.slice(0, maxChars - 1) + '…' : word
     } else {
       const c2 = line2 + ' ' + word
       if (c2.length <= maxChars) {
         line2 = c2
       } else {
-        // Truncate remainder onto line 2
         if (line2.length < maxChars - 1) line2 = line2 + ' ' + word.slice(0, maxChars - line2.length - 2) + '…'
         break
       }
     }
   }
-
   return line2 ? [line1, line2] : [line1]
 }
 
-const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0 }, ref) {
-  // All card geometry derived from the current rem size so cards scale with text
+const Timeline = forwardRef(function Timeline(
+  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds },
+  ref
+) {
   const remPx = REM_PX[textSize] || 22
 
-  // Card width — wide enough for ~17 Courier Prime chars at 0.6em
-  const CARD_W       = Math.round(remPx * 7.8)
-  // Title chars per line: available px / (0.6em * ~0.6 char-width ratio)
-  const TITLE_CHARS  = Math.floor((CARD_W - 20) / (remPx * 0.6 * 0.6))
-  // Connector gap from axis to nearest card edge
-  const CONN_LEN     = Math.round(remPx * 1.8)
-  // Vertical spacing constants (in SVG user-units = CSS px since viewBox matches)
-  const TOP_PAD      = Math.round(remPx * 0.65)   // top of card → first baseline
-  const TITLE_LH     = Math.round(remPx * 0.90)   // title line-to-line spacing
-  const SEC_GAP      = Math.round(remPx * 0.45)   // gap between title block and meta
-  const META_LH      = Math.round(remPx * 0.73)   // date / relative line spacing
-  const BOT_PAD      = Math.round(remPx * 0.40)   // baseline → card bottom
-  // Card heights for 1-line and 2-line titles
-  const CARD_H1      = TOP_PAD + META_LH + SEC_GAP + META_LH + META_LH + BOT_PAD
-  const CARD_H2      = TOP_PAD + META_LH + TITLE_LH + SEC_GAP + META_LH + META_LH + BOT_PAD
-  // Lane step: always use the taller (2-line) card so lanes never overlap
-  const CARD_STEP    = CARD_H2 + Math.round(remPx * 0.55)
+  const CARD_W      = Math.round(remPx * 7.8)
+  const TITLE_CHARS = Math.floor((CARD_W - 20) / (remPx * 0.6 * 0.6))
+  const CONN_LEN    = Math.round(remPx * 1.8)   // base connector gap axis→card
+  const TOP_PAD     = Math.round(remPx * 0.65)
+  const TITLE_LH    = Math.round(remPx * 0.90)
+  const SEC_GAP     = Math.round(remPx * 0.45)
+  const META_LH     = Math.round(remPx * 0.73)
+  const BOT_PAD     = Math.round(remPx * 0.40)
+  const CARD_H1     = TOP_PAD + META_LH + SEC_GAP + META_LH + META_LH + BOT_PAD
+  const CARD_H2     = TOP_PAD + META_LH + TITLE_LH + SEC_GAP + META_LH + META_LH + BOT_PAD
+  const CARD_STEP   = CARD_H2 + Math.round(remPx * 0.55)
+  // Max jitter adds 60% to CONN_LEN — use this for lane-fit calculation so
+  // even the tallest connector never pushes a card off-screen
+  const MAX_CONN    = Math.round(CONN_LEN * 1.6)
+
   const wrapRef = useRef(null)
   const [size, setSize] = useState({ w: 800, h: 340 })
   const [panMs, setPanMs] = useState(0)
+  const panMsRef = useRef(0)
+  const animRef  = useRef(null)
   const drag = useRef({ active: false, startX: 0, startPan: 0 })
 
-  useImperativeHandle(ref, () => ({ resetPan: () => setPanMs(0) }))
+  useEffect(() => { panMsRef.current = panMs }, [panMs])
+
+  // Smooth pan-to-today via ease-out cubic rAF loop
+  useImperativeHandle(ref, () => ({
+    resetPan: () => {
+      if (animRef.current) cancelAnimationFrame(animRef.current)
+      const start = panMsRef.current
+      if (Math.abs(start) < 500) { setPanMs(0); return }
+      const t0 = performance.now()
+      const dur = 480
+      function tick(now) {
+        const p = Math.min((now - t0) / dur, 1)
+        const eased = 1 - Math.pow(1 - p, 3)
+        setPanMs(start * (1 - eased))
+        if (p < 1) animRef.current = requestAnimationFrame(tick)
+      }
+      animRef.current = requestAnimationFrame(tick)
+    },
+  }), [])
 
   // Measure container
   useEffect(() => {
@@ -79,20 +93,20 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
   }, [])
 
   const { w, h } = size
-  const axisY     = Math.round(h * 0.5)
-  const today     = new Date()
-  const centerMs  = today.getTime() + panMs
+  const axisY    = Math.round(h * 0.5)
+  const today    = new Date()
+  const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRange(zoom, centerMs, customHalfMs)
-  const ticks        = getTickMarks(zoom, startMs, endMs, w)
-  const todayX       = dateToX(today.getTime(), startMs, endMs, w)
-  const msPerPx      = getMsPerPx(zoom, w, customHalfMs)
-  // Max lanes that fit between axis and container edge (16px safety margin)
-  const maxLane      = Math.max(0, Math.floor((axisY - CONN_LEN - CARD_H2 - 16) / CARD_STEP))
-  // Only bump to a higher lane when cards would actually overlap horizontally
-  const withLanes    = assignLanes(milestones, maxLane, msPerPx * CARD_W)
+  const ticks    = getTickMarks(zoom, startMs, endMs, w)
+  const todayX   = dateToX(today.getTime(), startMs, endMs, w)
+  const msPerPx  = getMsPerPx(zoom, w, customHalfMs)
+  // Use max possible connector length so no jittered card overflows
+  const maxLane  = Math.max(0, Math.floor((axisY - MAX_CONN - CARD_H2 - 16) / CARD_STEP))
+  const withLanes = assignLanes(milestones, maxLane, msPerPx * CARD_W)
 
   // ── Pan ─────────────────────────────────────────────────────────────────────
   const startDrag = useCallback((clientX) => {
+    if (animRef.current) cancelAnimationFrame(animRef.current)
     drag.current = { active: true, startX: clientX, startPan: panMs }
   }, [panMs])
 
@@ -103,7 +117,6 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
   }, [msPerPx])
 
   const endDrag = useCallback(() => { drag.current.active = false }, [])
-
   const touchId = useRef(null)
 
   return (
@@ -127,8 +140,7 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
       onTouchEnd={endDrag}
     >
       <svg
-        width={w}
-        height={h}
+        width={w} height={h}
         viewBox={`0 0 ${w} ${h}`}
         style={{ display: 'block', fontSize: '1rem', overflow: 'visible' }}
       >
@@ -159,37 +171,23 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
                 fill={tick.major ? 'rgba(232,224,208,0.35)' : 'rgba(232,224,208,0.18)'}
                 fontSize={tick.major ? '0.69em' : '0.56em'}
                 fontFamily="'Courier Prime', monospace"
-              >
-                {tick.label}
-              </text>
+              >{tick.label}</text>
             )}
           </g>
         ))}
 
         {/* ── Axis line ───────────────────────────────────────────────────── */}
-        <line
-          x1={0} y1={axisY} x2={w} y2={axisY}
-          stroke="rgba(232,224,208,0.18)" strokeWidth={1}
-        />
+        <line x1={0} y1={axisY} x2={w} y2={axisY}
+          stroke="rgba(232,224,208,0.18)" strokeWidth={1} />
 
         {/* ── Today marker ────────────────────────────────────────────────── */}
         {todayX > -10 && todayX < w + 10 && (
           <g>
-            <line
-              x1={todayX} y1={22}
-              x2={todayX} y2={h - 22}
-              stroke="#C8A96E" strokeWidth={1.5}
-              strokeDasharray="4 4" opacity={0.75}
-            />
-            <text
-              x={todayX} y={16}
-              textAnchor="middle"
+            <line x1={todayX} y1={22} x2={todayX} y2={h - 22}
+              stroke="#C8A96E" strokeWidth={1.5} strokeDasharray="4 4" opacity={0.75} />
+            <text x={todayX} y={16} textAnchor="middle"
               fill="#C8A96E" fontSize="0.56em"
-              fontFamily="'Courier Prime', monospace"
-              opacity={0.75}
-            >
-              today
-            </text>
+              fontFamily="'Courier Prime', monospace" opacity={0.75}>today</text>
           </g>
         )}
 
@@ -200,52 +198,66 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
 
           const isPast = new Date(m.date) < today
           const alpha  = isPast ? 0.72 : 1
+          const isHL   = !!highlightedIds?.has(m.id)
 
-          // Title wrap first — card height depends on number of lines
+          // Per-card connector length jitter: base + 0–60% extra, seeded stable
+          const connLen = CONN_LEN + Math.round((m.connRand ?? 0) * CONN_LEN * 0.6)
+
           const titleLines = wrapTitle(m.title, TITLE_CHARS)
           const cardH      = titleLines.length > 1 ? CARD_H2 : CARD_H1
 
-          // Card y position — stacked outward from axis per lane
           let cardY, connY1, connY2
           if (m.above) {
-            cardY  = axisY - CONN_LEN - m.lane * CARD_STEP - cardH
+            cardY  = axisY - connLen - m.lane * CARD_STEP - cardH
             connY1 = axisY - 4
             connY2 = cardY + cardH
           } else {
-            cardY  = axisY + CONN_LEN + m.lane * CARD_STEP
+            cardY  = axisY + connLen + m.lane * CARD_STEP
             connY1 = axisY + 4
             connY2 = cardY
           }
 
-          // Clamp card horizontally so it doesn't overflow SVG edges
           const cardX = Math.max(4, Math.min(x - CARD_W / 2, w - CARD_W - 4))
-
           const dateStr = formatDateDisplay(m.date, m.date_precision)
           const relStr  = relativeLabel(m.date, m.date_precision)
-          const borderOpacity = isPast ? 0.35 : 0.65
 
-          // Absolute text baseline y positions within the card
-          const yT1   = cardY + TOP_PAD                                      // title line 1
-          const yT2   = yT1 + TITLE_LH                                       // title line 2 (if any)
-          const yMeta = (titleLines.length > 1 ? yT2 : yT1) + SEC_GAP + META_LH  // date
-          const yRel  = yMeta + META_LH                                       // relative time
+          const borderOpacity = isHL ? 0.9 : (isPast ? 0.35 : 0.65)
+          const borderWidth   = isHL ? 1.5 : 1
+
+          const yT1   = cardY + TOP_PAD
+          const yT2   = yT1 + TITLE_LH
+          const yMeta = (titleLines.length > 1 ? yT2 : yT1) + SEC_GAP + META_LH
+          const yRel  = yMeta + META_LH
+
+          // CSS transform to scale highlighted card around its own centre
+          const cx = cardX + CARD_W / 2
+          const cy = cardY + cardH / 2
+          const groupStyle = {
+            cursor: 'pointer',
+            ...(isHL && {
+              transform: `translate(${cx}px,${cy}px) scale(1.06) translate(${-cx}px,${-cy}px)`,
+              transition: 'transform 0.22s ease',
+            }),
+          }
 
           return (
-            <g
-              key={m.id}
-              onClick={() => onMilestoneClick(m)}
-              style={{ cursor: 'pointer' }}
-              opacity={alpha}
-            >
-              {/* Axis anchor dot */}
-              <circle cx={x} cy={axisY} r={3.5} fill={m.color} opacity={0.85} />
+            <g key={m.id} onClick={() => onMilestoneClick(m)} style={groupStyle} opacity={alpha}>
+              {/* Axis anchor dot — larger when highlighted */}
+              <circle cx={x} cy={axisY}
+                r={isHL ? 5.5 : 3.5}
+                fill={m.color}
+                opacity={isHL ? 1 : 0.85} />
 
               {/* Connector line */}
-              <line
-                x1={x} y1={connY1}
-                x2={x} y2={connY2}
-                stroke={m.color} strokeWidth={1} opacity={0.3}
-              />
+              <line x1={x} y1={connY1} x2={x} y2={connY2}
+                stroke={m.color} strokeWidth={isHL ? 1.5 : 1} opacity={isHL ? 0.6 : 0.3} />
+
+              {/* Highlight glow halo behind card */}
+              {isHL && (
+                <rect x={cardX - 4} y={cardY - 4}
+                  width={CARD_W + 8} height={cardH + 8}
+                  fill={m.color} opacity={0.12} />
+              )}
 
               {/* Card body */}
               <rect
@@ -254,61 +266,45 @@ const Timeline = forwardRef(function Timeline({ milestones, zoom, textSize = 'no
                 fill="rgba(13,15,22,0.96)"
                 stroke={m.color}
                 strokeOpacity={borderOpacity}
-                strokeWidth={1}
+                strokeWidth={borderWidth}
                 style={{
                   animation: 'milestone-appear 0.4s cubic-bezier(0.34,1.56,0.64,1) both',
                   transformOrigin: `${x}px ${axisY}px`,
+                  filter: isHL ? `drop-shadow(0 0 7px ${m.color}99)` : undefined,
                 }}
               />
 
               {/* Left accent bar */}
-              <rect
-                x={cardX} y={cardY}
-                width={3} height={cardH}
-                fill={m.color}
-                opacity={isPast ? 0.5 : 0.85}
-              />
+              <rect x={cardX} y={cardY} width={3} height={cardH}
+                fill={m.color} opacity={isPast ? 0.5 : 0.85} />
 
-              {/* Title (1 or 2 lines) */}
+              {/* Title */}
               {titleLines.map((line, i) => (
-                <text
-                  key={i}
+                <text key={i}
                   x={cardX + 10} y={i === 0 ? yT1 : yT2}
                   fill="rgba(232,224,208,0.95)"
-                  fontSize="0.6em"
-                  fontFamily="'Courier Prime', monospace"
-                  fontWeight="bold"
-                >
-                  {line}
-                </text>
+                  fontSize="0.6em" fontFamily="'Courier Prime', monospace" fontWeight="bold"
+                >{line}</text>
               ))}
 
               {/* Date */}
-              <text
-                x={cardX + 10} y={yMeta}
+              <text x={cardX + 10} y={yMeta}
                 fill="rgba(232,224,208,0.45)"
-                fontSize="0.52em"
-                fontFamily="'Courier Prime', monospace"
-              >
-                {dateStr}
-              </text>
+                fontSize="0.52em" fontFamily="'Courier Prime', monospace"
+              >{dateStr}</text>
 
               {/* Relative time */}
-              <text
-                x={cardX + 10} y={yRel}
+              <text x={cardX + 10} y={yRel}
                 fill="#C8A96E"
-                fontSize="0.52em"
-                fontFamily="'Courier Prime', monospace"
-              >
-                {relStr}
-              </text>
+                fontSize="0.52em" fontFamily="'Courier Prime', monospace"
+              >{relStr}</text>
             </g>
           )
         })}
 
         {/* ── Edge fades ───────────────────────────────────────────────────── */}
-        <rect x={0}    y={0} width={70} height={h} fill="url(#tl-left)"  pointerEvents="none" />
-        <rect x={w-70} y={0} width={70} height={h} fill="url(#tl-right)" pointerEvents="none" />
+        <rect x={0}    y={0} width={70}   height={h} fill="url(#tl-left)"  pointerEvents="none" />
+        <rect x={w-70} y={0} width={70}   height={h} fill="url(#tl-right)" pointerEvents="none" />
       </svg>
     </div>
   )

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -6,7 +6,7 @@ import MilestoneDetail   from '../milestone/MilestoneDetail'
 import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS }   from '../../utils/timeline'
 import { CATEGORIES }    from '../../utils/colors'
-import { addMilestone, updateMilestone, deleteMilestone } from '../../data/milestones'
+import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones } from '../../data/milestones'
 
 const ZOOM_RANK = { decades: 5, '30yr': 4, years: 3, months: 2, weeks: 1, custom: 3.5 }
 
@@ -17,24 +17,27 @@ const TEXT_SIZES = {
   bigger: '30px',
 }
 
-// Zoom animation duration must match CSS transition duration
 const ZOOM_ANIM_MS = 380
 
 export default function TimelineView({ milestones, setMilestones }) {
-  const [zoom,       setZoom]      = useState('years')
-  const [zoomAnim,   setZoomAnim]  = useState('')
-  const [filter,     setFilter]    = useState('all')
-  const [addOpen,    setAddOpen]   = useState(false)
-  const [editTarget, setEditTarget] = useState(null)
-  const [detail,     setDetail]    = useState(null)
-  const [textSize,   setTextSize]  = useState(
+  const [zoom,        setZoom]       = useState('years')
+  const [zoomAnim,    setZoomAnim]   = useState('')
+  const [filter,      setFilter]     = useState('all')
+  const [addOpen,     setAddOpen]    = useState(false)
+  const [editTarget,  setEditTarget] = useState(null)
+  const [detail,      setDetail]     = useState(null)
+  const [textSize,    setTextSize]   = useState(
     () => localStorage.getItem('lifeglance-text-size') || 'normal'
   )
-  const [customYears, setCustomYears] = useState(15)   // ±15 yr = 30-year window
-  const timelineRef  = useRef(null)
-  const zoomWrapRef  = useRef(null)
-  const zoomRef      = useRef('years')   // mirrors zoom state, readable in event handlers
-  const zoomLocked   = useRef(false)     // throttle: one zoom step per animation
+  const [customYears, setCustomYears] = useState(15)
+  const [pastIdx,     setPastIdx]    = useState(0)
+  const [futureIdx,   setFutureIdx]  = useState(0)
+
+  const timelineRef = useRef(null)
+  const zoomWrapRef = useRef(null)
+  const zoomRef     = useRef('years')
+  const zoomLocked  = useRef(false)
+  const restoreRef  = useRef(null)
 
   // Apply font size globally
   useEffect(() => {
@@ -47,21 +50,14 @@ export default function TimelineView({ milestones, setMilestones }) {
     if (newZoom === zoom) return
     const dir = ZOOM_RANK[newZoom] > ZOOM_RANK[zoom] ? 'zooming-out' : 'zooming-in'
     setZoomAnim(dir)
-    setTimeout(() => {
-      setZoom(newZoom)
-      setZoomAnim('')
-    }, ZOOM_ANIM_MS)
+    setTimeout(() => { setZoom(newZoom); setZoomAnim('') }, ZOOM_ANIM_MS)
   }, [zoom])
 
-  // Keep ref in sync so the wheel handler always sees current zoom
   useEffect(() => { zoomRef.current = zoom }, [zoom])
-
-  // Stable ref to handleZoom so the wheel effect doesn't re-subscribe on every zoom change
   const handleZoomRef = useRef(handleZoom)
   useEffect(() => { handleZoomRef.current = handleZoom }, [handleZoom])
 
-  // ── Wheel zoom ───────────────────────────────────────────────────────────────
-  // Must be a non-passive listener to call preventDefault (stops page scroll)
+  // Wheel zoom (non-passive so we can preventDefault)
   useEffect(() => {
     const el = zoomWrapRef.current
     if (!el) return
@@ -69,8 +65,6 @@ export default function TimelineView({ milestones, setMilestones }) {
       e.preventDefault()
       if (zoomLocked.current) return
       const idx     = ZOOM_LEVELS.indexOf(zoomRef.current)
-      // scroll up (deltaY < 0) → zoom in → toward 'weeks' (higher index)
-      // scroll down (deltaY > 0) → zoom out → toward 'decades' (lower index)
       const nextIdx = e.deltaY < 0 ? idx + 1 : idx - 1
       if (nextIdx < 0 || nextIdx >= ZOOM_LEVELS.length) return
       zoomLocked.current = true
@@ -79,16 +73,36 @@ export default function TimelineView({ milestones, setMilestones }) {
     }
     el.addEventListener('wheel', onWheel, { passive: false })
     return () => el.removeEventListener('wheel', onWheel)
-  }, []) // stable refs — no deps needed
+  }, [])
 
   // ── Filter ───────────────────────────────────────────────────────────────────
-  // Only show filter chips for categories that appear in the data
   const presentCategories = CATEGORIES.filter(cat =>
     milestones.some(m => m.category === cat.id)
   )
   const filteredMilestones = filter === 'all'
     ? milestones
     : milestones.filter(m => m.category === filter)
+
+  // ── Past / future for stat panel ─────────────────────────────────────────────
+  const now    = new Date()
+  const past   = [...filteredMilestones]
+    .filter(m => new Date(m.date) < now)
+    .sort((a, b) => new Date(b.date) - new Date(a.date))   // most-recent first
+  const future = [...filteredMilestones]
+    .filter(m => new Date(m.date) >= now)
+    .sort((a, b) => new Date(a.date) - new Date(b.date))   // soonest first
+
+  // Clamp indices when lists shrink (filter change, deletion)
+  useEffect(() => {
+    setPastIdx(i => Math.min(i, Math.max(0, past.length - 1)))
+  }, [past.length])
+  useEffect(() => {
+    setFutureIdx(i => Math.min(i, Math.max(0, future.length - 1)))
+  }, [future.length])
+
+  const highlightedIds = new Set(
+    [past[pastIdx]?.id, future[futureIdx]?.id].filter(Boolean)
+  )
 
   // ── CRUD ─────────────────────────────────────────────────────────────────────
   async function handleSave(data, existing) {
@@ -106,8 +120,34 @@ export default function TimelineView({ milestones, setMilestones }) {
     setMilestones(prev => prev.filter(m => m.id !== id))
   }
 
-  function openEdit(m) { setEditTarget(m); setAddOpen(true) }
+  function openEdit(m)  { setEditTarget(m); setAddOpen(true) }
   function closeSheet() { setAddOpen(false); setEditTarget(null) }
+
+  // ── Backup ───────────────────────────────────────────────────────────────────
+  function handleSaveBackup() {
+    const json = JSON.stringify(milestones, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url  = URL.createObjectURL(blob)
+    const a    = document.createElement('a')
+    a.href     = url
+    a.download = `lifeglance-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function handleRestoreFile(e) {
+    const file = e.target.files[0]
+    if (!file) return
+    try {
+      const text     = await file.text()
+      const data     = JSON.parse(text)
+      const restored = await restoreMilestones(data)
+      setMilestones(restored)
+    } catch (err) {
+      console.error('Restore failed:', err)
+    }
+    e.target.value = ''
+  }
 
   const isEmpty = filteredMilestones.length === 0 && milestones.length === 0
 
@@ -125,70 +165,65 @@ export default function TimelineView({ milestones, setMilestones }) {
             {/* Text size */}
             <div className="zoom-tabs">
               {Object.keys(TEXT_SIZES).map(s => (
-                <button
-                  key={s}
+                <button key={s}
                   className={`zoom-tab ${textSize === s ? 'active' : ''}`}
-                  onClick={() => setTextSize(s)}
-                >
-                  {s}
-                </button>
+                  onClick={() => setTextSize(s)}>{s}</button>
               ))}
             </div>
 
             {/* Zoom level */}
             <div className="zoom-tabs">
               {ZOOM_LEVELS.map(z => (
-                <button
-                  key={z}
+                <button key={z}
                   className={`zoom-tab ${zoom === z ? 'active' : ''}`}
-                  onClick={() => handleZoom(z)}
-                >
-                  {z}
-                </button>
+                  onClick={() => handleZoom(z)}>{z}</button>
               ))}
               <button
                 className={`zoom-tab ${zoom === 'custom' ? 'active' : ''}`}
-                onClick={() => handleZoom('custom')}
-              >
-                custom
-              </button>
+                onClick={() => handleZoom('custom')}>custom</button>
             </div>
           </div>
 
-          {/* Zoom indicator / custom range input */}
+          {/* Zoom indicator / custom input */}
           <div className="zoom-indicator">
             {zoom === 'custom' ? (
               <div className="custom-zoom-row">
                 <span>±</span>
-                <input
-                  className="custom-zoom-input"
-                  type="number"
-                  min="1"
-                  max="200"
+                <input className="custom-zoom-input" type="number" min="1" max="200"
                   value={customYears}
                   onChange={e => {
                     const v = parseInt(e.target.value, 10)
                     if (!isNaN(v)) setCustomYears(Math.max(1, Math.min(200, v)))
-                  }}
-                />
+                  }} />
                 <span>yr</span>
               </div>
             ) : (
-              <TypewriterText
-                key={zoom}
-                text={`viewing: ${zoom}`}
-                options={{ delay: 38, jitter: 18 }}
-                showCursor={false}
-                hideCursorWhenDone
-              />
+              <TypewriterText key={zoom} text={`viewing: ${zoom}`}
+                options={{ delay: 38, jitter: 18 }} showCursor={false} hideCursorWhenDone />
             )}
+          </div>
+
+          {/* Backup links */}
+          <div className="header-actions">
+            <button className="action-link" onClick={handleSaveBackup}>save backup</button>
+            <span className="action-sep">·</span>
+            <button className="action-link" onClick={() => restoreRef.current?.click()}>restore</button>
+            <input ref={restoreRef} type="file" accept=".json"
+              style={{ display: 'none' }} onChange={handleRestoreFile} />
           </div>
         </div>
       </div>
 
       {/* ── Body ───────────────────────────────────────────────────────────── */}
       <div className="timeline-body">
-        {!isEmpty && <StatsPanel milestones={filteredMilestones} />}
+        {!isEmpty && (
+          <StatsPanel
+            past={past} future={future}
+            pastIdx={pastIdx} futureIdx={futureIdx}
+            onPastChange={i => setPastIdx(Math.max(0, Math.min(i, past.length - 1)))}
+            onFutureChange={i => setFutureIdx(Math.max(0, Math.min(i, future.length - 1)))}
+          />
+        )}
 
         <div ref={zoomWrapRef} className={`timeline-zoom-wrap ${zoomAnim}`}>
           <Timeline
@@ -197,6 +232,7 @@ export default function TimelineView({ milestones, setMilestones }) {
             zoom={zoom}
             textSize={textSize}
             customHalfMs={customYears * 365.25 * 24 * 3600 * 1000}
+            highlightedIds={highlightedIds}
             onMilestoneClick={setDetail}
           />
         </div>
@@ -204,17 +240,13 @@ export default function TimelineView({ milestones, setMilestones }) {
         {isEmpty && (
           <div className="empty-state">
             <div className="empty-state-label">
-              no milestones yet.<br />
-              add one to start your timeline.
+              no milestones yet.<br />add one to start your timeline.
             </div>
           </div>
         )}
-
         {!isEmpty && filteredMilestones.length === 0 && (
           <div className="empty-state">
-            <div className="empty-state-label">
-              no milestones in this category.
-            </div>
+            <div className="empty-state-label">no milestones in this category.</div>
           </div>
         )}
       </div>
@@ -227,18 +259,12 @@ export default function TimelineView({ milestones, setMilestones }) {
 
         {presentCategories.length > 0 && (
           <div className="filter-chips-inline">
-            <button
-              className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
-              onClick={() => setFilter('all')}
-            >
-              all
-            </button>
+            <button className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
+              onClick={() => setFilter('all')}>all</button>
             {presentCategories.map(cat => (
-              <button
-                key={cat.id}
+              <button key={cat.id}
                 className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
-                onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}
-              >
+                onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}>
                 <span className="filter-dot" style={{ background: cat.color }} />
                 {cat.label}
               </button>

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -67,3 +67,11 @@ export async function updateMilestone(id, updates, existing) {
 export async function deleteMilestone(id) {
   await dbDelete(id)
 }
+
+// Clear all milestones and replace with the supplied array (preserves original IDs)
+export async function restoreMilestones(items) {
+  const existing = await dbGetAll()
+  for (const m of existing) await dbDelete(m.id)
+  for (const m of items)    await dbPut(m)
+  return items
+}

--- a/src/index.css
+++ b/src/index.css
@@ -508,6 +508,50 @@ button, input, select, textarea {
 .stat-milestone-date  { font-size: 0.63rem; color: var(--text-muted); margin-top: 0.1rem; }
 .stat-milestone-rel   { font-size: 0.63rem; color: var(--amber);      margin-top: 0.08rem; }
 
+/* ─── Stat panel navigation ────────────────────────────────────────────────── */
+.stat-nav-row {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+.stat-nav-row-right { justify-content: flex-end; }
+.stat-nav-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 0.58rem;
+  padding: 0.08rem 0.32rem;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: color 0.15s, border-color 0.15s;
+}
+.stat-nav-btn:hover:not(:disabled) { color: var(--amber); border-color: var(--amber-dim); }
+.stat-nav-btn:disabled { opacity: 0.25; cursor: default; }
+.stat-nav-pos { font-size: 0.56rem; color: var(--text-muted); letter-spacing: 0.04em; }
+
+/* ─── Header backup links ───────────────────────────────────────────────────── */
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  justify-content: flex-end;
+}
+.action-link {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 0.56rem;
+  cursor: pointer;
+  padding: 0;
+  letter-spacing: 0.05em;
+  transition: color 0.15s;
+}
+.action-link:hover { color: var(--amber); }
+.action-sep { color: var(--border); font-size: 0.56rem; }
+
 /* ─── Sheet / Drawer ───────────────────────────────────────────────────────── */
 .sheet-overlay {
   position: fixed;

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -96,10 +96,10 @@ export function getTickMarks(zoom, startMs, endMs, width) {
   return ticks
 }
 
-// Deterministic hash → 0..1 float, stable per milestone ID
-function seededRand(id) {
+// Deterministic hash of an arbitrary string → 0..1 float
+function seededHash(str) {
   let h = 0
-  for (const c of String(id)) h = Math.imul(31, h) + c.charCodeAt(0) | 0
+  for (const c of str) h = Math.imul(31, h) + c.charCodeAt(0) | 0
   return (h >>> 0) / 4294967295
 }
 
@@ -107,9 +107,9 @@ function seededRand(id) {
 //   maxLane      – max lane index that fits in the container (caller computes)
 //   cardTimeSpan – ms equivalent of one card width at current zoom (for overlap detection)
 //
-// Algorithm: each milestone has a seeded-random preferred lane (lane 1 ~30% of the time
-// when space allows). If that lane has a time-proximity conflict, fall back to the first
-// conflict-free lane. This gives organic spread without deterministic uniformity.
+// Two independent hash values per milestone:
+//   laneRand – drives lane preference (~55% chance of preferring lane 1)
+//   connRand – drives connector-length jitter in the renderer (0 → 60% extra)
 export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0) {
   const sorted = [...milestones].sort(
     (a, b) => new Date(a.date) - new Date(b.date)
@@ -122,23 +122,24 @@ export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0) {
     const side  = above ? 'above' : 'below'
     const mMs   = new Date(m.date).getTime()
 
+    // Two independent seeds so lane choice and connector length don't correlate
+    const laneRand = seededHash(String(m.id) + String(m.date).slice(0, 10))
+    const connRand = seededHash(String(m.id) + '~conn')
+
     const hasConflict = (l) =>
       cardTimeSpan > 0 &&
       placed[side].some(p => p.lane === l && Math.abs(p.ms - mMs) < cardTimeSpan)
 
-    // Seeded random: ~30% of milestones prefer lane 1 for visual variety
-    const rand       = seededRand(m.id)
-    const preferLane = (maxLane >= 1 && rand < 0.30) ? 1 : 0
+    // ~55% of milestones spontaneously prefer lane 1 for visual variety
+    const preferLane = (maxLane >= 1 && laneRand < 0.55) ? 1 : 0
 
     let lane = preferLane
     if (hasConflict(lane)) {
-      // Scan upward from 0 for first free lane
       lane = 0
       while (lane < maxLane && hasConflict(lane)) lane++
-      // If still conflicting at maxLane, accept it (unavoidable dense cluster)
     }
 
     placed[side].push({ ms: mMs, lane })
-    return { ...m, above, lane }
+    return { ...m, above, lane, connRand }
   })
 }


### PR DESCRIPTION
Randomness:
- Two independent hashes per milestone (lane vs connector jitter)
- 55% prefer lane 1 (up from 30%) for more organic spread
- Connector length varies 0–60% per card via connRand, so cards at the same lane no longer sit at identical heights

Save / restore:
- restoreMilestones() clears IndexedDB and re-inserts from JSON backup
- "save backup" / "restore" text links in header; restore via file input

Stat panel navigation + timeline highlight:
- past/future arrays lifted to TimelineView; pastIdx/futureIdx state
- ← / → arrow buttons in each stat panel to browse milestones
- Highlighted milestone gets: 1.06× scale, glow drop-shadow, bright border, halo rect, larger axis dot

Smooth jump-to-today:
- resetPan now runs a 480ms ease-out-cubic rAF animation instead of instant set; dragging during animation cancels it cleanly

https://claude.ai/code/session_01BqH7ddfaJQtpn8rEeGGuxY