### PR TITLE
Centre step 1 welcome screen vertically

### DIFF
--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -38,7 +38,7 @@ export default function Onboarding({ onComplete }) {
   const previewMilestones = [pastMilestone, futureMilestone].filter(Boolean)
 
   return (
-    <div className="onboarding">
+    <div className={`onboarding${step === 1 ? ' onboarding-welcome' : ''}`}>
       {step === 1 && <Step1Welcome onBegin={handleBegin} onSkip={finish} />}
       {step === 2 && <Step2Past    onSubmit={handlePast}    onSkip={finish} />}
       {step === 3 && <Step3Future  onSubmit={handleFuture}  onSkip={finish} pastMilestone={pastMilestone} />}

--- a/src/index.css
+++ b/src/index.css
@@ -223,6 +223,9 @@ button, input, select, textarea {
   position: relative;
 }
 
+/* No preview strip on step 1 — use symmetrical padding so content is truly centred */
+.onboarding-welcome { padding-bottom: 2rem; }
+
 .onboarding-step {
   width: 100%;
   max-width: 580px;


### PR DESCRIPTION
The 6rem bottom padding (reserved for the preview strip) was offsetting the flex-centre upward on step 1 where no strip is shown. Add .onboarding-welcome class and reset bottom padding to 2rem so top and bottom are symmetrical and the logo/CTA sit in the true vertical centre.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby