### PR TITLE
ultraCompact axis: move from h-40 (86%) to ~70% on screens ≤500px tall

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -57,6 +57,9 @@ const Timeline = forwardRef(function Timeline(
   const [compactLayout, setCompactLayout] = useState(
     () => window.matchMedia('(max-height: 900px)').matches
   )
+  const [ultraCompact, setUltraCompact] = useState(
+    () => window.matchMedia('(max-height: 500px)').matches
+  )
   const [photoTip,    setPhotoTip]    = useState(null) // { uri, x, y }
   // Track which IDs have already played their fly-in so we don't re-animate on re-renders
   const [flyDoneIds,  setFlyDoneIds]  = useState(() => new Set())
@@ -69,6 +72,13 @@ const Timeline = forwardRef(function Timeline(
   useEffect(() => {
     const mq = window.matchMedia('(max-height: 900px)')
     const handler = (e) => setCompactLayout(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-height: 500px)')
+    const handler = (e) => setUltraCompact(e.matches)
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
@@ -117,9 +127,16 @@ const Timeline = forwardRef(function Timeline(
   }, [])
 
   const { w, h } = size
-  // Compact: pin axis a fixed distance from the bottom so there's no dead space below.
-  // Normal: centre the axis.
-  const axisY    = compactLayout ? h - 40 : Math.round(h * 0.50)
+  // ultraCompact (≤500px tall): axis at ~70% so cards fit above and there's
+  //   breathing room below before the map bar; floor at 193 so cards never
+  //   cross the axis (topClamp 84 + CARD_H2 101 + 8px min-connector = 193).
+  // compact (≤900px): axis pinned near bottom to maximise card space above.
+  // normal: axis centred.
+  const axisY = ultraCompact
+    ? Math.max(193, Math.round(h * 0.70))
+    : compactLayout
+      ? h - 40
+      : Math.round(h * 0.50)
   const today    = new Date()
   const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRangeForView(zoom, centerMs, viewMode, customHalfMs)


### PR DESCRIPTION
On S20 Ultra landscape (body ~287px), axisY=h-40=247 put the axis 86% down with only 20px below tick labels before the grip strip — it read as "sitting on the map bar."

New ultraCompact (max-height: 500px) mode positions the axis at max(193, h*0.70), e.g. 201 on a 287px body (70%), leaving 86px of visible space below the axis before the grip. The 193 floor ensures cards (clamped to y≥84, height 101px) never cross the axis even on very short bodies.

compactLayout (max-height: 900px) behaviour unchanged for tablets/laptops.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby