### PR TITLE
Add URL links, recurrence, stats summary, and On This Day

### DIFF
--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -12,15 +12,17 @@ const MONTHS = [
 export default function AddMilestoneSheet({ onSave, onClose, existing, categories = DEFAULT_CATEGORIES }) {
   const isEdit = !!existing
 
-  const [title,     setTitle]     = useState(existing?.title     ?? '')
-  const [month,     setMonth]     = useState('6')
-  const [day,       setDay]       = useState('')
-  const [year,      setYear]      = useState('')
-  const [precision, setPrecision] = useState(existing?.date_precision ?? 'month')
-  const [category,  setCategory]  = useState(existing?.category  ?? 'personal')
-  const [note,      setNote]      = useState(existing?.note       ?? '')
-  const [photoUri,  setPhotoUri]  = useState(existing?.photo_uri  ?? '')
-  const [busy,      setBusy]      = useState(false)
+  const [title,      setTitle]      = useState(existing?.title     ?? '')
+  const [month,      setMonth]      = useState('6')
+  const [day,        setDay]        = useState('')
+  const [year,       setYear]       = useState('')
+  const [precision,  setPrecision]  = useState(existing?.date_precision ?? 'month')
+  const [category,   setCategory]   = useState(existing?.category  ?? 'personal')
+  const [note,       setNote]       = useState(existing?.note       ?? '')
+  const [url,        setUrl]        = useState(existing?.url        ?? '')
+  const [photoUri,   setPhotoUri]   = useState(existing?.photo_uri  ?? '')
+  const [recurrence, setRecurrence] = useState(false)
+  const [busy,       setBusy]       = useState(false)
   const photoRef = useRef(null)
 
   // Pre-fill date from existing
@@ -50,6 +52,9 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         color: selectedCat?.color,
         note: note.trim(),
         photo_uri: photoUri,
+        url: url.trim(),
+        recurrence: (!isEdit && recurrence) ? 'annual' : (existing?.recurrence ?? null),
+        recurrence_id: existing?.recurrence_id ?? null,
       }, existing)
       onClose()
     } finally {
@@ -174,6 +179,19 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
           />
         </div>
 
+        {/* URL */}
+        <div className="sheet-field">
+          <label className="field-label">link (optional)</label>
+          <input
+            className="input"
+            type="url"
+            placeholder="https://…"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            autoComplete="off"
+          />
+        </div>
+
         {/* Photo */}
         <div className="sheet-field">
           <label className="field-label">photo (optional)</label>
@@ -204,6 +222,28 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
             }}
           />
         </div>
+
+        {/* Recurrence (new milestones only) */}
+        {!isEdit && (
+          <div className="sheet-field">
+            <label className="recurrence-toggle-row">
+              <span className="field-label" style={{ marginBottom: 0 }}>repeats annually</span>
+              <input type="checkbox" className="settings-toggle"
+                checked={recurrence}
+                onChange={e => setRecurrence(e.target.checked)} />
+            </label>
+            {recurrence && (
+              <div className="sheet-recurrence-note">
+                instances will be created from this year through {new Date().getFullYear() + 3}
+              </div>
+            )}
+          </div>
+        )}
+        {isEdit && existing?.recurrence === 'annual' && (
+          <div className="sheet-field">
+            <div className="detail-recurrence">↻ repeats annually — editing this instance only</div>
+          </div>
+        )}
 
         {/* Actions */}
         <div className="sheet-actions">

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 
-export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, birthday }) {
+export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday }) {
   function handleDelete() {
     if (window.confirm(`Delete "${m.title}"?`)) {
       onDelete(m.id)
+      onClose()
+    }
+  }
+
+  function handleDeleteSeries() {
+    if (window.confirm(`Delete all instances of "${m.title}"?`)) {
+      onDeleteSeries(m.recurrence_id)
       onClose()
     }
   }
@@ -49,16 +56,35 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
           {m.category}
         </div>
 
+        {/* Recurrence badge */}
+        {m.recurrence === 'annual' && (
+          <div className="detail-recurrence">↻ repeats annually</div>
+        )}
+
         {/* Note */}
         {m.note && (
           <div className="detail-note">{m.note}</div>
         )}
 
+        {/* URL link */}
+        {m.url && (
+          <a href={m.url} target="_blank" rel="noopener noreferrer" className="detail-url">
+            {m.url.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+          </a>
+        )}
+
         {/* Actions */}
         <div className="sheet-actions">
-          <button className="btn-ghost" onClick={handleDelete}>
-            delete
-          </button>
+          <div className="detail-delete-group">
+            <button className="btn-ghost" onClick={handleDelete}>
+              delete
+            </button>
+            {m.recurrence_id && onDeleteSeries && (
+              <button className="btn-ghost detail-delete-series" onClick={handleDeleteSeries}>
+                delete series
+              </button>
+            )}
+          </div>
           <div className="sheet-actions-right">
             <button className="btn" onClick={() => { onClose(); onEdit(m); }}
               style={{ fontSize: '0.8rem', padding: '0.45rem 0.9rem' }}

--- a/src/components/stats/SummaryModal.jsx
+++ b/src/components/stats/SummaryModal.jsx
@@ -1,0 +1,142 @@
+import React, { useMemo } from 'react'
+import { formatDateDisplay } from '../../utils/dates'
+
+function formatSpan(ms) {
+  const days   = ms / (24 * 3600 * 1000)
+  const years  = Math.floor(days / 365.25)
+  const months = Math.floor((days % 365.25) / 30.4)
+  if (years > 0 && months > 0) return `${years} yr${years !== 1 ? 's' : ''}, ${months} mo`
+  if (years > 0)               return `${years} yr${years !== 1 ? 's' : ''}`
+  if (months > 0)              return `${months} mo`
+  return `${Math.round(days)} day${Math.round(days) !== 1 ? 's' : ''}`
+}
+
+export default function SummaryModal({ milestones, onClose }) {
+  const stats = useMemo(() => {
+    if (!milestones.length) return null
+
+    const today   = new Date()
+    // Exclude recurring duplicates from analytical stats — keep only one per recurrence_id
+    const deduped = milestones.filter((m, _, arr) =>
+      !m.recurrence_id || arr.findIndex(x => x.recurrence_id === m.recurrence_id) === arr.indexOf(m)
+    )
+    const sorted  = [...deduped].sort((a, b) => new Date(a.date) - new Date(b.date))
+
+    const past   = milestones.filter(m => new Date(m.date) < today).length
+    const future = milestones.filter(m => new Date(m.date) >= today).length
+
+    // Span from earliest to latest (including recurring)
+    const allSorted = [...milestones].sort((a, b) => new Date(a.date) - new Date(b.date))
+    const spanMs = allSorted.length > 1
+      ? new Date(allSorted.at(-1).date) - new Date(allSorted[0].date)
+      : 0
+
+    // Longest gap between consecutive deduplicated milestones
+    let longestGap = 0, gapA = null, gapB = null
+    for (let i = 1; i < sorted.length; i++) {
+      const gap = new Date(sorted[i].date) - new Date(sorted[i - 1].date)
+      if (gap > longestGap) { longestGap = gap; gapA = sorted[i - 1]; gapB = sorted[i] }
+    }
+
+    // Busiest year (deduped)
+    const byYear = {}
+    for (const m of deduped) {
+      const y = new Date(m.date).getFullYear()
+      byYear[y] = (byYear[y] || 0) + 1
+    }
+    const busiestEntry = Object.entries(byYear).sort((a, b) => b[1] - a[1])[0]
+
+    // Decade breakdown (deduped)
+    const byDecade = {}
+    for (const m of deduped) {
+      const dec = Math.floor(new Date(m.date).getFullYear() / 10) * 10
+      byDecade[dec] = (byDecade[dec] || 0) + 1
+    }
+    const decades      = Object.entries(byDecade).sort((a, b) => Number(a[0]) - Number(b[0]))
+    const maxDecCount  = Math.max(...decades.map(d => d[1]), 1)
+
+    return { total: milestones.length, past, future, spanMs, longestGap, gapA, gapB, busiestEntry, decades, maxDecCount }
+  }, [milestones])
+
+  return (
+    <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="sheet">
+        <div className="sheet-header">
+          <span className="sheet-title">timeline stats</span>
+          <button className="sheet-close" onClick={onClose}>✕</button>
+        </div>
+
+        {!stats ? (
+          <div className="settings-note">no milestones yet</div>
+        ) : (
+          <>
+            {/* Overview grid */}
+            <div className="summary-grid">
+              <div className="summary-cell">
+                <div className="summary-value">{stats.total}</div>
+                <div className="summary-label">milestones</div>
+              </div>
+              <div className="summary-cell">
+                <div className="summary-value">{stats.past}</div>
+                <div className="summary-label">in the past</div>
+              </div>
+              <div className="summary-cell">
+                <div className="summary-value">{stats.future}</div>
+                <div className="summary-label">upcoming</div>
+              </div>
+              <div className="summary-cell">
+                <div className="summary-value">{stats.spanMs > 0 ? formatSpan(stats.spanMs) : '—'}</div>
+                <div className="summary-label">time tracked</div>
+              </div>
+            </div>
+
+            {/* Longest gap */}
+            {stats.gapA && stats.gapB && (
+              <div className="summary-section">
+                <div className="summary-section-label">longest gap</div>
+                <div className="summary-gap">
+                  <span className="summary-gap-title">{stats.gapA.title}</span>
+                  <span className="summary-gap-arrow">→</span>
+                  <span className="summary-gap-title">{stats.gapB.title}</span>
+                </div>
+                <div className="summary-gap-dur">{formatSpan(stats.longestGap)}</div>
+              </div>
+            )}
+
+            {/* Busiest year */}
+            {stats.busiestEntry && (
+              <div className="summary-section">
+                <div className="summary-section-label">busiest year</div>
+                <div className="summary-busiest">
+                  <span className="summary-busiest-year">{stats.busiestEntry[0]}</span>
+                  <span className="summary-busiest-count">
+                    {stats.busiestEntry[1]} milestone{stats.busiestEntry[1] !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* Decade breakdown */}
+            {stats.decades.length > 0 && (
+              <div className="summary-section">
+                <div className="summary-section-label">by decade</div>
+                <div className="summary-decades">
+                  {stats.decades.map(([dec, count]) => (
+                    <div key={dec} className="summary-decade-row">
+                      <div className="summary-decade-label">{dec}s</div>
+                      <div className="summary-decade-track">
+                        <div className="summary-decade-bar"
+                          style={{ width: `${(count / stats.maxDecCount) * 100}%` }} />
+                      </div>
+                      <div className="summary-decade-count">{count}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/timeline/OnThisDayModal.jsx
+++ b/src/components/timeline/OnThisDayModal.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { formatDateDisplay } from '../../utils/dates'
+
+export default function OnThisDayModal({ items, onClose, onSelect }) {
+  const today     = new Date()
+  const todayYear = today.getFullYear()
+
+  return (
+    <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="sheet">
+        <div className="sheet-header">
+          <span className="sheet-title">on this day</span>
+          <button className="sheet-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="otd-list">
+          {items.map(m => {
+            const yearsAgo = todayYear - new Date(m.date).getFullYear()
+            return (
+              <div key={m.id} className="otd-item" onClick={() => onSelect(m)}>
+                <div className="otd-dot" style={{ background: m.color }} />
+                <div className="otd-content">
+                  <div className="otd-title">{m.title}</div>
+                  <div className="otd-meta">
+                    {formatDateDisplay(m.date, m.date_precision)}
+                    {yearsAgo > 0 && (
+                      <span className="otd-years">
+                        {' '}· {yearsAgo} year{yearsAgo !== 1 ? 's' : ''} ago
+                      </span>
+                    )}
+                    {m.date_precision === 'month' && (
+                      <span className="otd-approx"> (approx.)</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -405,32 +405,72 @@ const Timeline = forwardRef(function Timeline(
                 ) : null
               })()}
 
-              {/* Vintage camera indicator — top-right corner */}
-              {m.photo_uri && (
-                <g transform={`translate(${cardX + CARD_W - 21},${cardY + 3})`}
-                   opacity={isHL ? 0.9 : 0.52}
-                   style={{ cursor: 'zoom-in' }}
-                   onMouseEnter={e => setPhotoTip({ uri: m.photo_uri, x: e.clientX, y: e.clientY })}
-                   onMouseLeave={() => setPhotoTip(null)}>
-                  {/* invisible hit area for reliable hover */}
-                  <rect x={-2} y={-1} width={18} height={13} fill="transparent" />
-                  {/* body */}
-                  <rect x={0} y={2.5} width={14} height={8} rx={1.3}
-                    fill="none" stroke={m.color} strokeWidth={0.85} />
-                  {/* viewfinder bump */}
-                  <rect x={2} y={0.5} width={4} height={2.8} rx={0.7}
-                    fill="none" stroke={m.color} strokeWidth={0.75} />
-                  {/* lens ring */}
-                  <circle cx={7} cy={6.5} r={2.6}
-                    fill="none" stroke={m.color} strokeWidth={0.85} />
-                  {/* lens glass */}
-                  <circle cx={7} cy={6.5} r={1.25}
-                    fill={m.color} opacity={0.55} />
-                  {/* shutter button */}
-                  <circle cx={11.8} cy={4} r={0.75}
-                    fill={m.color} />
-                </g>
-              )}
+              {/* Card icons — top-right corner: camera, link, recurrence (right → left) */}
+              {(() => {
+                const icons = []
+                if (m.photo_uri)  icons.push('camera')
+                if (m.url)        icons.push('link')
+                if (m.recurrence) icons.push('recurrence')
+                return icons.map((type, i) => {
+                  const ix = cardX + CARD_W - 21 - i * 17
+                  const iy = cardY + 3
+                  const op = isHL ? 0.9 : 0.52
+                  if (type === 'camera') return (
+                    <g key="camera" transform={`translate(${ix},${iy})`}
+                       opacity={op} style={{ cursor: 'zoom-in' }}
+                       onMouseEnter={e => setPhotoTip({ uri: m.photo_uri, x: e.clientX, y: e.clientY })}
+                       onMouseLeave={() => setPhotoTip(null)}>
+                      <rect x={-2} y={-1} width={18} height={13} fill="transparent" />
+                      <rect x={0} y={2.5} width={14} height={8} rx={1.3}
+                        fill="none" stroke={m.color} strokeWidth={0.85} />
+                      <rect x={2} y={0.5} width={4} height={2.8} rx={0.7}
+                        fill="none" stroke={m.color} strokeWidth={0.75} />
+                      <circle cx={7} cy={6.5} r={2.6}
+                        fill="none" stroke={m.color} strokeWidth={0.85} />
+                      <circle cx={7} cy={6.5} r={1.25}
+                        fill={m.color} opacity={0.55} />
+                      <circle cx={11.8} cy={4} r={0.75} fill={m.color} />
+                    </g>
+                  )
+                  if (type === 'link') return (
+                    <g key="link" transform={`translate(${ix},${iy})`}
+                       opacity={op} style={{ cursor: 'pointer' }}
+                       onClick={e => { e.stopPropagation(); window.open(m.url, '_blank', 'noopener,noreferrer') }}>
+                      <rect x={-2} y={-1} width={18} height={13} fill="transparent" />
+                      {/* page */}
+                      <rect x={0} y={3} width={8} height={7} rx={1}
+                        fill="none" stroke={m.color} strokeWidth={0.85} />
+                      {/* arrow shaft */}
+                      <line x1={6} y1={5} x2={12} y2={0}
+                        stroke={m.color} strokeWidth={0.85} strokeLinecap="round" />
+                      {/* arrow head */}
+                      <polyline points="9,0 12,0 12,3"
+                        fill="none" stroke={m.color} strokeWidth={0.85}
+                        strokeLinecap="round" strokeLinejoin="round" />
+                    </g>
+                  )
+                  if (type === 'recurrence') return (
+                    <g key="recurrence" transform={`translate(${ix},${iy})`} opacity={op}>
+                      <rect x={-2} y={-1} width={18} height={13} fill="transparent" />
+                      {/* top arc */}
+                      <path d="M 2,5.5 C 2,1 11,1 11,5.5"
+                        fill="none" stroke={m.color} strokeWidth={0.85} strokeLinecap="round" />
+                      {/* top arrowhead */}
+                      <polyline points="9,3 11,5.5 8.5,6.5"
+                        fill="none" stroke={m.color} strokeWidth={0.85}
+                        strokeLinecap="round" strokeLinejoin="round" />
+                      {/* bottom arc */}
+                      <path d="M 11,6.5 C 11,11 2,11 2,6.5"
+                        fill="none" stroke={m.color} strokeWidth={0.85} strokeLinecap="round" />
+                      {/* bottom arrowhead */}
+                      <polyline points="3.5,8.5 2,6.5 4.5,5.5"
+                        fill="none" stroke={m.color} strokeWidth={0.85}
+                        strokeLinecap="round" strokeLinejoin="round" />
+                    </g>
+                  )
+                  return null
+                })
+              })()}
               </g>
               </g>
             </g>

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -6,6 +6,8 @@ import MilestoneDetail   from '../milestone/MilestoneDetail'
 import SettingsModal     from '../settings/SettingsModal'
 import HelpModal         from '../help/HelpModal'
 import SearchModal       from '../search/SearchModal'
+import SummaryModal      from '../stats/SummaryModal'
+import OnThisDayModal    from './OnThisDayModal'
 import MinimapBar        from '../minimap/MinimapBar'
 import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS }   from '../../utils/timeline'
@@ -74,6 +76,8 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [canUndo,       setCanUndo]       = useState(false)
   const [canRedo,       setCanRedo]       = useState(false)
   const [newlyAddedId,  setNewlyAddedId]  = useState(null)
+  const [summaryOpen,   setSummaryOpen]   = useState(false)
+  const [onThisDayOpen, setOnThisDayOpen] = useState(false)
 
   const timelineRef    = useRef(null)
   const zoomWrapRef    = useRef(null)
@@ -176,6 +180,21 @@ export default function TimelineView({ milestones, setMilestones }) {
   const filteredMilestones = filter === 'all'
     ? milestones
     : milestones.filter(m => m.category === filter)
+
+  // ── "On this day" — milestones that share today's month (and day if precision allows) ──
+  const onThisDayItems = React.useMemo(() => {
+    const today = new Date()
+    const todayMonth = today.getMonth() + 1
+    const todayDay   = today.getDate()
+    return milestones.filter(m => {
+      if (new Date(m.date) >= today) return false
+      if (m.date_precision === 'year') return false
+      const d = new Date(m.date)
+      const sameMonth = d.getMonth() + 1 === todayMonth
+      if (m.date_precision === 'month') return sameMonth
+      return sameMonth && d.getDate() === todayDay
+    }).sort((a, b) => new Date(b.date) - new Date(a.date))
+  }, [milestones])
 
   // ── Past / future for stat panel ─────────────────────────────────────────────
   const now    = new Date()
@@ -485,6 +504,32 @@ export default function TimelineView({ milestones, setMilestones }) {
       pushHistory(newMs)
       setMilestones(newMs)
       audio.playEditSave()
+    } else if (data.recurrence === 'annual') {
+      // Generate one instance per year from base year to current+3
+      const rid       = crypto.randomUUID()
+      const baseDate  = new Date(data.date)
+      const baseYear  = baseDate.getFullYear()
+      const endYear   = Math.max(baseYear, new Date().getFullYear()) + 3
+      const created   = []
+      for (let y = baseYear; y <= endYear; y++) {
+        const d = new Date(baseDate)
+        d.setFullYear(y)
+        const m = await addMilestone({
+          ...data,
+          date:          d,
+          recurrence_id: rid,
+          // only the base-year instance keeps the original note / photo / url
+          note:      y === baseYear ? data.note      : '',
+          photo_uri: y === baseYear ? data.photo_uri : '',
+          url:       y === baseYear ? data.url       : '',
+        })
+        created.push(m)
+      }
+      const newMs = [...milestones, ...created]
+      pushHistory(newMs)
+      setMilestones(newMs)
+      setNewlyAddedId(created[0].id)
+      audio.playChime()
     } else {
       const m = await addMilestone(data)
       const newMs = [...milestones, m]
@@ -498,6 +543,14 @@ export default function TimelineView({ milestones, setMilestones }) {
   async function handleDelete(id) {
     await deleteMilestone(id)
     const newMs = milestones.filter(m => m.id !== id)
+    pushHistory(newMs)
+    setMilestones(newMs)
+  }
+
+  async function handleDeleteSeries(recurrence_id) {
+    const toDelete = milestones.filter(m => m.recurrence_id === recurrence_id)
+    for (const m of toDelete) await deleteMilestone(m.id)
+    const newMs = milestones.filter(m => m.recurrence_id !== recurrence_id)
     pushHistory(newMs)
     setMilestones(newMs)
   }
@@ -718,8 +771,10 @@ export default function TimelineView({ milestones, setMilestones }) {
           )}
         </div>
 
-        {/* Right: settings + help */}
+        {/* Right: stats + settings + help */}
         <div className="header-right">
+          <button className="action-link" onClick={() => setSummaryOpen(true)}>stats</button>
+          <span className="action-sep">|</span>
           <button className="action-link" onClick={() => setSettingsOpen(true)}>settings</button>
           <span className="action-sep">|</span>
           <button className="action-link" onClick={() => setHelpOpen(true)}>?</button>
@@ -839,6 +894,11 @@ export default function TimelineView({ milestones, setMilestones }) {
           )
         )}
 
+        {onThisDayItems.length > 0 && (
+          <button className="today-btn otd-btn" onClick={() => setOnThisDayOpen(true)}>
+            on this day
+          </button>
+        )}
         <button className="today-btn" onClick={handleJumpToToday}>
           jump to today
         </button>
@@ -857,6 +917,7 @@ export default function TimelineView({ milestones, setMilestones }) {
           onClose={() => setDetail(null)}
           onEdit={openEdit}
           onDelete={handleDelete}
+          onDeleteSeries={handleDeleteSeries}
           birthday={birthday}
         />
       )}
@@ -869,6 +930,19 @@ export default function TimelineView({ milestones, setMilestones }) {
       )}
       {helpOpen && (
         <HelpModal onClose={() => setHelpOpen(false)} />
+      )}
+      {summaryOpen && (
+        <SummaryModal
+          milestones={milestones}
+          onClose={() => setSummaryOpen(false)}
+        />
+      )}
+      {onThisDayOpen && (
+        <OnThisDayModal
+          items={onThisDayItems}
+          onClose={() => setOnThisDayOpen(false)}
+          onSelect={m => { setOnThisDayOpen(false); setDetail(m) }}
+        />
       )}
       {settingsOpen && (
         <SettingsModal

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -13,6 +13,9 @@ export function buildMilestone({
   color,
   note           = '',
   photo_uri      = '',
+  url            = '',
+  recurrence     = null,   // null | 'annual'
+  recurrence_id  = null,   // UUID shared across instances of a series
 }) {
   const dateObj = date instanceof Date ? date : new Date(date)
   const today   = new Date()
@@ -28,6 +31,9 @@ export function buildMilestone({
     color:          color || categoryColor(category),
     note,
     photo_uri,
+    url,
+    recurrence,
+    recurrence_id,
     created_at:     now,
     updated_at:     now,
   }

--- a/src/index.css
+++ b/src/index.css
@@ -963,6 +963,187 @@ button, input, select, textarea {
   padding-left: 0.75rem;
 }
 
+/* ─── Milestone detail — extra fields ─────────────────────────────────────── */
+.detail-url {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--amber);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  word-break: break-all;
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+.detail-url:hover { opacity: 1; }
+
+.detail-recurrence {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.detail-delete-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.detail-delete-series {
+  font-size: 0.72rem;
+  opacity: 0.75;
+}
+
+/* ─── Add milestone sheet — recurrence ─────────────────────────────────────── */
+.recurrence-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+}
+.sheet-recurrence-note {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+  margin-top: 0.2rem;
+}
+
+/* ─── Summary modal ─────────────────────────────────────────────────────────── */
+.summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  border: 1px solid var(--border);
+}
+.summary-cell {
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.summary-value {
+  font-size: 1.15rem;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+.summary-label {
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+.summary-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--border);
+}
+.summary-section-label {
+  font-size: 0.62rem;
+  color: var(--amber);
+  letter-spacing: 0.07em;
+}
+.summary-gap {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+.summary-gap-title {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+.summary-gap-arrow {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+.summary-gap-dur {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+.summary-busiest {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+.summary-busiest-year  { font-size: 1.1rem; color: var(--text); }
+.summary-busiest-count { font-size: 0.72rem; color: var(--text-muted); }
+
+.summary-decades {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.summary-decade-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.summary-decade-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  width: 3.2rem;
+  flex-shrink: 0;
+}
+.summary-decade-track {
+  flex: 1;
+  height: 4px;
+  background: rgba(232,224,208,0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.summary-decade-bar {
+  height: 100%;
+  background: var(--amber);
+  opacity: 0.65;
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+.summary-decade-count {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  width: 1.4rem;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ─── On this day modal ─────────────────────────────────────────────────────── */
+.otd-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.otd-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgba(232,224,208,0.06);
+  cursor: pointer;
+  transition: background 0.12s;
+  border-radius: 3px;
+  padding-left: 0.3rem;
+}
+.otd-item:hover { background: rgba(232,224,208,0.04); }
+.otd-item:last-child { border-bottom: none; }
+.otd-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 0.3rem;
+}
+.otd-content { display: flex; flex-direction: column; gap: 0.18rem; }
+.otd-title   { font-size: 0.85rem; color: var(--text-dim); }
+.otd-meta    { font-size: 0.65rem; color: var(--text-muted); }
+.otd-years   { color: var(--amber); opacity: 0.8; }
+.otd-approx  { opacity: 0.6; font-style: italic; }
+
+/* "on this day" bottom-bar button — amber accent to draw attention */
+.otd-btn { color: var(--amber) !important; opacity: 0.85; }
+.otd-btn:hover { opacity: 1; }
+
 /* ─── Empty state ──────────────────────────────────────────────────────────── */
 .empty-state {
   position: absolute;


### PR DESCRIPTION
(1) URL/link field — new `url` field on every milestone; shown as a
    clickable external-link icon on the timeline card (opens new tab)
    and as a link in the detail sheet.

(2) Recurrence — `recurrence: 'annual'` + `recurrence_id` fields;
    toggle in AddMilestoneSheet auto-generates one instance per year
    from the base year through current+3. Recurrence icon (↻ arrows)
    appears on every instance card. Detail sheet shows badge and a
    'delete series' action alongside 'delete'.

(3) Stats summary — new SummaryModal (header 'stats' link): total /
    past / future counts, time tracked, longest gap, busiest year,
    decade breakdown bar chart.

(4) On This Day — bottom-bar 'on this day' button appears whenever
    milestones share today's month/day; opens OnThisDayModal listing
    matches with how many years ago, tapping opens the detail sheet.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby