### PR TITLE
Restore minimap grip for manual open; hide only on auto-open

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -790,9 +790,11 @@ export default function TimelineView({ milestones, setMilestones }) {
               viewMode={viewMode}
             />
           )}
-          {compactStats && !minimapOpen && (
-            <button className="minimap-grip" onClick={() => setMinimapOpen(true)}>
-              ▾ map
+          {compactStats && (!minimapOpen || !(ultraCompact && textSize === 'small')) && (
+            <button
+              className={`minimap-grip${minimapOpen ? ' minimap-grip-open' : ''}`}
+              onClick={() => setMinimapOpen(o => !o)}>
+              {minimapOpen ? '▴ map' : '▾ map'}
             </button>
           )}
         </>


### PR DESCRIPTION
Grip is hidden only when the minimap was auto-opened (ultraCompact + small text) — in that case text size is the natural toggle. When the user manually opens the minimap via the grip, the grip stays visible as '▴ map' so they can close it again.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby