### PR TITLE
Add recurrence year-range picker (max +50 years)

### DIFF
--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -22,6 +22,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
   const [url,        setUrl]        = useState(existing?.url        ?? '')
   const [photoUri,   setPhotoUri]   = useState(existing?.photo_uri  ?? '')
   const [recurrence, setRecurrence] = useState(false)
+  const [recEndYear, setRecEndYear] = useState('')
   const [busy,       setBusy]       = useState(false)
   const photoRef = useRef(null)
 
@@ -34,6 +35,19 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
       setYear(String(d.getFullYear()))
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Keep the recurrence end-year default in sync with the base year
+  React.useEffect(() => {
+    if (recurrence && year.length >= 4) {
+      const base = Number(year)
+      setRecEndYear(y => {
+        // only override if blank or user hasn't manually changed it
+        const current = Number(y)
+        const def = Math.max(base, new Date().getFullYear()) + 3
+        return (!y || current < base) ? String(def) : y
+      })
+    }
+  }, [recurrence, year])
 
   const canSave = title.trim() && year.length >= 4
 
@@ -55,6 +69,9 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         url: url.trim(),
         recurrence: (!isEdit && recurrence) ? 'annual' : (existing?.recurrence ?? null),
         recurrence_id: existing?.recurrence_id ?? null,
+        recurrenceEndYear: (!isEdit && recurrence && year.length >= 4)
+          ? (recEndYear ? Number(recEndYear) : Math.max(Number(year), new Date().getFullYear()) + 3)
+          : undefined,
       }, existing)
       onClose()
     } finally {
@@ -230,13 +247,32 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
               <span className="field-label" style={{ marginBottom: 0 }}>repeats annually</span>
               <input type="checkbox" className="settings-toggle"
                 checked={recurrence}
-                onChange={e => setRecurrence(e.target.checked)} />
+                onChange={e => { setRecurrence(e.target.checked); setRecEndYear('') }} />
             </label>
-            {recurrence && (
-              <div className="sheet-recurrence-note">
-                instances will be created from this year through {new Date().getFullYear() + 3}
-              </div>
-            )}
+            {recurrence && year.length >= 4 && (() => {
+              const base  = Number(year)
+              const end   = recEndYear ? Number(recEndYear) : Math.max(base, new Date().getFullYear()) + 3
+              const count = Math.max(0, end - base + 1)
+              return (
+                <div className="recurrence-range-row">
+                  <span className="recurrence-range-from">{year}</span>
+                  <span className="recurrence-range-arrow">→</span>
+                  <input
+                    type="number"
+                    className="input input-sm"
+                    style={{ width: '5.2rem' }}
+                    value={recEndYear}
+                    placeholder={String(Math.max(base, new Date().getFullYear()) + 3)}
+                    onChange={e => setRecEndYear(e.target.value)}
+                    min={year}
+                    max={base + 50}
+                  />
+                  <span className="recurrence-range-count">
+                    {count} instance{count !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              )
+            })()}
           </div>
         )}
         {isEdit && existing?.recurrence === 'annual' && (

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -505,11 +505,14 @@ export default function TimelineView({ milestones, setMilestones }) {
       setMilestones(newMs)
       audio.playEditSave()
     } else if (data.recurrence === 'annual') {
-      // Generate one instance per year from base year to current+3
+      // Generate one instance per year from base year to chosen end year (max +50)
       const rid       = crypto.randomUUID()
       const baseDate  = new Date(data.date)
       const baseYear  = baseDate.getFullYear()
-      const endYear   = Math.max(baseYear, new Date().getFullYear()) + 3
+      const endYear   = Math.min(
+        data.recurrenceEndYear ?? Math.max(baseYear, new Date().getFullYear()) + 3,
+        baseYear + 50
+      )
       const created   = []
       for (let y = baseYear; y <= endYear; y++) {
         const d = new Date(baseDate)

--- a/src/index.css
+++ b/src/index.css
@@ -1006,6 +1006,16 @@ button, input, select, textarea {
   letter-spacing: 0.03em;
   margin-top: 0.2rem;
 }
+.recurrence-range-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+  flex-wrap: wrap;
+}
+.recurrence-range-from  { font-size: 0.72rem; color: var(--text-muted); }
+.recurrence-range-arrow { font-size: 0.72rem; color: var(--text-muted); }
+.recurrence-range-count { font-size: 0.65rem; color: var(--text-muted); font-style: italic; }
 
 /* ─── Summary modal ─────────────────────────────────────────────────────────── */
 .summary-grid {


### PR DESCRIPTION
User can now choose exactly how far forward the annual series extends. The end-year input defaults to max(baseYear, currentYear)+3, auto-updates when the base year changes, and is capped at baseYear+50. A live instance count updates as the end year is adjusted.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby