### PR TITLE
Fix minimap auto-open on ultra-compact screens (S26 Ultra)

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -60,7 +60,8 @@ export default function TimelineView({ milestones, setMilestones }) {
     () => window.matchMedia('(max-height: 500px)').matches
   )
   const [minimapOpen,   setMinimapOpen]   = useState(
-    () => window.matchMedia('(max-height: 500px)').matches &&
+    () => !window.matchMedia('(max-height: 500px)').matches &&
+          window.matchMedia('(max-width: 768px), (max-height: 600px)').matches &&
           (localStorage.getItem('lifeglance-text-size') || 'normal') === 'small'
   )
   const [clustering,    setClustering]    = useState(
@@ -132,7 +133,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   // Auto-show minimap on ultra-compact only when text is small enough to fit.
   // Auto-hide when leaving compact or switching to a larger text size.
   useEffect(() => {
-    if (compactStats) setMinimapOpen(ultraCompact && textSize === 'small')
+    if (compactStats) setMinimapOpen(!ultraCompact && textSize === 'small')
   }, [compactStats, ultraCompact, textSize])
 
   // Restrict text size: big/bigger cards overflow the axis on short screens.
@@ -790,7 +791,7 @@ export default function TimelineView({ milestones, setMilestones }) {
               viewMode={viewMode}
             />
           )}
-          {compactStats && (!minimapOpen || !(ultraCompact && textSize === 'small')) && (
+          {compactStats && (!minimapOpen || ultraCompact || textSize !== 'small') && (
             <button
               className={`minimap-grip${minimapOpen ? ' minimap-grip-open' : ''}`}
               onClick={() => setMinimapOpen(o => !o)}>


### PR DESCRIPTION
At truly short viewport heights (≤500px), the minimap was auto-opening and blocking the timeline with no grip available to close it. The auto-open range should only fire in the 500–600px compact-but-not-ultraCompact zone.

- Initial minimapOpen state: require !ultraCompact AND compactStats AND small
- Auto-open effect: !ultraCompact && textSize === 'small' (was ultraCompact)
- Grip visibility: always show grip when ultraCompact, hiding it only when the minimap was auto-opened in the compact (non-ultra) range

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby