### PR TITLE
v1.0.2 — Fix version number in help modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Built for people who want to map their life without handing their data to a cloud service. lifeGLANCE is a privacy-first progressive web app that runs entirely in the browser. There is no account, no server, no sync — your data never leaves your device.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.1-brightgreen.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.0.2-brightgreen.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "date-fns": "^3.6.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/help/HelpModal.jsx
+++ b/src/components/help/HelpModal.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react'
 
-const VERSION = '1.0.1'
+const VERSION = '1.0.2'
 
 const SHORTCUTS = [
   { keys: ['←', '→'],        desc: 'cycle past / future milestones'   },


### PR DESCRIPTION
## Summary

- Bumps version to 1.0.2 in `package.json`, `package-lock.json`, `README.md`, and `HelpModal.jsx`
- The help modal was still showing `v1.0.0` after the v1.0.1 release; this corrects it to `v1.0.2`

## Test plan

- [ ] Open the help modal and confirm it displays `v1.0.2`

https://claude.ai/code/session_01Xbo6jntGuTFDbuxoC5Mhqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbo6jntGuTFDbuxoC5Mhqk)_