### PR TITLE
Bug fixes + CI update

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,8 @@
 name: Build & Push to GHCR
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   build-push:
@@ -36,10 +33,9 @@ jobs:
         with:
           images: ghcr.io/krelltunez/lifeglance
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/src/components/help/HelpModal.jsx
+++ b/src/components/help/HelpModal.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react'
-
-const VERSION = '1.0.2'
+import { version as VERSION } from '../../../package.json'
 
 const SHORTCUTS = [
   { keys: ['←', '→'],        desc: 'cycle past / future milestones'   },

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -35,7 +35,7 @@ function wrapTitle(text, maxChars) {
 }
 
 const Timeline = forwardRef(function Timeline(
-  { milestones, zoom, textSize = 'normal', onMilestoneClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
+  { milestones, zoom, textSize = 'normal', onMilestoneClick, onMilestoneDoubleClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
   ref
 ) {
   const remPx = REM_PX[textSize] || 22
@@ -384,7 +384,7 @@ const Timeline = forwardRef(function Timeline(
           }
 
           return (
-            <g key={m.id} onClick={() => onMilestoneClick(m)} opacity={alpha} style={{ cursor: 'pointer' }}>
+            <g key={m.id} onClick={(e) => { if (e.detail >= 2) onMilestoneDoubleClick?.(m); else onMilestoneClick(m) }} opacity={alpha} style={{ cursor: 'pointer' }}>
               {/* Dot and connector: not inside the scale group so they stay on the axis */}
               <g style={stemAnimStyle}>
                 <circle cx={x} cy={axisY}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -994,6 +994,7 @@ export default function TimelineView({ milestones, setMilestones }) {
             customHalfMs={customHalfMs}
             highlightedIds={highlightedIds}
             onMilestoneClick={handleMilestoneClick}
+            onMilestoneDoubleClick={openEdit}
             panMs={panMs}
             onPanMs={setPanMs}
             viewMode={viewMode}


### PR DESCRIPTION
## Summary

- Fix double-click to edit milestone (was missing entirely — uses `e.detail >= 2` on the existing click handler, no timer needed)
- Pull version number in help modal from `package.json` instead of a hardcoded constant
- Switch GHCR workflow trigger from push-to-main/tag to `release: published`, ready for a future Electron workflow triggered by `v*` tags

## Test plan

- [ ] Double-click a milestone card → edit form opens directly
- [ ] Single-click a milestone → selects/pans as before; second single-click opens detail
- [ ] Open help modal → version matches `package.json`
- [ ] Confirm no Docker image is built on a plain push to `main`

https://claude.ai/code/session_01XNryV5DQyQ2DutaMTSgSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNryV5DQyQ2DutaMTSgSNw)_