### PR TITLE
Apply popup border/background to all stat panels

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -684,6 +684,9 @@ button, input, select, textarea {
   font-size: 0.7rem;
   max-width: 155px;
   line-height: 1.5;
+  background: rgba(13, 15, 22, 0.92);
+  border: 1px solid var(--border);
+  padding: 0.55rem 0.65rem;
 }
 .stat-panel-label {
   color: var(--amber);
@@ -1373,9 +1376,6 @@ button, input, select, textarea {
 
 .stat-panel-popup {
   margin-top: 0.35rem;
-  background: rgba(13, 15, 22, 0.92);
-  border: 1px solid var(--border);
-  padding: 0.55rem 0.65rem;
 }
 
 


### PR DESCRIPTION
Move background, border, and padding from .stat-panel-popup onto .stat-panel so the always-expanded desktop panels match the overlay look of the phone popup (dark bg, border, overlays milestones). Popup retains only its margin-top.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby