### PR TITLE
Fix compact layout empty space; collapse filter chips on narrow viewp…

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -117,7 +117,9 @@ const Timeline = forwardRef(function Timeline(
   }, [])
 
   const { w, h } = size
-  const axisY    = Math.round(h * (compactLayout ? 0.78 : 0.50))
+  // Compact: pin axis a fixed distance from the bottom so there's no dead space below.
+  // Normal: centre the axis.
+  const axisY    = compactLayout ? h - 40 : Math.round(h * 0.50)
   const today    = new Date()
   const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRangeForView(zoom, centerMs, viewMode, customHalfMs)

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -45,6 +45,9 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [viewMode,      setViewMode]      = useState('all')
   const [categories,    setCategories]    = useState(loadCategories)
   const [panMs,         setPanMs]         = useState(0)
+  const [compactFilter, setCompactFilter] = useState(
+    () => window.matchMedia('(max-width: 1200px)').matches
+  )
   const [clustering,    setClustering]    = useState(
     () => localStorage.getItem('lifeglance-clustering') !== 'false'
   )
@@ -68,6 +71,13 @@ export default function TimelineView({ milestones, setMilestones }) {
     document.documentElement.style.fontSize = TEXT_SIZES[textSize]
     localStorage.setItem('lifeglance-text-size', textSize)
   }, [textSize])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 1200px)')
+    const handler = (e) => setCompactFilter(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
 
   // ── Zoom ─────────────────────────────────────────────────────────────────────
   const handleZoom = useCallback((newZoom) => {
@@ -676,18 +686,34 @@ export default function TimelineView({ milestones, setMilestones }) {
         </button>
 
         {presentCategories.length > 0 && (
-          <div className="filter-chips-inline">
-            <button className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
-              onClick={() => setFilter('all')}>all</button>
-            {presentCategories.map(cat => (
-              <button key={cat.id}
-                className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
-                onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}>
-                <span className="filter-dot" style={{ background: cat.color }} />
-                {cat.label}
-              </button>
-            ))}
-          </div>
+          compactFilter ? (
+            <div className="filter-compact">
+              <button className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
+                onClick={() => setFilter('all')}>all</button>
+              <select
+                className={`filter-select ${filter !== 'all' ? 'active' : ''}`}
+                value={filter === 'all' ? '' : filter}
+                onChange={e => setFilter(e.target.value || 'all')}>
+                <option value="">category</option>
+                {presentCategories.map(cat => (
+                  <option key={cat.id} value={cat.id}>{cat.label}</option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <div className="filter-chips-inline">
+              <button className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
+                onClick={() => setFilter('all')}>all</button>
+              {presentCategories.map(cat => (
+                <button key={cat.id}
+                  className={`filter-chip ${filter === cat.id ? 'active' : ''}`}
+                  onClick={() => setFilter(filter === cat.id ? 'all' : cat.id)}>
+                  <span className="filter-dot" style={{ background: cat.color }} />
+                  {cat.label}
+                </button>
+              ))}
+            </div>
+          )
         )}
 
         <button className="today-btn" onClick={handleJumpToToday}>

--- a/src/index.css
+++ b/src/index.css
@@ -534,6 +534,29 @@ button, input, select, textarea {
 .filter-chip.active { color: var(--amber); border-color: var(--amber); }
 .filter-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 
+/* ─── Compact filter (all + select, used at max-width: 1200px) ─────────────── */
+.filter-compact {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+.filter-select {
+  padding: 0.3rem 0.55rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-left: none;
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.filter-select:hover { color: var(--text-dim); }
+.filter-select.active { color: var(--amber); border-color: var(--amber); }
+.filter-select option { background: #0F1117; color: var(--text); }
+
 /* ─── Stat panels ──────────────────────────────────────────────────────────── */
 .stat-panels {
   pointer-events: none;


### PR DESCRIPTION
…orts

- Axis now pinned to h-40 in compact mode (fixed bottom margin) instead of 78% of container height, eliminating dead space below the timeline
- Filter chips collapse to [all] + [category <select>] at max-width: 1200px, preventing wrapping on iPad Air and similar viewports

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby