### PR TITLE
Fix ICS import modal not scrolling on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1427,6 +1427,13 @@ button, input, select, textarea {
   flex-direction: column;
   overflow: hidden;          /* table-wrap scrolls, not the sheet */
   max-height: 88vh;
+  /* On mobile the sheet is bottom-anchored and grows to content, so max-height
+     alone gives flex children no concrete reference — fix with an explicit height. */
+  height: 88vh;
+}
+@media (min-width: 640px) {
+  /* On wider screens let it shrink to fit shorter lists */
+  .ics-sheet { height: auto; }
 }
 
 .ics-notice {
@@ -1454,6 +1461,7 @@ button, input, select, textarea {
 
 .ics-table-wrap {
   flex: 1;
+  min-height: 0;             /* allow flex child to shrink below content size */
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 6px;


### PR DESCRIPTION
On narrow screens the sheet is bottom-anchored and grows to content, so max-height alone gives flex children no concrete height reference.
- Set height: 88vh on .ics-sheet unconditionally; override to height: auto on ≥640px screens so the modal still shrinks to fit short lists on desktop.
- Add min-height: 0 to .ics-table-wrap so the flex child can shrink below its content size and overflow-y: auto kicks in correctly.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby