### PR TITLE
Compact layout polish: custom filter dropdown, today zone, clustering

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -126,12 +126,11 @@ const Timeline = forwardRef(function Timeline(
   const ticks    = getTickMarks(zoom, startMs, endMs, w)
   const todayX   = dateToX(today.getTime(), startMs, endMs, w)
   const msPerPx  = getMsPerPx(zoom, w, customHalfMs)
-  const maxLane  = Math.max(0, Math.floor((axisY - MAX_CONN - CARD_H2 - 16) / CARD_STEP))
-
-  // ── Auto-density clustering ──────────────────────────────────────────────────
-  // Milestones whose axis dots fall within CLUSTER_THRESHOLD px of each other
-  // are collapsed into a badge instead of rendering as overlapping cards.
-  const CLUSTER_THRESHOLD = CARD_W * 0.4
+  // In compact mode: reserve 120px from the top for the today label, and
+  // cluster milestones more aggressively to reduce card pile-up near today.
+  const TOP_RESERVE        = compactLayout ? 120 : 16
+  const CLUSTER_THRESHOLD  = CARD_W * (compactLayout ? 0.6 : 0.4)
+  const maxLane  = Math.max(0, Math.floor((axisY - MAX_CONN - CARD_H2 - TOP_RESERVE) / CARD_STEP))
 
   const sorted = [...milestones].sort((a, b) => new Date(a.date) - new Date(b.date))
   const groups = []

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -48,6 +48,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [compactFilter, setCompactFilter] = useState(
     () => window.matchMedia('(max-width: 1200px)').matches
   )
+  const [filterOpen,    setFilterOpen]    = useState(false)
   const [clustering,    setClustering]    = useState(
     () => localStorage.getItem('lifeglance-clustering') !== 'false'
   )
@@ -78,6 +79,13 @@ export default function TimelineView({ milestones, setMilestones }) {
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
+
+  useEffect(() => {
+    if (!filterOpen) return
+    const close = () => setFilterOpen(false)
+    document.addEventListener('click', close)
+    return () => document.removeEventListener('click', close)
+  }, [filterOpen])
 
   // ── Zoom ─────────────────────────────────────────────────────────────────────
   const handleZoom = useCallback((newZoom) => {
@@ -687,18 +695,34 @@ export default function TimelineView({ milestones, setMilestones }) {
 
         {presentCategories.length > 0 && (
           compactFilter ? (
-            <div className="filter-compact">
+            <div className="filter-compact" onClick={e => e.stopPropagation()}>
               <button className={`filter-chip ${filter === 'all' ? 'active' : ''}`}
-                onClick={() => setFilter('all')}>all</button>
-              <select
-                className={`filter-select ${filter !== 'all' ? 'active' : ''}`}
-                value={filter === 'all' ? '' : filter}
-                onChange={e => setFilter(e.target.value || 'all')}>
-                <option value="">category</option>
-                {presentCategories.map(cat => (
-                  <option key={cat.id} value={cat.id}>{cat.label}</option>
-                ))}
-              </select>
+                onClick={() => { setFilter('all'); setFilterOpen(false) }}>all</button>
+              <div className="filter-dropdown-wrap">
+                <button
+                  className={`filter-chip filter-dropdown-btn ${filter !== 'all' ? 'active' : ''}`}
+                  onClick={() => setFilterOpen(o => !o)}>
+                  {filter !== 'all' ? (
+                    <>
+                      <span className="filter-dot"
+                        style={{ background: presentCategories.find(c => c.id === filter)?.color }} />
+                      {presentCategories.find(c => c.id === filter)?.label}
+                    </>
+                  ) : 'category'} ▾
+                </button>
+                {filterOpen && (
+                  <div className="filter-dropdown">
+                    {presentCategories.map(cat => (
+                      <button key={cat.id}
+                        className={`filter-dropdown-item ${filter === cat.id ? 'active' : ''}`}
+                        onClick={() => { setFilter(cat.id); setFilterOpen(false) }}>
+                        <span className="filter-dot" style={{ background: cat.color }} />
+                        {cat.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           ) : (
             <div className="filter-chips-inline">

--- a/src/index.css
+++ b/src/index.css
@@ -534,28 +534,48 @@ button, input, select, textarea {
 .filter-chip.active { color: var(--amber); border-color: var(--amber); }
 .filter-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 
-/* ─── Compact filter (all + select, used at max-width: 1200px) ─────────────── */
+/* ─── Compact filter (all + dropdown, used at max-width: 1200px) ───────────── */
 .filter-compact {
   display: flex;
   align-items: center;
   gap: 0;
 }
-.filter-select {
-  padding: 0.3rem 0.55rem;
-  background: transparent;
-  border: 1px solid var(--border);
+.filter-dropdown-btn {
   border-left: none;
+  gap: 0.35rem;
+}
+.filter-dropdown-wrap {
+  position: relative;
+}
+.filter-dropdown {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  min-width: 100%;
+  z-index: 50;
+}
+.filter-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--border);
   color: var(--text-muted);
   font-family: var(--font);
   font-size: 0.7rem;
   letter-spacing: 0.03em;
   cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
+  text-align: left;
+  white-space: nowrap;
 }
-.filter-select:hover { color: var(--text-dim); }
-.filter-select.active { color: var(--amber); border-color: var(--amber); }
-.filter-select option { background: #0F1117; color: var(--text); }
+.filter-dropdown-item:first-child { border-top: none; }
+.filter-dropdown-item:hover { color: var(--text-dim); background: rgba(200,169,110,0.06); }
+.filter-dropdown-item.active { color: var(--amber); }
 
 /* ─── Stat panels ──────────────────────────────────────────────────────────── */
 .stat-panels {


### PR DESCRIPTION
- Replace native <select> with custom styled dropdown matching app aesthetic; opens upward above the bottom bar, closes on outside click
- Reserve 120px from SVG top in compact mode so milestone cards can't crowd the today label (vs 16px in normal mode)
- Increase cluster threshold from 40% to 60% of card width in compact mode to reduce card pile-up near today

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby