### PR TITLE
Hide minimap grip when minimap is open

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -790,11 +790,9 @@ export default function TimelineView({ milestones, setMilestones }) {
               viewMode={viewMode}
             />
           )}
-          {compactStats && (
-            <button
-              className={`minimap-grip${minimapOpen ? ' minimap-grip-open' : ''}`}
-              onClick={() => setMinimapOpen(o => !o)}>
-              {minimapOpen ? '▴ map' : '▾ map'}
+          {compactStats && !minimapOpen && (
+            <button className="minimap-grip" onClick={() => setMinimapOpen(true)}>
+              ▾ map
             </button>
           )}
         </>


### PR DESCRIPTION
The grip strip only serves to reveal a hidden minimap. When the minimap is visible (auto-opened for small text, or manually opened), showing the grip is redundant overhead — hide it. Switching text size back to normal auto-closes the minimap and the grip reappears.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby