### PR TITLE
Add portrait mode warning overlay (orientation:portrait + max-width:1…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,18 @@ import TimelineView from './components/timeline/TimelineView'
 import { initDB, dbGetAll } from './data/db'
 
 export default function App() {
-  const [screen,     setScreen]     = useState('loading')  // loading | onboarding | timeline
-  const [milestones, setMilestones] = useState([])
+  const [screen,      setScreen]      = useState('loading')  // loading | onboarding | timeline
+  const [milestones,  setMilestones]  = useState([])
+  const [portraitWarn, setPortraitWarn] = useState(
+    () => window.matchMedia('(orientation: portrait) and (max-width: 1024px)').matches
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia('(orientation: portrait) and (max-width: 1024px)')
+    const handler = (e) => setPortraitWarn(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
 
   useEffect(() => {
     initDB()
@@ -25,22 +35,32 @@ export default function App() {
     setScreen('timeline')
   }
 
-  if (screen === 'loading') {
-    return (
-      <div className="app-loading">
-        <span className="cursor" style={{ width: '8px', height: '8px', borderRadius: '50%' }} />
-      </div>
-    )
-  }
-
-  if (screen === 'onboarding') {
-    return <Onboarding onComplete={handleOnboardingComplete} />
-  }
+  const content = screen === 'loading' ? (
+    <div className="app-loading">
+      <span className="cursor" style={{ width: '8px', height: '8px', borderRadius: '50%' }} />
+    </div>
+  ) : screen === 'onboarding' ? (
+    <Onboarding onComplete={handleOnboardingComplete} />
+  ) : (
+    <TimelineView milestones={milestones} setMilestones={setMilestones} />
+  )
 
   return (
-    <TimelineView
-      milestones={milestones}
-      setMilestones={setMilestones}
-    />
+    <>
+      {content}
+      {portraitWarn && (
+        <div className="portrait-overlay">
+          <div className="logo">
+            <span className="logo-life">life</span>
+            <span className="logo-glance">GLANCE</span>
+          </div>
+          <div className="portrait-rotate-icon">↻</div>
+          <div className="portrait-message">
+            please rotate your device<br />
+            for the best experience
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,40 @@ button, input, select, textarea {
   animation: cursor-blink 1s step-end infinite;
 }
 
+/* ─── Portrait warning overlay ─────────────────────────────────────────────── */
+.portrait-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.portrait-rotate-icon {
+  font-size: 3.2rem;
+  color: var(--amber);
+  display: inline-block;
+  animation: portrait-rock 2.4s ease-in-out infinite;
+}
+
+@keyframes portrait-rock {
+  0%, 100% { transform: rotate(-25deg); }
+  50%       { transform: rotate(25deg); }
+}
+
+.portrait-message {
+  text-align: center;
+  font-family: var(--font);
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  line-height: 1.8;
+}
+
 /* ─── Loading ──────────────────────────────────────────────────────────────── */
 .app-loading {
   height: 100%;


### PR DESCRIPTION
…024px)

Fixed overlay (z-index 9998, below film grain) with the app logo, a gently rocking ↻ icon, and a 'please rotate your device' message. The app renders underneath so no state is lost on rotation — the overlay simply disappears when the device goes landscape.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby