### PR TITLE
Compact layout: shift axis down and force milestones above on small s…

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -106,7 +106,8 @@ const Timeline = forwardRef(function Timeline(
   }, [])
 
   const { w, h } = size
-  const axisY    = Math.round(h * 0.5)
+  const compactLayout = h < 700
+  const axisY    = Math.round(h * (compactLayout ? 0.78 : 0.50))
   const today    = new Date()
   const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRangeForView(zoom, centerMs, viewMode, customHalfMs)
@@ -138,7 +139,7 @@ const Timeline = forwardRef(function Timeline(
 
   const singles       = clustering ? groups.filter(g => g.length === 1).map(g => g[0]) : milestones
   const clusterGroups = clustering ? groups.filter(g => g.length > 1) : []
-  const withLanes     = assignLanes(singles, maxLane, msPerPx * CARD_W)
+  const withLanes     = assignLanes(singles, maxLane, msPerPx * CARD_W, compactLayout)
 
   // ── Pan ─────────────────────────────────────────────────────────────────────
   // startDrag reads panMsRef so it doesn't need panMs as a dep

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -123,7 +123,7 @@ function seededHash(str) {
 // Two independent hash values per milestone:
 //   laneRand – drives lane preference (~55% chance of preferring lane 1)
 //   connRand – drives connector-length jitter in the renderer (0 → 60% extra)
-export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0) {
+export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0, forceAbove = false) {
   const sorted = [...milestones].sort(
     (a, b) => new Date(a.date) - new Date(b.date)
   )
@@ -131,7 +131,7 @@ export function assignLanes(milestones, maxLane = 0, cardTimeSpan = 0) {
   const placed = { above: [], below: [] }
 
   return sorted.map((m, i) => {
-    const above = i % 2 === 0
+    const above = forceAbove || i % 2 === 0
     const side  = above ? 'above' : 'below'
     const mMs   = new Date(m.date).getTime()
 


### PR DESCRIPTION
…creens

When the timeline container is shorter than 700px (roughly a ≤900px viewport), the axis moves to 78% of SVG height instead of 50%, giving milestone cards ~78% of vertical space rather than 50%. All milestones are forced above the axis so lane conflict detection stays accurate.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby