### PR TITLE
Fix stat pills pointer-events; collapse header to single row on short…

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1305,6 +1305,7 @@ button, input, select, textarea {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  pointer-events: all;
 }
 .stat-pill-wrap-right { align-items: flex-end; }
 
@@ -1357,6 +1358,14 @@ button, input, select, textarea {
 }
 .minimap-grip:hover     { color: var(--amber-dim); background: rgba(200, 169, 110, 0.03); }
 .minimap-grip-open      { border-top-color: rgba(200, 169, 110, 0.12); }
+
+/* ─── Short-screen header (landscape phones ≤500px tall) ──────────────────── */
+/* Collapses the two-row header-center (zoom + view tabs) into a single row,   */
+/* saving ~37px of vertical space for the timeline body.                        */
+@media (max-height: 500px) {
+  .timeline-header  { padding: 0.28rem 0.8rem; }
+  .header-center    { flex-direction: row; gap: 0.5rem; align-items: center; }
+}
 
 /* ─── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 480px) {


### PR DESCRIPTION
… screens

pointer-events fix:
  .stat-panels has pointer-events:none so child .stat-pill-wrap inherited it,
  making all tap/click events fall through — pills looked present but did
  nothing. Added pointer-events:all to .stat-pill-wrap to re-enable.

Short-screen header (max-height: 500px):
  On landscape phones (e.g. S20 Ultra 915x412) the two-row compact header
  (zoom dropdown stacked above view tabs) consumed ~79px, leaving only ~250px
  for the timeline body and pushing the axis to axisY≈210 (84% down).
  At max-height:500px the header-center switches to flex-row so zoom and
  view tabs sit side-by-side, reducing header height to ~42px and giving
  the body ~37px more space.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby