### PR TITLE
Improve onboarding vertical centering on steps 2+

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -219,7 +219,7 @@ button, input, select, textarea {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1.5rem 6rem;
+  padding: 2rem 1.5rem 3.5rem;
   position: relative;
 }
 
@@ -1389,8 +1389,8 @@ button, input, select, textarea {
   .timeline-header  { padding: 0.28rem 0.8rem; }
   .header-center    { flex-direction: row; gap: 0.5rem; align-items: center; }
 
-  /* Onboarding: switch to top-aligned, compress everything for landscape phones */
-  .onboarding         { justify-content: flex-start; padding: 0.6rem 1.5rem 4rem; }
+  /* Onboarding: compress everything for landscape phones, push content down from edge */
+  .onboarding         { justify-content: flex-start; padding: 1.5rem 1.5rem 4rem; }
   /* Step 1 has no preview strip — keep it vertically centred */
   .onboarding-welcome { justify-content: center; padding: 1rem 1.5rem; }
   .onboarding-step    { gap: 0.65rem; }
@@ -1403,7 +1403,7 @@ button, input, select, textarea {
 /* ─── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 480px) {
   /* Onboarding: reduce gaps and reserved prompt height on portrait phones */
-  .onboarding         { padding: 1.5rem 1.25rem 5rem; }
+  .onboarding         { padding: 1.5rem 1.25rem 3.5rem; }
   .onboarding-step    { gap: 1.2rem; }
   .onboarding-inputs  { gap: 0.85rem; }
   .onboarding-prompt  { font-size: 1.05rem; min-height: 4rem; }


### PR DESCRIPTION
- Reduce default bottom padding 6rem→3.5rem so justify-content:center lands closer to the true screen midpoint on portrait/desktop
- Landscape phones: increase top padding 0.6rem→1.5rem so the form doesn't feel stuck to the top edge

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby