### PR TITLE
Fix compactStats breakpoint to trigger on height as well as width

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -54,7 +54,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   )
   const [filterOpen,    setFilterOpen]    = useState(false)
   const [compactStats,  setCompactStats]  = useState(
-    () => window.matchMedia('(max-width: 768px)').matches
+    () => window.matchMedia('(max-width: 768px), (max-height: 600px)').matches
   )
   const [minimapOpen,   setMinimapOpen]   = useState(false)
   const [clustering,    setClustering]    = useState(
@@ -110,7 +110,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   }, [filterOpen])
 
   useEffect(() => {
-    const mq = window.matchMedia('(max-width: 768px)')
+    const mq = window.matchMedia('(max-width: 768px), (max-height: 600px)')
     const handler = (e) => {
       setCompactStats(e.matches)
       if (!e.matches) setMinimapOpen(false) // reset when leaving compact mode


### PR DESCRIPTION
max-width: 768px alone misses landscape phones (e.g. S20 Ultra 915x412).
Combined query (max-width: 768px), (max-height: 600px) covers both:
- Portrait phones: hit by the width clause
- Landscape phones: hit by the height clause
- Tablets / laptops: neither clause fires

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby