### PR TITLE
ultraCompact: auto minimap, text-size guard, restrict big/bigger in s…

### DIFF
--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -2,7 +2,8 @@ import React, { useRef, useState } from 'react'
 import { saveCategories } from '../../utils/colors'
 import { isMuted, setMuted } from '../../utils/audio'
 
-const TEXT_SIZES = { small: true, normal: true, big: true, bigger: true }
+const TEXT_SIZES_ALL     = ['small', 'normal', 'big', 'bigger']
+const TEXT_SIZES_COMPACT = ['small', 'normal']
 
 const COLOR_PALETTE = [
   '#9370DB', '#A78BFA', '#6366F1', '#3D3580',
@@ -23,6 +24,7 @@ export default function SettingsModal({
   milestones,
   onExportImage, onSaveBackup, onRestoreFile,
   onClose,
+  ultraCompact = false,
 }) {
   const [newLabel,  setNewLabel]  = useState('')
   const [newColor,  setNewColor]  = useState(COLOR_PALETTE[0])
@@ -65,12 +67,15 @@ export default function SettingsModal({
         <div className="settings-section">
           <div className="settings-label">text size</div>
           <div className="zoom-tabs">
-            {Object.keys(TEXT_SIZES).map(s => (
+            {(ultraCompact ? TEXT_SIZES_COMPACT : TEXT_SIZES_ALL).map(s => (
               <button key={s}
                 className={`zoom-tab ${textSize === s ? 'active' : ''}`}
                 onClick={() => onTextSizeChange(s)}>{s}</button>
             ))}
           </div>
+          {ultraCompact && (
+            <div className="settings-note">big / bigger unavailable on short screens</div>
+          )}
         </div>
 
         {/* ── Display ───────────────────────────────────────────────────── */}

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -34,7 +34,7 @@ function wrapTitle(text, maxChars) {
 }
 
 const Timeline = forwardRef(function Timeline(
-  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null },
+  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
   ref
 ) {
   const remPx = REM_PX[textSize] || 22
@@ -57,9 +57,6 @@ const Timeline = forwardRef(function Timeline(
   const [compactLayout, setCompactLayout] = useState(
     () => window.matchMedia('(max-height: 900px)').matches
   )
-  const [ultraCompact, setUltraCompact] = useState(
-    () => window.matchMedia('(max-height: 500px)').matches
-  )
   const [photoTip,    setPhotoTip]    = useState(null) // { uri, x, y }
   // Track which IDs have already played their fly-in so we don't re-animate on re-renders
   const [flyDoneIds,  setFlyDoneIds]  = useState(() => new Set())
@@ -72,13 +69,6 @@ const Timeline = forwardRef(function Timeline(
   useEffect(() => {
     const mq = window.matchMedia('(max-height: 900px)')
     const handler = (e) => setCompactLayout(e.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
-
-  useEffect(() => {
-    const mq = window.matchMedia('(max-height: 500px)')
-    const handler = (e) => setUltraCompact(e.matches)
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -56,7 +56,13 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [compactStats,  setCompactStats]  = useState(
     () => window.matchMedia('(max-width: 768px), (max-height: 600px)').matches
   )
-  const [minimapOpen,   setMinimapOpen]   = useState(false)
+  const [ultraCompact,  setUltraCompact]  = useState(
+    () => window.matchMedia('(max-height: 500px)').matches
+  )
+  const [minimapOpen,   setMinimapOpen]   = useState(
+    () => window.matchMedia('(max-height: 500px)').matches &&
+          (localStorage.getItem('lifeglance-text-size') || 'normal') === 'small'
+  )
   const [clustering,    setClustering]    = useState(
     () => localStorage.getItem('lifeglance-clustering') !== 'false'
   )
@@ -111,13 +117,30 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 768px), (max-height: 600px)')
-    const handler = (e) => {
-      setCompactStats(e.matches)
-      if (!e.matches) setMinimapOpen(false) // reset when leaving compact mode
-    }
+    const handler = (e) => setCompactStats(e.matches)
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-height: 500px)')
+    const handler = (e) => setUltraCompact(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  // Auto-show minimap on ultra-compact only when text is small enough to fit.
+  // Auto-hide when leaving compact or switching to a larger text size.
+  useEffect(() => {
+    if (compactStats) setMinimapOpen(ultraCompact && textSize === 'small')
+  }, [compactStats, ultraCompact, textSize])
+
+  // Restrict text size: big/bigger cards overflow the axis on short screens.
+  useEffect(() => {
+    if (ultraCompact && (textSize === 'big' || textSize === 'bigger')) {
+      setTextSize('normal')
+    }
+  }, [ultraCompact, textSize])
 
   // ── Zoom ─────────────────────────────────────────────────────────────────────
   const handleZoom = useCallback((newZoom) => {
@@ -735,6 +758,7 @@ export default function TimelineView({ milestones, setMilestones }) {
             clustering={clustering}
             birthday={birthday}
             newlyAddedId={newlyAddedId}
+            ultraCompact={ultraCompact}
           />
         </div>
 
@@ -863,6 +887,7 @@ export default function TimelineView({ milestones, setMilestones }) {
       {settingsOpen && (
         <SettingsModal
           textSize={textSize}       onTextSizeChange={setTextSize}
+          ultraCompact={ultraCompact}
           categories={categories}   onCategoriesChange={setCategories}
           clustering={clustering}   onClusteringChange={v => {
             setClustering(v)

--- a/src/index.css
+++ b/src/index.css
@@ -983,6 +983,12 @@ button, input, select, textarea {
   color: var(--amber);
   letter-spacing: 0.07em;
 }
+.settings-note {
+  font-size: 0.55rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  margin-top: 0.2rem;
+}
 
 .settings-cat-list {
   display: flex;


### PR DESCRIPTION
…ettings

- ultraCompact state moved to TimelineView so it can drive cross-component decisions; passed as prop to Timeline (axisY formula) and SettingsModal

- Auto minimap: when compactStats + ultraCompact + textSize='small', minimap opens automatically (small text leaves enough room for the 40px bar); reverts to hidden when text size grows or screen is no longer ultra-compact

- Text size guard: if a user lands on an ultra-compact screen with big/bigger already set, auto-downgrade to normal (big/bigger cards overflow the axis)

- Settings restriction: big/bigger tabs hidden on ultra-compact screens with an explanatory note; all four sizes remain available on larger screens

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby