### PR TITLE
Fix ICS table crushed to zero height by flex layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1448,6 +1448,7 @@ button, input, select, textarea {
 }
 
 .ics-table-wrap {
+  flex-shrink: 0;             /* prevent flex from crushing the table to zero height */
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow-x: auto;


### PR DESCRIPTION
The base .sheet is a flex column. With default flex-shrink:1, the table-wrap gets squeezed toward zero height when the modal chrome approaches max-height: 88vh (common on landscape phones). Setting flex-shrink:0 preserves the table's natural height; the sheet then scrolls via overflow-y:auto and the sticky actions bar keeps the buttons pinned.

https://claude.ai/code/session_01Kyv4eiveFTXaHULiDHjAby