### PR TITLE
Collapse compact header to single row; tighten ultraCompact sizing

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -758,57 +758,54 @@ export default function TimelineView({ milestones, setMilestones }) {
         {/* Center: zoom row + view picker */}
         <div className="header-center">
           {compactHeader ? (
-            <>
-              <div className="zoom-row">
-                <div className="zoom-dropdown-wrap" onClick={e => e.stopPropagation()}>
-                  <button
-                    className={`zoom-tab active zoom-dropdown-btn`}
-                    onClick={() => setZoomOpen(o => !o)}>
-                    {zoom === 'custom' ? 'custom' : zoom} ▾
-                  </button>
-                  {zoomOpen && (
-                    <div className="zoom-dropdown">
-                      {[...ZOOM_LEVELS, 'custom'].map(z => (
-                        <button key={z}
-                          className={`zoom-dropdown-item ${zoom === z ? 'active' : ''}`}
-                          onClick={() => { handleZoom(z); setZoomOpen(false) }}>
-                          {z}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {zoom === 'custom' && (
-                  <div className="custom-zoom-row">
-                    <span>±</span>
-                    <input ref={customInputRef} autoFocus
-                      className="custom-zoom-input" type="number" min="1" max="200"
-                      value={customYears}
-                      onChange={e => {
-                        const v = parseInt(e.target.value, 10)
-                        if (!isNaN(v)) setCustomYears(Math.max(1, Math.min(200, v)))
-                      }} />
-                    <span>yr</span>
+            /* Single row on narrow screens: zoom ▾  |  past ↺  |  rec: next */
+            <div className="compact-controls-row">
+              <div className="zoom-dropdown-wrap" onClick={e => e.stopPropagation()}>
+                <button
+                  className="zoom-tab active zoom-dropdown-btn"
+                  onClick={() => setZoomOpen(o => !o)}>
+                  {zoom === 'custom' ? 'custom' : zoom} ▾
+                </button>
+                {zoomOpen && (
+                  <div className="zoom-dropdown">
+                    {[...ZOOM_LEVELS, 'custom'].map(z => (
+                      <button key={z}
+                        className={`zoom-dropdown-item ${zoom === z ? 'active' : ''}`}
+                        onClick={() => { handleZoom(z); setZoomOpen(false) }}>
+                        {z}
+                      </button>
+                    ))}
                   </div>
                 )}
               </div>
-              <div className="view-tabs-row">
-                <div className="view-tabs">
-                  {[['past', 'past'], ['all', 'all'], ['future', 'future']].map(([mode, label]) => (
-                    <button key={mode}
-                      className={`view-tab ${viewMode === mode ? 'active' : ''}`}
-                      onClick={() => handleViewMode(mode)}>{label}</button>
-                  ))}
+              {zoom === 'custom' && (
+                <div className="custom-zoom-row">
+                  <span>±</span>
+                  <input ref={customInputRef} autoFocus
+                    className="custom-zoom-input" type="number" min="1" max="200"
+                    value={customYears}
+                    onChange={e => {
+                      const v = parseInt(e.target.value, 10)
+                      if (!isNaN(v)) setCustomYears(Math.max(1, Math.min(200, v)))
+                    }} />
+                  <span>yr</span>
                 </div>
-                {hasRecurring && (
-                  <button
-                    className={`recur-filter-btn${recurFilter !== 'next' ? ' active' : ''}`}
-                    onClick={cycleRecurFilter}>
-                    recurring: {recurFilter}
-                  </button>
-                )}
-              </div>
-            </>
+              )}
+              <button
+                className="zoom-tab active view-cycle-btn"
+                onClick={() => handleViewMode(
+                  viewMode === 'past' ? 'all' : viewMode === 'all' ? 'future' : 'past'
+                )}>
+                {viewMode} ↺
+              </button>
+              {hasRecurring && (
+                <button
+                  className={`recur-filter-btn${recurFilter !== 'next' ? ' active' : ''}`}
+                  onClick={cycleRecurFilter}>
+                  rec: {recurFilter}
+                </button>
+              )}
+            </div>
           ) : (
             <>
               <div className="zoom-row">

--- a/src/index.css
+++ b/src/index.css
@@ -448,6 +448,20 @@ button, input, select, textarea {
 .recur-filter-btn:hover { color: var(--text-dim); background: rgba(200, 169, 110, 0.06); }
 .recur-filter-btn.active { color: var(--amber); background: rgba(200, 169, 110, 0.1); border-color: rgba(200, 169, 110, 0.3); }
 
+/* Single-row compact controls: zoom ▾  |  past ↺  |  rec: next */
+.compact-controls-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: nowrap;
+}
+/* View-mode cycle button — standalone tab, same look as zoom dropdown btn */
+.view-cycle-btn {
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  white-space: nowrap;
+}
+
 .timeline-body {
   flex: 1;
   position: relative;
@@ -1719,12 +1733,13 @@ button, input, select, textarea {
 }
 
 
-/* ─── Short-screen header (landscape phones ≤500px tall) ──────────────────── */
-/* Collapses the two-row header-center (zoom + view tabs) into a single row,   */
-/* saving ~37px of vertical space for the timeline body.                        */
+/* ─── Short-screen overrides (landscape phones ≤500px tall) ───────────────── */
+/* compact header already collapses to a single row; here we squeeze padding   */
+/* and shrink the action-link strip to recover extra pixels for the SVG.       */
 @media (max-height: 500px) {
-  .timeline-header  { padding: 0.28rem 0.8rem; }
-  .header-center    { flex-direction: row; gap: 0.5rem; align-items: center; }
+  .timeline-header { padding: 0.18rem 0.8rem; }
+  .action-link     { font-size: 0.5rem; }
+  .action-sep      { font-size: 0.6rem; }
 
   /* Onboarding: compress everything for landscape phones, push content down from edge */
   .onboarding         { justify-content: flex-start; padding: 1.5rem 1.5rem 4rem; }


### PR DESCRIPTION
On narrow screens (≤1080px), the header-center previously showed two rows: a zoom dropdown row and a view-tabs row. This made the header taller and pushed the SVG down, especially on phones.

- Replace two-row layout with a single .compact-controls-row containing: zoom ▾  |  past ↺  |  rec: next  (recurring button only if series exist) The view-mode cycling button replaces the three separate tabs; label abbreviates the recurring filter to 'rec: xxx' to save width.
- Add .view-cycle-btn CSS (standalone tab styled like zoom dropdown btn).
- ultraCompact (≤500px height): reduce header padding to 0.18rem and shrink action-link font to 0.5rem, reclaiming ~10px for the SVG. Remove the now-redundant header-center flex-direction override since the compact controls row is already a single horizontal line.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby