### PR TITLE
Unify axis formula: h-40 for all compact heights (≤900px)

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -117,16 +117,13 @@ const Timeline = forwardRef(function Timeline(
   }, [])
 
   const { w, h } = size
-  // ultraCompact (≤500px tall): axis at ~70% so cards fit above and there's
-  //   breathing room below before the map bar; floor at 193 so cards never
-  //   cross the axis (topClamp 84 + CARD_H2 101 + 8px min-connector = 193).
-  // compact (≤900px): axis pinned near bottom to maximise card space above.
+  // ultraCompact + compactLayout (≤900px): axis pinned 40px from bottom so
+  //   cards maximise space above and axis sits just above the minimap bar.
+  //   Floor at 193 prevents card overflow at very small heights.
   // normal: axis centred.
-  const axisY = ultraCompact
-    ? Math.min(h - 32, Math.max(193, Math.round(h * 0.70)))
-    : compactLayout
-      ? h - 40
-      : Math.round(h * 0.50)
+  const axisY = compactLayout
+    ? Math.max(193, h - 40)
+    : Math.round(h * 0.50)
   const today    = new Date()
   const centerMs = today.getTime() + panMs
   const { startMs, endMs } = getTimeRangeForView(zoom, centerMs, viewMode, customHalfMs)


### PR DESCRIPTION
The ultraCompact branch used h×0.70 which left ~30% dead space below the axis. Since compactLayout (h-40) already worked well, extend it to cover ultraCompact too. Both are now max(193, h-40), pinning the axis just above the minimap and maximising card space above.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby