### PR TITLE
Implement deferred fixes #5 and #6: test coverage + photo blob storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
+        "fake-indexeddb": "^6.2.5",
         "vite": "^8.0.8",
-        "vite-plugin-pwa": "^0.19.8"
+        "vite-plugin-pwa": "^0.19.8",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -2101,6 +2103,13 @@
         }
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2170,6 +2179,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2210,6 +2237,149 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -2279,6 +2449,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -2526,6 +2706,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -2855,6 +3045,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2927,6 +3124,26 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4444,6 +4661,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -4512,6 +4740,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5123,6 +5358,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5196,6 +5438,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5386,6 +5642,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5401,6 +5674,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5762,6 +6045,106 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -5884,6 +6267,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workbox-background-sync": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "date-fns": "^3.6.0",
@@ -18,7 +20,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
+    "fake-indexeddb": "^6.2.5",
     "vite": "^8.0.8",
-    "vite-plugin-pwa": "^0.19.8"
+    "vite-plugin-pwa": "^0.19.8",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { DEFAULT_CATEGORIES } from '../../utils/colors'
 import { buildDateFromParts } from '../../utils/dates'
+import { dbGetPhoto } from '../../data/db'
 
 const MONTHS = [
   { v: '1',  l: 'Jan' }, { v: '2',  l: 'Feb' }, { v: '3',  l: 'Mar' },
@@ -20,7 +21,13 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
   const [category,   setCategory]   = useState(existing?.category  ?? 'personal')
   const [note,       setNote]       = useState(existing?.note       ?? '')
   const [url,        setUrl]        = useState(existing?.url        ?? '')
-  const [photoUri,      setPhotoUri]      = useState(existing?.photo_uri ?? '')
+
+  // Photo state — File object for new selection; objectUrl for preview
+  const [photoFile,       setPhotoFile]       = useState(null)
+  const [photoObjectUrl,  setPhotoObjectUrl]  = useState(null)  // new photo preview
+  const [existingPhotoUrl, setExistingPhotoUrl] = useState(null) // loaded from IDB for edit
+  const [photoRemoved,    setPhotoRemoved]    = useState(false)
+
   const [mediaFile,     setMediaFile]     = useState(null)   // new File selected this session
   const [mediaRemoved,  setMediaRemoved]  = useState(false)  // user cleared existing media
   const [mediaObjectUrl, setMediaObjectUrl] = useState(null) // transient preview URL
@@ -30,7 +37,24 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
   const photoRef = useRef(null)
   const mediaRef = useRef(null)
 
-  // Revoke preview URL when it changes or the form unmounts
+  // Load existing photo blob from IndexedDB for edit mode
+  React.useEffect(() => {
+    if (!isEdit || !existing?.has_photo) return
+    let objectUrl
+    dbGetPhoto(existing.id).then(result => {
+      if (!result) return
+      objectUrl = URL.createObjectURL(result.blob)
+      setExistingPhotoUrl(objectUrl)
+    })
+    return () => { if (objectUrl) URL.revokeObjectURL(objectUrl) }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Revoke new-photo preview URL on change or unmount
+  React.useEffect(() => {
+    return () => { if (photoObjectUrl) URL.revokeObjectURL(photoObjectUrl) }
+  }, [photoObjectUrl])
+
+  // Revoke media preview URL on change or unmount
   React.useEffect(() => {
     return () => { if (mediaObjectUrl) URL.revokeObjectURL(mediaObjectUrl) }
   }, [mediaObjectUrl])
@@ -50,7 +74,6 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
     if (recurrence && year.length >= 4) {
       const base = Number(year)
       setRecEndYear(y => {
-        // only override if blank or user hasn't manually changed it
         const current = Number(y)
         const def = Math.max(base, new Date().getFullYear()) + 3
         return (!y || current < base) ? String(def) : y
@@ -60,6 +83,26 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
 
   const canSave = title.trim() && year.length >= 4
 
+  // Determine what to show in the photo section
+  const previewUrl    = photoFile ? photoObjectUrl : (!photoRemoved ? existingPhotoUrl : null)
+  const hasExisting   = !photoRemoved && !!existing?.has_photo && !photoFile
+
+  function handlePhotoSelect(file) {
+    if (!file) return
+    if (photoObjectUrl) URL.revokeObjectURL(photoObjectUrl)
+    setPhotoFile(file)
+    setPhotoRemoved(false)
+    setPhotoObjectUrl(URL.createObjectURL(file))
+  }
+
+  function handlePhotoRemove() {
+    if (photoObjectUrl) URL.revokeObjectURL(photoObjectUrl)
+    setPhotoFile(null)
+    setPhotoObjectUrl(null)
+    setPhotoRemoved(true)
+    if (photoRef.current) photoRef.current.value = ''
+  }
+
   async function handleSubmit(e) {
     e.preventDefault()
     if (!canSave || busy) return
@@ -67,6 +110,9 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
     try {
       const date = buildDateFromParts(month, year, precision, day)
       const selectedCat = categories.find(c => c.id === category)
+      const hasPhoto = photoFile
+        ? true
+        : (!photoRemoved && !!existing?.has_photo)
       await onSave({
         title: title.trim(),
         date,
@@ -74,7 +120,9 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         category,
         color: selectedCat?.color,
         note: note.trim(),
-        photo_uri: photoUri,
+        has_photo: hasPhoto,
+        photoFile,
+        photoRemoved,
         mediaFile,
         mediaRemoved,
         url: url.trim(),
@@ -223,11 +271,23 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         {/* Photo */}
         <div className="sheet-field">
           <label className="field-label">photo (optional)</label>
-          {photoUri ? (
+          {previewUrl ? (
             <div className="photo-preview-wrap">
-              <img src={photoUri} className="photo-preview" alt="milestone" />
-              <button type="button" className="photo-remove"
-                onClick={() => { setPhotoUri(''); if (photoRef.current) photoRef.current.value = '' }}>
+              <img src={previewUrl} className="photo-preview" alt="milestone" />
+              <button type="button" className="photo-remove" onClick={handlePhotoRemove}>
+                remove
+              </button>
+            </div>
+          ) : hasExisting ? (
+            // Existing photo not yet loaded from IDB — show placeholder while loading
+            <div className="audio-attached-row">
+              <span className="audio-attached-label">photo attached</span>
+              <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
+                onClick={() => photoRef.current?.click()}>
+                replace
+              </button>
+              <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
+                onClick={handlePhotoRemove}>
                 remove
               </button>
             </div>
@@ -241,13 +301,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
           <input
             ref={photoRef} type="file" accept="image/*"
             style={{ display: 'none' }}
-            onChange={e => {
-              const file = e.target.files[0]
-              if (!file) return
-              const reader = new FileReader()
-              reader.onload = () => setPhotoUri(reader.result)
-              reader.readAsDataURL(file)
-            }}
+            onChange={e => handlePhotoSelect(e.target.files[0])}
           />
         </div>
 

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
-import { dbGetMedia } from '../../data/db'
+import { dbGetMedia, dbGetPhoto } from '../../data/db'
 
 export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday }) {
-  const [audioUrl, setAudioUrl] = useState(null)
-  const [confirm,  setConfirm]  = useState(null) // null | 'single' | 'series'
+  const [audioUrl,  setAudioUrl]  = useState(null)
+  const [photoUrl,  setPhotoUrl]  = useState(null)
+  const [confirm,   setConfirm]   = useState(null) // null | 'single' | 'series'
 
   useEffect(() => {
     if (!m.media_type) return
@@ -16,6 +17,17 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
     })
     return () => { if (objectUrl) URL.revokeObjectURL(objectUrl) }
   }, [m.id, m.media_type])
+
+  useEffect(() => {
+    if (!m.has_photo) return
+    let objectUrl
+    dbGetPhoto(m.id).then(result => {
+      if (!result) return
+      objectUrl = URL.createObjectURL(result.blob)
+      setPhotoUrl(objectUrl)
+    })
+    return () => { if (objectUrl) URL.revokeObjectURL(objectUrl) }
+  }, [m.id, m.has_photo])
 
   function doDelete()       { onDelete(m.id); onClose() }
   function doDeleteSeries() { onDeleteSeries(m.recurrence_id); onClose() }
@@ -29,9 +41,9 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
         </div>
 
         {/* Photo */}
-        {m.photo_uri && (
+        {photoUrl && (
           <div className="detail-photo-wrap">
-            <img src={m.photo_uri} alt={m.title} className="detail-photo" />
+            <img src={photoUrl} alt={m.title} className="detail-photo" />
           </div>
         )}
 
@@ -64,7 +76,6 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
         {m.recurrence === 'annual' && (
           <div className="detail-recurrence">↻ repeats annually</div>
         )}
-
 
         {/* Media (audio / video) */}
         {audioUrl && (

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -11,10 +11,11 @@ import OnThisDayModal    from './OnThisDayModal'
 import IcsImportModal    from '../import/IcsImportModal'
 import MinimapBar        from '../minimap/MinimapBar'
 import TypewriterText    from '../ui/TypewriterText'
-import { ZOOM_LEVELS }   from '../../utils/timeline'
+import { ZOOM_LEVELS, applyRecurFilter } from '../../utils/timeline'
+import { expandAnnualDates } from '../../utils/recurrence'
 import { loadCategories } from '../../utils/colors'
 import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones, uid } from '../../data/milestones'
-import { dbPutMedia } from '../../data/db'
+import { dbPutMedia, dbPutPhoto, dbDeletePhoto, dbGetPhoto, dbPut } from '../../data/db'
 import { parseIcs }      from '../../utils/icsParser'
 import * as audio from '../../utils/audio'
 
@@ -28,23 +29,6 @@ const TEXT_SIZES = {
 }
 
 const ZOOM_ANIM_MS = 380
-
-function applyRecurFilter(ms, mode) {
-  if (mode === 'all') return ms
-  const now    = new Date()
-  const nonRec = ms.filter(m => !m.recurrence_id)
-  const rec    = ms.filter(m =>  m.recurrence_id)
-  if (mode === 'past')   return [...nonRec, ...rec.filter(m => new Date(m.date) <  now)]
-  if (mode === 'future') return [...nonRec, ...rec.filter(m => new Date(m.date) >= now)]
-  // 'next': one instance per series — nearest upcoming, or most recent past if none upcoming
-  const byId = {}
-  for (const m of rec) { (byId[m.recurrence_id] ??= []).push(m) }
-  const picked = Object.values(byId).map(arr => {
-    const up = arr.filter(m => new Date(m.date) >= now).sort((a, b) => new Date(a.date) - new Date(b.date))
-    return up.length ? up[0] : arr.sort((a, b) => new Date(b.date) - new Date(a.date))[0]
-  })
-  return [...nonRec, ...picked]
-}
 
 export default function TimelineView({ milestones, setMilestones }) {
   const [zoom,          setZoom]          = useState('years')
@@ -555,9 +539,10 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   // ── CRUD ─────────────────────────────────────────────────────────────────────
   async function executeSave(data, existing) {
-    // mediaFile / mediaRemoved are transfer-only fields from the form — strip them
-    // before passing to the data layer, and handle blob persistence here.
-    const { mediaFile, mediaRemoved, ...milestoneData } = data
+    // photoFile / photoRemoved / mediaFile / mediaRemoved are transfer-only fields
+    // from the form — strip them before passing to the data layer and handle blob
+    // persistence here.
+    const { mediaFile, mediaRemoved, photoFile, photoRemoved, ...milestoneData } = data
     const newMediaType = mediaFile
       ? (mediaFile.type.startsWith('video/') ? 'video' : 'audio')
       : null
@@ -567,36 +552,40 @@ export default function TimelineView({ milestones, setMilestones }) {
         const mediaType = mediaFile    ? newMediaType
                         : mediaRemoved ? null
                         : (existing.media_type ?? null)
-        const updated = await updateMilestone(existing.id, { ...milestoneData, media_type: mediaType }, existing)
-        if (mediaFile) await dbPutMedia(updated.id, mediaFile, mediaFile.type)
+        const hasPhoto  = photoFile    ? true
+                        : photoRemoved ? false
+                        : (existing.has_photo ?? false)
+        const updated = await updateMilestone(existing.id, { ...milestoneData, media_type: mediaType, has_photo: hasPhoto }, existing)
+        if (mediaFile)    await dbPutMedia(updated.id, mediaFile, mediaFile.type)
+        if (photoFile)    await dbPutPhoto(updated.id, photoFile, photoFile.type)
+        if (photoRemoved) await dbDeletePhoto(updated.id)
         const newMs = milestones.map(m => m.id === existing.id ? updated : m)
         pushHistory(newMs)
         setMilestones(newMs)
         audio.playEditSave()
       } else if (milestoneData.recurrence === 'annual') {
         // Generate one instance per year from base year to chosen end year (max +99)
-        const rid       = uid()
-        const baseDate  = new Date(milestoneData.date)
-        const baseYear  = baseDate.getFullYear()
-        const endYear   = Math.max(baseYear, Math.min(
-          milestoneData.recurrenceEndYear ?? Math.max(baseYear, new Date().getFullYear()) + 3,
-          baseYear + 99
-        ))
-        const created   = []
-        for (let y = baseYear; y <= endYear; y++) {
-          const d = new Date(baseDate)
-          d.setFullYear(y)
+        const rid      = uid()
+        const baseDate = new Date(milestoneData.date)
+        const baseYear = baseDate.getFullYear()
+        const reqEnd   = milestoneData.recurrenceEndYear ?? Math.max(baseYear, new Date().getFullYear()) + 3
+        const dates    = expandAnnualDates(baseDate, reqEnd)
+        const created  = []
+        for (const d of dates) {
+          const isBase = d.getFullYear() === baseYear
           const m = await addMilestone({
             ...milestoneData,
             date:          d,
             recurrence_id: rid,
             // only the base-year instance keeps the original note / photo / media / url
-            note:       y === baseYear ? milestoneData.note      : '',
-            photo_uri:  y === baseYear ? milestoneData.photo_uri : '',
-            media_type: y === baseYear ? newMediaType            : null,
-            url:        y === baseYear ? milestoneData.url       : '',
+            note:       isBase ? milestoneData.note      : '',
+            photo_uri:  '',
+            has_photo:  isBase ? milestoneData.has_photo : false,
+            media_type: isBase ? newMediaType            : null,
+            url:        isBase ? milestoneData.url       : '',
           })
-          if (y === baseYear && mediaFile) await dbPutMedia(m.id, mediaFile, mediaFile.type)
+          if (isBase && mediaFile) await dbPutMedia(m.id, mediaFile, mediaFile.type)
+          if (isBase && milestoneData.photoFile) await dbPutPhoto(m.id, milestoneData.photoFile, milestoneData.photoFile.type)
           created.push(m)
         }
         const newMs = [...milestones, ...created]
@@ -605,8 +594,9 @@ export default function TimelineView({ milestones, setMilestones }) {
         setNewlyAddedId(created[0].id)
         audio.playChime()
       } else {
-        const m = await addMilestone({ ...milestoneData, media_type: newMediaType })
+        const m = await addMilestone({ ...milestoneData, media_type: newMediaType, has_photo: !!photoFile })
         if (mediaFile) await dbPutMedia(m.id, mediaFile, mediaFile.type)
+        if (photoFile) await dbPutPhoto(m.id, photoFile, photoFile.type)
         const newMs = [...milestones, m]
         pushHistory(newMs)
         setMilestones(newMs)
@@ -625,22 +615,23 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   async function handleSave(data, existing) {
     audio.init()   // ensure AudioContext is running (form submit = user gesture)
-    const { mediaFile } = data
+    const { mediaFile, photoFile } = data
+    const bigFile = mediaFile || (photoFile && photoFile.size > 50 * 1024 * 1024 ? photoFile : null)
 
-    if (mediaFile) {
+    if (bigFile) {
       let remaining = null
       if (navigator.storage?.estimate) {
         try {
           const { quota, usage } = await navigator.storage.estimate()
           remaining = quota - usage
-          if (remaining < mediaFile.size) {
+          if (remaining < bigFile.size) {
             showToast('Not enough storage space for this file. Free up space and try again.')
             return
           }
         } catch { /* estimate unavailable, proceed */ }
       }
-      if (mediaFile.size > 50 * 1024 * 1024) {
-        setMediaConfirm({ data, existing, fileSize: mediaFile.size, remaining })
+      if (bigFile.size > 50 * 1024 * 1024) {
+        setMediaConfirm({ data, existing, fileSize: bigFile.size, remaining })
         return
       }
     }
@@ -778,8 +769,22 @@ export default function TimelineView({ milestones, setMilestones }) {
   }
 
   // ── Backup ───────────────────────────────────────────────────────────────────
-  function handleSaveBackup() {
-    const json = JSON.stringify(milestones, null, 2)
+  async function handleSaveBackup() {
+    // Collect photos as base64 data-URIs keyed by milestone id
+    const photos = {}
+    for (const m of milestones) {
+      if (!m.has_photo) continue
+      try {
+        const result = await dbGetPhoto(m.id)
+        if (!result) continue
+        const buf = await result.blob.arrayBuffer()
+        const b64 = btoa([...new Uint8Array(buf)].map(b => String.fromCharCode(b)).join(''))
+        photos[m.id] = `data:${result.mimeType};base64,${b64}`
+      } catch { /* skip unreadable photo */ }
+    }
+
+    const payload = { milestones, photos }
+    const json = JSON.stringify(payload, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url  = URL.createObjectURL(blob)
     const a    = document.createElement('a')
@@ -833,11 +838,39 @@ export default function TimelineView({ milestones, setMilestones }) {
     const file = e.target.files[0]
     if (!file) return
     try {
-      const text     = await file.text()
-      const data     = JSON.parse(text)
-      const restored = await restoreMilestones(data)
-      setMilestones(restored)
-      historyRef.current = { stack: [restored], idx: 0 }
+      const text   = await file.text()
+      const parsed = JSON.parse(text)
+
+      // Support both legacy format (array) and new format ({ milestones, photos })
+      const items  = Array.isArray(parsed) ? parsed : (parsed.milestones ?? parsed)
+      const photos = (!Array.isArray(parsed) && parsed.photos) ? parsed.photos : {}
+
+      const restored = await restoreMilestones(items)
+
+      // Re-import photo blobs into the media store
+      for (const m of restored) {
+        const dataUri = photos[m.id]
+        if (!dataUri) continue
+        try {
+          const [header, b64] = dataUri.split(',')
+          const mimeType = header.match(/:(.*?);/)[1]
+          const raw      = atob(b64)
+          const arr      = new Uint8Array(raw.length)
+          for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i)
+          const blob = new Blob([arr], { type: mimeType })
+          await dbPutPhoto(m.id, blob, mimeType)
+          // Mark the milestone as having a photo now that the blob is stored
+          m.has_photo = true
+        } catch { /* malformed data-URI — skip */ }
+      }
+
+      // Persist any has_photo=true updates
+      for (const m of restored) {
+        if (m.has_photo) await dbPut(m)
+      }
+
+      setMilestones([...restored])
+      historyRef.current = { stack: [[...restored]], idx: 0 }
       setCanUndo(false)
       setCanRedo(false)
     } catch (err) {

--- a/src/data/db.js
+++ b/src/data/db.js
@@ -1,5 +1,5 @@
 const DB_NAME    = 'lifeglance'
-const DB_VERSION = 2          // v2: adds media object store
+const DB_VERSION = 3          // v3: photos migrated from data-URI to media blob store
 const STORE      = 'milestones'
 const MEDIA      = 'media'
 
@@ -32,6 +32,37 @@ export function initDB() {
             const rec = { ...c.value }
             delete rec.audio_uri
             c.update(rec)
+          }
+          c.continue()
+        }
+      }
+
+      // v3 — migrate photo_uri base64 strings into the media blob store
+      if (e.oldVersion < 3) {
+        const mediaStore = e.target.transaction.objectStore(MEDIA)
+        const s = e.target.transaction.objectStore(STORE)
+        s.openCursor().onsuccess = ev => {
+          const c = ev.target.result
+          if (!c) return
+          const rec = c.value
+          if (rec.photo_uri && rec.photo_uri.startsWith('data:')) {
+            try {
+              const [header, b64] = rec.photo_uri.split(',')
+              const mimeType = header.match(/:(.*?);/)[1]
+              const raw      = atob(b64)
+              const arr      = new Uint8Array(raw.length)
+              for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i)
+              const blob = new Blob([arr], { type: mimeType })
+              mediaStore.put({ id: `${rec.id}-photo`, blob, mimeType })
+            } catch { /* malformed data-URI — skip */ }
+            const updated = { ...rec }
+            delete updated.photo_uri
+            updated.has_photo = true
+            c.update(updated)
+          } else if ('photo_uri' in rec) {
+            const updated = { ...rec }
+            delete updated.photo_uri
+            c.update(updated)
           }
           c.continue()
         }
@@ -85,7 +116,7 @@ export function dbDelete(id) {
   })
 }
 
-// ── Media (audio blobs) ──────────────────────────────────────────────────────
+// ── Media (audio / video blobs) ──────────────────────────────────────────────
 
 export function dbPutMedia(id, blob, mimeType) {
   return new Promise((resolve, reject) => {
@@ -111,6 +142,35 @@ export function dbGetMedia(id) {
 export function dbClearAllMedia() {
   return new Promise((resolve, reject) => {
     const req = mediaTx('readwrite').clear()
+    req.onsuccess = () => resolve()
+    req.onerror   = () => reject(req.error)
+  })
+}
+
+// ── Photos (keyed as `${id}-photo` in the media store) ──────────────────────
+
+export function dbPutPhoto(id, blob, mimeType) {
+  return new Promise((resolve, reject) => {
+    const req = mediaTx('readwrite').put({ id: `${id}-photo`, blob, mimeType })
+    req.onsuccess = () => resolve()
+    req.onerror   = () => reject(req.error)
+  })
+}
+
+export function dbGetPhoto(id) {
+  return new Promise((resolve, reject) => {
+    const req = mediaTx().get(`${id}-photo`)
+    req.onsuccess = () => {
+      const rec = req.result
+      resolve(rec ? { blob: rec.blob, mimeType: rec.mimeType } : null)
+    }
+    req.onerror   = () => reject(req.error)
+  })
+}
+
+export function dbDeletePhoto(id) {
+  return new Promise((resolve, reject) => {
+    const req = mediaTx('readwrite').delete(`${id}-photo`)
     req.onsuccess = () => resolve()
     req.onerror   = () => reject(req.error)
   })

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -19,7 +19,7 @@ export function buildMilestone({
   category       = 'personal',
   color,
   note           = '',
-  photo_uri      = '',
+  has_photo      = false,
   media_type     = null,   // null | 'audio' | 'video'
   url            = '',
   recurrence     = null,   // null | 'annual'
@@ -38,7 +38,7 @@ export function buildMilestone({
     category,
     color:          color || categoryColor(category),
     note,
-    photo_uri,
+    has_photo,
     media_type,
     url,
     recurrence,
@@ -66,9 +66,12 @@ export async function updateMilestone(id, updates, existing) {
   const today   = new Date()
   const now     = new Date().toISOString()
 
+  // Strip photo_uri from any legacy data still in flight
+  const { photo_uri: _discard, ...safeUpdates } = updates
+
   const m = {
     ...existing,
-    ...updates,
+    ...safeUpdates,
     id,
     date:      dateObj.toISOString(),
     direction: dateObj < today ? 'past' : 'future',
@@ -85,12 +88,16 @@ export async function deleteMilestone(id) {
 
 // Clear all milestones and replace with the supplied array (preserves original IDs).
 // Also wipes all media blobs — they are never included in JSON backups, so any
-// media_type flags on restored items are reset to null to stay consistent.
+// media_type / has_photo flags on restored items are reset to stay consistent.
 export async function restoreMilestones(items) {
   const existing = await dbGetAll()
   for (const m of existing) await dbDelete(m.id)
   await dbClearAllMedia()
-  const clean = items.map(m => ({ ...m, media_type: null }))
+  const clean = items.map(({ photo_uri: _discard, ...m }) => ({
+    ...m,
+    media_type: null,
+    has_photo:  false,
+  }))
   for (const m of clean) await dbPut(m)
   return clean
 }

--- a/src/data/milestones.test.js
+++ b/src/data/milestones.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+
+// Reset the module registry and IndexedDB before each test so each test
+// gets a fresh in-memory database with no leftover state.
+beforeEach(() => {
+  global.indexedDB = new IDBFactory()
+  vi.resetModules()
+})
+
+async function setup() {
+  const { initDB }                           = await import('./db')
+  const { addMilestone, updateMilestone, deleteMilestone, loadMilestones, restoreMilestones } =
+    await import('./milestones')
+  await initDB()
+  return { addMilestone, updateMilestone, deleteMilestone, loadMilestones, restoreMilestones }
+}
+
+describe('addMilestone', () => {
+  it('stores a milestone and returns it with an id', async () => {
+    const { addMilestone, loadMilestones } = await setup()
+    const m = await addMilestone({ title: 'First Home', date: new Date('2015-06-01') })
+    expect(m.id).toBeTruthy()
+    expect(m.title).toBe('First Home')
+    const all = await loadMilestones()
+    expect(all).toHaveLength(1)
+    expect(all[0].id).toBe(m.id)
+  })
+
+  it('sets direction to past for past dates', async () => {
+    const { addMilestone } = await setup()
+    const m = await addMilestone({ title: 'Past', date: new Date('2000-01-01') })
+    expect(m.direction).toBe('past')
+  })
+
+  it('sets direction to future for future dates', async () => {
+    const { addMilestone } = await setup()
+    const m = await addMilestone({ title: 'Future', date: new Date('2099-01-01') })
+    expect(m.direction).toBe('future')
+  })
+
+  it('stores multiple milestones independently', async () => {
+    const { addMilestone, loadMilestones } = await setup()
+    await addMilestone({ title: 'A', date: new Date('2010-01-01') })
+    await addMilestone({ title: 'B', date: new Date('2011-01-01') })
+    await addMilestone({ title: 'C', date: new Date('2012-01-01') })
+    const all = await loadMilestones()
+    expect(all).toHaveLength(3)
+  })
+
+  it('does not include photo_uri in stored record', async () => {
+    const { addMilestone, loadMilestones } = await setup()
+    await addMilestone({ title: 'Photo test', date: new Date('2020-01-01'), has_photo: true })
+    const all = await loadMilestones()
+    expect('photo_uri' in all[0]).toBe(false)
+  })
+})
+
+describe('updateMilestone', () => {
+  it('updates an existing milestone', async () => {
+    const { addMilestone, updateMilestone, loadMilestones } = await setup()
+    const m = await addMilestone({ title: 'Original', date: new Date('2015-01-01') })
+    await updateMilestone(m.id, { title: 'Updated', date: new Date('2015-01-01') }, m)
+    const all = await loadMilestones()
+    expect(all[0].title).toBe('Updated')
+  })
+
+  it('recalculates direction on date change', async () => {
+    const { addMilestone, updateMilestone, loadMilestones } = await setup()
+    const m = await addMilestone({ title: 'Test', date: new Date('2000-01-01') })
+    expect(m.direction).toBe('past')
+    await updateMilestone(m.id, { title: 'Test', date: new Date('2099-01-01') }, m)
+    const all = await loadMilestones()
+    expect(all[0].direction).toBe('future')
+  })
+
+  it('strips any photo_uri field passed in updates', async () => {
+    const { addMilestone, updateMilestone, loadMilestones } = await setup()
+    const m = await addMilestone({ title: 'Test', date: new Date('2020-01-01') })
+    await updateMilestone(m.id, { title: 'Test', date: new Date('2020-01-01'), photo_uri: 'data:...' }, m)
+    const all = await loadMilestones()
+    expect('photo_uri' in all[0]).toBe(false)
+  })
+})
+
+describe('deleteMilestone', () => {
+  it('removes the milestone from the store', async () => {
+    const { addMilestone, deleteMilestone, loadMilestones } = await setup()
+    const m = await addMilestone({ title: 'To Delete', date: new Date('2020-01-01') })
+    await deleteMilestone(m.id)
+    const all = await loadMilestones()
+    expect(all).toHaveLength(0)
+  })
+
+  it('does not affect other milestones', async () => {
+    const { addMilestone, deleteMilestone, loadMilestones } = await setup()
+    const a = await addMilestone({ title: 'Keep', date: new Date('2020-01-01') })
+    const b = await addMilestone({ title: 'Delete', date: new Date('2021-01-01') })
+    await deleteMilestone(b.id)
+    const all = await loadMilestones()
+    expect(all).toHaveLength(1)
+    expect(all[0].id).toBe(a.id)
+  })
+})
+
+describe('restoreMilestones', () => {
+  it('replaces all existing milestones', async () => {
+    const { addMilestone, restoreMilestones, loadMilestones } = await setup()
+    await addMilestone({ title: 'Old', date: new Date('2010-01-01') })
+    const imported = [
+      { id: 'x1', title: 'New A', date: '2020-01-01T00:00:00.000Z', date_precision: 'day',
+        category: 'personal', color: '#888', direction: 'past', note: '', has_photo: false,
+        media_type: null, url: '', recurrence: null, recurrence_id: null,
+        created_at: '2020-01-01T00:00:00.000Z', updated_at: '2020-01-01T00:00:00.000Z' },
+    ]
+    const restored = await restoreMilestones(imported)
+    expect(restored).toHaveLength(1)
+    const all = await loadMilestones()
+    expect(all).toHaveLength(1)
+    expect(all[0].title).toBe('New A')
+  })
+
+  it('strips photo_uri and resets has_photo from restored items', async () => {
+    const { restoreMilestones, loadMilestones } = await setup()
+    const items = [
+      { id: 'y1', title: 'Photo Mile', date: '2020-01-01T00:00:00.000Z', date_precision: 'day',
+        category: 'personal', color: '#888', direction: 'past', note: '',
+        photo_uri: 'data:image/png;base64,abc', has_photo: true, media_type: null,
+        url: '', recurrence: null, recurrence_id: null,
+        created_at: '2020-01-01T00:00:00.000Z', updated_at: '2020-01-01T00:00:00.000Z' },
+    ]
+    await restoreMilestones(items)
+    const all = await loadMilestones()
+    expect('photo_uri' in all[0]).toBe(false)
+    expect(all[0].has_photo).toBe(false)
+  })
+})

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { buildDateFromParts } from './dates'
+
+describe('buildDateFromParts', () => {
+  describe('day precision', () => {
+    it('returns exact date', () => {
+      const d = buildDateFromParts('3', '2020', 'day', '15')
+      expect(d).toEqual(new Date(2020, 2, 15))
+    })
+
+    it('defaults to day 1 when day is empty', () => {
+      const d = buildDateFromParts('6', '2021', 'day', '')
+      expect(d).toEqual(new Date(2021, 5, 1))
+    })
+
+    it('handles Dec 31', () => {
+      const d = buildDateFromParts('12', '2023', 'day', '31')
+      expect(d).toEqual(new Date(2023, 11, 31))
+    })
+
+    it('handles Feb 29 in a leap year', () => {
+      const d = buildDateFromParts('2', '2024', 'day', '29')
+      expect(d).toEqual(new Date(2024, 1, 29))
+    })
+  })
+
+  describe('month precision', () => {
+    it('returns the 15th of the month', () => {
+      const d = buildDateFromParts('8', '2019', 'month', '')
+      expect(d).toEqual(new Date(2019, 7, 15))
+    })
+
+    it('returns midpoint regardless of day argument', () => {
+      const d1 = buildDateFromParts('1', '2020', 'month', '1')
+      const d2 = buildDateFromParts('1', '2020', 'month', '31')
+      expect(d1).toEqual(new Date(2020, 0, 15))
+      expect(d2).toEqual(new Date(2020, 0, 15))
+    })
+  })
+
+  describe('year precision', () => {
+    it('returns Jan 1 of the given year', () => {
+      const d = buildDateFromParts('6', '1999', 'year', '15')
+      expect(d).toEqual(new Date(1999, 0, 1))
+    })
+
+    it('ignores month and day arguments', () => {
+      const d = buildDateFromParts('12', '2050', 'year', '31')
+      expect(d).toEqual(new Date(2050, 0, 1))
+    })
+  })
+})

--- a/src/utils/icsParser.test.js
+++ b/src/utils/icsParser.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { parseIcs } from './icsParser'
+
+function makeEvent({ dtstart, summary = 'Test Event', extra = '' } = {}) {
+  return [
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    `DTSTART${dtstart.includes('T') ? '' : ';VALUE=DATE'}:${dtstart}`,
+    `SUMMARY:${summary}`,
+    extra,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean).join('\r\n')
+}
+
+describe('parseIcs', () => {
+  it('returns empty candidates and zero timedCount for empty input', () => {
+    const { candidates, timedCount } = parseIcs('')
+    expect(candidates).toEqual([])
+    expect(timedCount).toBe(0)
+  })
+
+  it('returns empty candidates for malformed non-ICS text', () => {
+    const { candidates, timedCount } = parseIcs('not an ics file\nrandom text')
+    expect(candidates).toEqual([])
+    expect(timedCount).toBe(0)
+  })
+
+  it('parses a single all-day event', () => {
+    const ics = makeEvent({ dtstart: '20200315', summary: 'Moved to Portland' })
+    const { candidates, timedCount } = parseIcs(ics)
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].title).toBe('Moved to Portland')
+    expect(candidates[0].date).toEqual(new Date(2020, 2, 15))
+    expect(candidates[0].selected).toBe(true)
+    expect(timedCount).toBe(0)
+  })
+
+  it('skips timed events and increments timedCount', () => {
+    const ics = makeEvent({ dtstart: '20200315T090000Z', summary: 'Morning Meeting' })
+    const { candidates, timedCount } = parseIcs(ics)
+    expect(candidates).toHaveLength(0)
+    expect(timedCount).toBe(1)
+  })
+
+  it('parses multiple events and sorts by date', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART;VALUE=DATE:20200601',
+      'SUMMARY:June Event',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART;VALUE=DATE:20190101',
+      'SUMMARY:Jan Event',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n')
+    const { candidates } = parseIcs(ics)
+    expect(candidates).toHaveLength(2)
+    expect(candidates[0].title).toBe('Jan Event')
+    expect(candidates[1].title).toBe('June Event')
+  })
+
+  it('counts timed events separately from all-day events', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART;VALUE=DATE:20200601',
+      'SUMMARY:All Day',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20200601T100000Z',
+      'SUMMARY:Timed',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20200601T120000Z',
+      'SUMMARY:Also Timed',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n')
+    const { candidates, timedCount } = parseIcs(ics)
+    expect(candidates).toHaveLength(1)
+    expect(timedCount).toBe(2)
+  })
+
+  it('detects yearly recurrence via RRULE', () => {
+    const ics = makeEvent({ dtstart: '20200101', extra: 'RRULE:FREQ=YEARLY' })
+    const { candidates } = parseIcs(ics)
+    expect(candidates[0].isRecurring).toBe(true)
+  })
+
+  it('marks non-recurring events as isRecurring false', () => {
+    const ics = makeEvent({ dtstart: '20200101' })
+    const { candidates } = parseIcs(ics)
+    expect(candidates[0].isRecurring).toBe(false)
+  })
+
+  it('unescapes ICS special characters in summary', () => {
+    const ics = makeEvent({ dtstart: '20200101', summary: 'Rock\\, Paper\\, Scissors' })
+    const { candidates } = parseIcs(ics)
+    expect(candidates[0].title).toBe('Rock, Paper, Scissors')
+  })
+
+  it('handles line-folded content (CRLF + whitespace continuation)', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART;VALUE=DATE:20200101',
+      'SUMMARY:Long Sum',
+      ' mary Here',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n')
+    const { candidates } = parseIcs(ics)
+    expect(candidates[0].title).toBe('Long Summary Here')
+  })
+
+  it('guesses category from summary keywords', () => {
+    const cases = [
+      { summary: 'Family reunion',   expected: 'family' },
+      { summary: 'Vacation trip',    expected: 'travel' },
+      { summary: 'New job interview', expected: 'career' },
+      { summary: 'Birthday party',   expected: 'personal' },
+    ]
+    for (const { summary, expected } of cases) {
+      const ics = makeEvent({ dtstart: '20200101', summary })
+      const { candidates } = parseIcs(ics)
+      expect(candidates[0].category).toBe(expected)
+    }
+  })
+
+  it('uses (untitled) as fallback for missing summary', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART;VALUE=DATE:20200101',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n')
+    const { candidates } = parseIcs(ics)
+    expect(candidates[0].title).toBe('(untitled)')
+  })
+})

--- a/src/utils/recurrence.js
+++ b/src/utils/recurrence.js
@@ -1,0 +1,14 @@
+// Expand an annual recurrence into per-year Date instances.
+// Returns an array of Date objects from baseDate's year to endYear (clamped to base+99).
+export function expandAnnualDates(baseDate, requestedEndYear) {
+  const base    = baseDate instanceof Date ? baseDate : new Date(baseDate)
+  const baseYear = base.getFullYear()
+  const endYear  = Math.max(baseYear, Math.min(requestedEndYear, baseYear + 99))
+  const dates    = []
+  for (let y = baseYear; y <= endYear; y++) {
+    const d = new Date(base)
+    d.setFullYear(y)
+    dates.push(d)
+  }
+  return dates
+}

--- a/src/utils/recurrence.test.js
+++ b/src/utils/recurrence.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { expandAnnualDates } from './recurrence'
+
+describe('expandAnnualDates', () => {
+  const base = new Date(2020, 2, 15) // 15 March 2020
+
+  it('generates one date per year from base to end year', () => {
+    const dates = expandAnnualDates(base, 2023)
+    expect(dates).toHaveLength(4)
+    expect(dates.map(d => d.getFullYear())).toEqual([2020, 2021, 2022, 2023])
+  })
+
+  it('preserves month and day across all instances', () => {
+    const dates = expandAnnualDates(base, 2022)
+    for (const d of dates) {
+      expect(d.getMonth()).toBe(2)   // March
+      expect(d.getDate()).toBe(15)
+    }
+  })
+
+  it('returns a single date when base year equals end year', () => {
+    const dates = expandAnnualDates(base, 2020)
+    expect(dates).toHaveLength(1)
+    expect(dates[0].getFullYear()).toBe(2020)
+  })
+
+  it('clamps end year to base + 99', () => {
+    const dates = expandAnnualDates(base, 2200) // 180 years requested
+    expect(dates).toHaveLength(100)             // only base+99 = 100 instances
+    expect(dates[dates.length - 1].getFullYear()).toBe(2119)
+  })
+
+  it('clamps end year when requested end < base year', () => {
+    const dates = expandAnnualDates(base, 2015) // end before base
+    expect(dates).toHaveLength(1)               // still at least the base year
+    expect(dates[0].getFullYear()).toBe(2020)
+  })
+
+  it('accepts ISO string as baseDate', () => {
+    const dates = expandAnnualDates('2020-03-15', 2022)
+    expect(dates).toHaveLength(3)
+    expect(dates[0].getFullYear()).toBe(2020)
+  })
+
+  it('produces correct instance count', () => {
+    for (const n of [1, 5, 10, 50, 99, 100]) {
+      const endYear = 2020 + n - 1
+      const dates   = expandAnnualDates(base, endYear)
+      expect(dates).toHaveLength(Math.min(n, 100))
+    }
+  })
+})

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -116,6 +116,28 @@ function seededHash(str) {
   return (h >>> 0) / 4294967295
 }
 
+// Filter recurring milestones according to the selected recurrence display mode.
+//   all    — show everything
+//   past   — non-recurring + recurring instances that are in the past
+//   future — non-recurring + recurring instances that are in the future
+//   next   — non-recurring + one instance per series (nearest upcoming, or most recent past)
+export function applyRecurFilter(ms, mode) {
+  if (mode === 'all') return ms
+  const now    = new Date()
+  const nonRec = ms.filter(m => !m.recurrence_id)
+  const rec    = ms.filter(m =>  m.recurrence_id)
+  if (mode === 'past')   return [...nonRec, ...rec.filter(m => new Date(m.date) <  now)]
+  if (mode === 'future') return [...nonRec, ...rec.filter(m => new Date(m.date) >= now)]
+  // 'next': one instance per series
+  const byId = {}
+  for (const m of rec) { (byId[m.recurrence_id] ??= []).push(m) }
+  const picked = Object.values(byId).map(arr => {
+    const up = arr.filter(m => new Date(m.date) >= now).sort((a, b) => new Date(a.date) - new Date(b.date))
+    return up.length ? up[0] : arr.sort((a, b) => new Date(b.date) - new Date(a.date))[0]
+  })
+  return [...nonRec, ...picked]
+}
+
 // Assign above/below lanes to sorted milestones.
 //   maxLane      – max lane index that fits in the container (caller computes)
 //   cardTimeSpan – ms equivalent of one card width at current zoom (for overlap detection)

--- a/src/utils/timeline.test.js
+++ b/src/utils/timeline.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { applyRecurFilter } from './timeline'
+
+// Helper to build a minimal milestone-like object
+function ms(id, dateStr, recurrence_id = null) {
+  return { id, date: dateStr, recurrence_id }
+}
+
+// Dates relative to test run: use far-past and far-future to avoid flakiness
+const PAST1   = '2000-01-01'
+const PAST2   = '2001-06-15'
+const FUTURE1 = '2099-01-01'
+const FUTURE2 = '2099-06-15'
+const RID_A   = 'rid-a'
+const RID_B   = 'rid-b'
+
+// Fixture set
+//   non-recurring: n1 (past), n2 (future)
+//   series A:      a1 (past), a2 (future)
+//   series B:      b1 (past), b2 (past) — both past, no upcoming
+const n1 = ms('n1', PAST1)
+const n2 = ms('n2', FUTURE1)
+const a1 = ms('a1', PAST2,   RID_A)
+const a2 = ms('a2', FUTURE2, RID_A)
+const b1 = ms('b1', PAST1,   RID_B)
+const b2 = ms('b2', PAST2,   RID_B)
+
+const ALL = [n1, n2, a1, a2, b1, b2]
+
+describe('applyRecurFilter', () => {
+  it('all — returns the full set unchanged', () => {
+    const result = applyRecurFilter(ALL, 'all')
+    expect(result).toHaveLength(ALL.length)
+    expect(result).toEqual(expect.arrayContaining(ALL))
+  })
+
+  it('past — keeps non-recurring and only past recurring instances', () => {
+    const result = applyRecurFilter(ALL, 'past')
+    expect(result).toContain(n1)
+    expect(result).toContain(n2)   // non-recurring are always included
+    expect(result).toContain(a1)   // past recurring ✓
+    expect(result).not.toContain(a2) // future recurring ✗
+    expect(result).toContain(b1)
+    expect(result).toContain(b2)
+  })
+
+  it('future — keeps non-recurring and only future recurring instances', () => {
+    const result = applyRecurFilter(ALL, 'future')
+    expect(result).toContain(n1)
+    expect(result).toContain(n2)
+    expect(result).not.toContain(a1) // past recurring ✗
+    expect(result).toContain(a2)     // future recurring ✓
+    expect(result).not.toContain(b1) // both b's are past
+    expect(result).not.toContain(b2)
+  })
+
+  it('next — picks nearest upcoming per series, falls back to most recent past', () => {
+    const result = applyRecurFilter(ALL, 'next')
+    expect(result).toContain(n1)
+    expect(result).toContain(n2)
+    // Series A has a future instance → picks a2 (nearest upcoming)
+    expect(result).toContain(a2)
+    expect(result).not.toContain(a1)
+    // Series B has no future instances → picks b2 (most recent past)
+    expect(result).toContain(b2)
+    expect(result).not.toContain(b1)
+  })
+
+  it('next — with only future instances picks the nearest one', () => {
+    const rid = 'rid-future'
+    const near = ms('near', FUTURE1, rid)
+    const far  = ms('far',  FUTURE2, rid)
+    const result = applyRecurFilter([near, far], 'next')
+    expect(result).toContain(near)
+    expect(result).not.toContain(far)
+  })
+
+  it('handles empty input', () => {
+    expect(applyRecurFilter([], 'all')).toEqual([])
+    expect(applyRecurFilter([], 'past')).toEqual([])
+    expect(applyRecurFilter([], 'future')).toEqual([])
+    expect(applyRecurFilter([], 'next')).toEqual([])
+  })
+
+  it('all — returns milestones with no recurrence_id unchanged', () => {
+    const plain = [n1, n2]
+    const result = applyRecurFilter(plain, 'all')
+    expect(result).toEqual(plain)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,4 +27,7 @@ export default defineConfig({
     }),
   ],
   base: '/',
+  test: {
+    environment: 'node',
+  },
 })


### PR DESCRIPTION
Fix #5 — Test coverage:
- Add Vitest with `npm test` / `npm run test:watch` scripts
- Extract `applyRecurFilter` from TimelineView into src/utils/timeline.js (exported)
- Extract recurrence year-expansion loop into src/utils/recurrence.js (expandAnnualDates)
- 46 tests across 5 modules: icsParser, dates, timeline, recurrence, milestones

Fix #6 — Photo storage: data-URI → IndexedDB blob:
- Bump DB to v3; migration cursor converts existing photo_uri data-URIs to blobs stored in the media store as `${id}-photo`, deletes photo_uri from milestone records
- Add dbPutPhoto / dbGetPhoto / dbDeletePhoto helpers in db.js
- Replace photo_uri field with has_photo boolean on milestone objects
- AddMilestoneSheet: FileReader/readAsDataURL replaced with photoFile File state; existing photos loaded lazily from IndexedDB on mount
- MilestoneDetail: photo loaded from IndexedDB via dbGetPhoto + URL.createObjectURL
- Backup format updated to { milestones, photos } with base64 photos keyed by id; restore handles both legacy array format and new format

https://claude.ai/code/session_01Htb4QzdVBMtZTqVMqAhpbv