### PR TITLE
Auto-default text size based on screen height on first visit

### DIFF
--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -2,8 +2,7 @@ import React, { useRef, useState } from 'react'
 import { saveCategories } from '../../utils/colors'
 import { isMuted, setMuted } from '../../utils/audio'
 
-const TEXT_SIZES_ALL     = ['small', 'normal', 'big', 'bigger']
-const TEXT_SIZES_COMPACT = ['small', 'normal']
+const TEXT_SIZES_ALL = ['small', 'normal', 'big', 'bigger']
 
 const COLOR_PALETTE = [
   '#9370DB', '#A78BFA', '#6366F1', '#3D3580',
@@ -66,15 +65,16 @@ export default function SettingsModal({
         {/* ── Text size ─────────────────────────────────────────────────── */}
         <div className="settings-section">
           <div className="settings-label">text size</div>
-          <div className="zoom-tabs">
-            {(ultraCompact ? TEXT_SIZES_COMPACT : TEXT_SIZES_ALL).map(s => (
-              <button key={s}
-                className={`zoom-tab ${textSize === s ? 'active' : ''}`}
-                onClick={() => onTextSizeChange(s)}>{s}</button>
-            ))}
-          </div>
-          {ultraCompact && (
-            <div className="settings-note">big / bigger unavailable on short screens</div>
+          {ultraCompact ? (
+            <div className="settings-note">text size adjustment unavailable on short screens</div>
+          ) : (
+            <div className="zoom-tabs">
+              {TEXT_SIZES_ALL.map(s => (
+                <button key={s}
+                  className={`zoom-tab ${textSize === s ? 'active' : ''}`}
+                  onClick={() => onTextSizeChange(s)}>{s}</button>
+              ))}
+            </div>
           )}
         </div>
 

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -31,9 +31,15 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [addOpen,       setAddOpen]       = useState(false)
   const [editTarget,    setEditTarget]    = useState(null)
   const [detail,        setDetail]        = useState(null)
-  const [textSize,      setTextSize]      = useState(
-    () => localStorage.getItem('lifeglance-text-size') || 'normal'
-  )
+  const [textSize,      setTextSize]      = useState(() => {
+    const stored = localStorage.getItem('lifeglance-text-size')
+    if (stored) return stored
+    // First-visit default: estimate available SVG height (total minus fixed chrome)
+    const hEst = window.innerHeight - 141
+    if (hEst < 240) return 'small'
+    if (hEst < 640) return 'normal'
+    return 'big'
+  })
   const [customYears,   setCustomYears]   = useState(15)
   const [pastIdx,       setPastIdx]       = useState(0)
   const [futureIdx,     setFutureIdx]     = useState(0)


### PR DESCRIPTION
- On first load (no localStorage), compute default from window.innerHeight: <240px available → small, <640px → normal, ≥640px → big (bigger is never auto-selected per design intent)
- ultraCompact: hide text size controls entirely, show note instead
- Remove unused TEXT_SIZES_COMPACT constant

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby