### PR TITLE
Fix SVG height stuck at default 340px on compact screens

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -34,7 +34,7 @@ function wrapTitle(text, maxChars) {
 }
 
 const Timeline = forwardRef(function Timeline(
-  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false, onDebug },
+  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
   ref
 ) {
   const remPx = REM_PX[textSize] || 22
@@ -127,8 +127,6 @@ const Timeline = forwardRef(function Timeline(
     : compactLayout
       ? h - 40
       : Math.round(h * 0.50)
-  useEffect(() => { onDebug?.(`svgH:${h} ax:${axisY}`) }, [h, axisY, onDebug])
-
   const today    = new Date()
   const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRangeForView(zoom, centerMs, viewMode, customHalfMs)

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -72,8 +72,6 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [canUndo,       setCanUndo]       = useState(false)
   const [canRedo,       setCanRedo]       = useState(false)
   const [newlyAddedId,  setNewlyAddedId]  = useState(null)
-  const [dbg,           setDbg]           = useState('')
-  const [tlDbg,         setTlDbg]         = useState('')
 
   const timelineRef    = useRef(null)
   const zoomWrapRef    = useRef(null)
@@ -136,16 +134,6 @@ export default function TimelineView({ milestones, setMilestones }) {
   useEffect(() => {
     if (compactStats) setMinimapOpen(ultraCompact && textSize === 'small')
   }, [compactStats, ultraCompact, textSize])
-
-  // DEBUG — measure real DOM heights each render
-  useEffect(() => {
-    const body   = document.querySelector('.timeline-body')?.offsetHeight ?? '?'
-    const bottom = document.querySelector('.timeline-bottom')?.offsetHeight ?? '?'
-    const map    = document.querySelector('.minimap-bar')?.offsetHeight ?? 0
-    const grip   = document.querySelector('.minimap-grip')?.offsetHeight ?? 0
-    const hdr    = document.querySelector('.timeline-header')?.offsetHeight ?? '?'
-    setDbg(`${__BUILD_TIME__.slice(11,19)} win:${window.innerWidth}×${window.innerHeight} | hdr:${hdr} body:${body} map:${map} grip:${grip} btm:${bottom} | uc:${ultraCompact?1:0} cs:${compactStats?1:0} mo:${minimapOpen?1:0} ts:${textSize}`)
-  })
 
   // Restrict text size: big/bigger cards overflow the axis on short screens.
   useEffect(() => {
@@ -771,7 +759,6 @@ export default function TimelineView({ milestones, setMilestones }) {
             birthday={birthday}
             newlyAddedId={newlyAddedId}
             ultraCompact={ultraCompact}
-            onDebug={setTlDbg}
           />
         </div>
 
@@ -869,11 +856,6 @@ export default function TimelineView({ milestones, setMilestones }) {
         <button className="today-btn" onClick={handleJumpToToday}>
           jump to today
         </button>
-      </div>
-
-      {/* ── DEBUG ──────────────────────────────────────────────────────────── */}
-      <div style={{ position:'fixed', bottom:0, left:0, right:0, background:'rgba(0,0,0,0.85)', color:'#0f0', fontSize:'9px', padding:'2px 6px', zIndex:99999, pointerEvents:'none', fontFamily:'monospace', whiteSpace:'nowrap', overflow:'hidden' }}>
-        {dbg} | {tlDbg}
       </div>
 
       {/* ── Sheets ─────────────────────────────────────────────────────────── */}

--- a/src/index.css
+++ b/src/index.css
@@ -435,6 +435,7 @@ button, input, select, textarea {
 /* ─── SVG Timeline wrapper (pan + zoom) ────────────────────────────────────── */
 .timeline-svg-wrap {
   flex: 1;
+  min-height: 0;
   width: 100%;
   cursor: grab;
   touch-action: pan-y;
@@ -445,6 +446,7 @@ button, input, select, textarea {
 /* Zoom animation wrapper — wraps the entire Timeline component */
 .timeline-zoom-wrap {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   transition: transform 0.42s cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,9 +3,6 @@ import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
-  define: {
-    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
-  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
The ResizeObserver on .timeline-svg-wrap was caught in a circular dependency: SVG renders at h=340 (default) → expands the flex wrapper → ResizeObserver reports 340 → h stays 340. Meanwhile the actual visible body is only ~243px, so the axis at 70% of 340 = 238px was fine, but tick labels at axisY+20 = 258px were clipped by the 243px overflow:hidden boundary.

Fix: add min-height:0 to .timeline-svg-wrap and .timeline-zoom-wrap. This prevents flex children from expanding their parent beyond the flex-allocated height, breaking the circular dependency and letting the ResizeObserver report the true container height (~243px).

Also removes all temporary debug instrumentation.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby