### PR TITLE
feat(chapters): Phase 3 — Chapter create/edit/delete UI

### DIFF
--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -1,0 +1,315 @@
+import React, { useState, useMemo, useEffect } from 'react'
+
+const CHAPTER_COLORS = [
+  { hex: '#C8A96E', label: 'amber'  },
+  { hex: '#3D3580', label: 'indigo' },
+  { hex: '#E8748A', label: 'coral'  },
+  { hex: '#9370DB', label: 'purple' },
+]
+
+function fmtDate(m) {
+  const d = new Date(m.date)
+  if (m.date_precision === 'year')
+    return String(d.getUTCFullYear())
+  if (m.date_precision === 'month')
+    return d.toLocaleString('default', { month: 'short', year: 'numeric', timeZone: 'UTC' })
+  return d.toLocaleString('default', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })
+}
+
+export default function ChapterSheet({ onSave, onClose, onDelete, existing, milestones = [] }) {
+  const isEdit = !!existing
+
+  const [title,          setTitle]          = useState(existing?.title       ?? '')
+  const [start,          setStart]          = useState(existing?.start ? existing.start.slice(0, 10) : '')
+  const [end,            setEnd]            = useState(existing?.end   ? existing.end.slice(0, 10)   : '')
+  const [color,          setColor]          = useState(existing?.color ?? CHAPTER_COLORS[0].hex)
+  const [desc,           setDesc]           = useState(existing?.description ?? '')
+  const [defVis,         setDefVis]         = useState(existing?.defaultMemberVisibility ?? 'shown')
+  const [checkedIds,     setCheckedIds]     = useState(() => new Set(existing?.milestoneIds ?? []))
+  const [confirmDelete,  setConfirmDelete]  = useState(false)
+  const [dateError,      setDateError]      = useState(null)
+  const [busy,           setBusy]           = useState(false)
+
+  // Milestones whose dates fall within [start, end]
+  const inRange = useMemo(() => {
+    if (!start || !end) return []
+    const s = new Date(start)
+    const e = new Date(end)
+    if (s > e) return []
+    return milestones
+      .filter(m => { const d = new Date(m.date); return d >= s && d <= e })
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+  }, [start, end, milestones])
+
+  const inRangeIds = useMemo(() => new Set(inRange.map(m => m.id)), [inRange])
+
+  // Create mode: auto-check all in-range milestones when the range changes.
+  // Edit mode: existing memberships are controlled only by the user.
+  useEffect(() => {
+    if (isEdit) return
+    setCheckedIds(new Set(inRange.map(m => m.id)))
+  }, [inRange, isEdit])
+
+  // Display list:
+  //   create — milestones in range (auto-checked by default)
+  //   edit   — union of in-range milestones (appear unchecked if not members) and
+  //            currently-checked members (preserved even if outside the new range)
+  const displayMilestones = useMemo(() => {
+    if (!isEdit) return inRange
+    return milestones
+      .filter(m => inRangeIds.has(m.id) || checkedIds.has(m.id))
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+  }, [isEdit, inRange, inRangeIds, checkedIds, milestones])
+
+  function toggleId(id) {
+    setCheckedIds(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  function clearDateError() { setDateError(null) }
+
+  function validateDates() {
+    if (!start || !end) { setDateError('both dates are required'); return false }
+    if (new Date(start) >= new Date(end)) {
+      setDateError('end date must be after start date')
+      return false
+    }
+    return true
+  }
+
+  const canSave = title.trim() && start && end && !busy
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!validateDates() || !canSave) return
+    setBusy(true)
+    try {
+      await onSave(
+        {
+          title:                  title.trim(),
+          start,
+          end,
+          color,
+          description:            desc.trim(),
+          defaultMemberVisibility: defVis,
+          milestoneIds:           [...checkedIds],
+        },
+        existing,
+      )
+      onClose()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleDelete() {
+    setBusy(true)
+    try {
+      await onDelete(existing.id)
+      onClose()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <form className="sheet" onSubmit={handleSubmit}>
+
+        {/* Header */}
+        <div className="sheet-header">
+          <span className="sheet-title">{isEdit ? 'edit chapter' : 'add chapter'}</span>
+          <button type="button" className="sheet-close" onClick={onClose}>✕</button>
+        </div>
+
+        {/* Title */}
+        <div className="sheet-field">
+          <label className="field-label">chapter name</label>
+          <input
+            className="input"
+            type="text"
+            placeholder="e.g. College years"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            autoFocus
+            autoComplete="off"
+            maxLength={80}
+          />
+        </div>
+
+        {/* Date range */}
+        <div className="sheet-field">
+          <label className="field-label">date range</label>
+          <div className="chapter-date-row">
+            <div className="chapter-date-field">
+              <label className="field-label">from</label>
+              <input
+                className="input input-sm"
+                type="date"
+                value={start}
+                onChange={e => { setStart(e.target.value); clearDateError() }}
+              />
+            </div>
+            <span className="chapter-date-arrow">→</span>
+            <div className="chapter-date-field">
+              <label className="field-label">to</label>
+              <input
+                className="input input-sm"
+                type="date"
+                value={end}
+                onChange={e => { setEnd(e.target.value); clearDateError() }}
+              />
+            </div>
+          </div>
+          {dateError && <div className="chapter-date-error">{dateError}</div>}
+        </div>
+
+        {/* Color */}
+        <div className="sheet-field">
+          <label className="field-label">color</label>
+          <div className="chapter-color-row">
+            {CHAPTER_COLORS.map(c => (
+              <button
+                key={c.hex}
+                type="button"
+                className={`chapter-color-swatch ${color === c.hex ? 'selected' : ''}`}
+                style={{ background: c.hex }}
+                onClick={() => setColor(c.hex)}
+                title={c.label}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className="sheet-field">
+          <label className="field-label">description (optional)</label>
+          <textarea
+            className="input"
+            rows={2}
+            placeholder="A short description of this chapter…"
+            value={desc}
+            onChange={e => setDesc(e.target.value)}
+            maxLength={300}
+            style={{ resize: 'vertical', lineHeight: 1.5 }}
+          />
+        </div>
+
+        {/* Default member visibility */}
+        <div className="sheet-field">
+          <label className="settings-toggle-row">
+            <span className="field-label" style={{ marginBottom: 0 }}>
+              hide members from main timeline by default
+            </span>
+            <input
+              type="checkbox"
+              className="settings-toggle"
+              checked={defVis === 'hidden'}
+              onChange={e => setDefVis(e.target.checked ? 'hidden' : 'shown')}
+            />
+          </label>
+        </div>
+
+        {/* Member milestones */}
+        <div className="sheet-field">
+          <label className="field-label">
+            milestones in this chapter
+            {displayMilestones.length > 0 && (
+              <span className="chapter-member-count"> — {[...checkedIds].filter(id => displayMilestones.some(m => m.id === id)).length} selected</span>
+            )}
+          </label>
+          {!start || !end ? (
+            <div className="chapter-members-empty">set a date range above to see milestones</div>
+          ) : displayMilestones.length === 0 ? (
+            <div className="chapter-members-empty">no milestones in this date range</div>
+          ) : (
+            <div className="chapter-members-list">
+              {displayMilestones.map(m => (
+                <label key={m.id} className="chapter-member-row">
+                  <input
+                    type="checkbox"
+                    className="chapter-member-check"
+                    checked={checkedIds.has(m.id)}
+                    onChange={() => toggleId(m.id)}
+                  />
+                  <span
+                    className="chapter-member-dot"
+                    style={{ background: m.color ?? 'var(--text-muted)' }}
+                  />
+                  <span className={`chapter-member-title${isEdit && !inRangeIds.has(m.id) ? ' chapter-member-retained' : ''}`}>
+                    {m.title}
+                  </span>
+                  <span className="chapter-member-date">{fmtDate(m)}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Delete — edit mode only */}
+        {isEdit && (
+          confirmDelete ? (
+            <div className="detail-confirm">
+              <div className="detail-confirm-msg">
+                delete <strong style={{ color: 'var(--text)' }}>{existing.title}</strong>?
+                milestones in this chapter will not be deleted — they will simply no longer
+                be part of this chapter.
+              </div>
+              <div className="detail-confirm-actions">
+                <button type="button" className="btn" onClick={() => setConfirmDelete(false)}>
+                  cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={handleDelete}
+                  disabled={busy}
+                >
+                  {busy ? 'deleting…' : 'yes, delete chapter'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="sheet-field">
+              <button
+                type="button"
+                className="btn btn-danger"
+                style={{ alignSelf: 'flex-start', fontSize: '0.75rem', padding: '0.35rem 0.75rem' }}
+                onClick={() => setConfirmDelete(true)}
+              >
+                delete chapter
+              </button>
+            </div>
+          )
+        )}
+
+        {/* Actions */}
+        <div className="sheet-actions">
+          <span />
+          <div className="sheet-actions-right">
+            <button
+              type="button"
+              className="btn"
+              onClick={onClose}
+              style={{ fontSize: '0.8rem', padding: '0.45rem 0.9rem' }}
+            >
+              cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-filled"
+              disabled={!canSave || busy}
+              style={{ fontSize: '0.8rem', padding: '0.45rem 0.9rem' }}
+            >
+              {busy ? 'saving…' : isEdit ? 'save changes' : 'add chapter'}
+            </button>
+          </div>
+        </div>
+
+      </form>
+    </div>
+  )
+}

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -64,7 +64,7 @@ function wrapTitle(text, maxChars) {
 }
 
 const Timeline = forwardRef(function Timeline(
-  { milestones, chapters = [], zoom, textSize = 'normal', onMilestoneClick, onMilestoneDoubleClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
+  { milestones, chapters = [], zoom, textSize = 'normal', onMilestoneClick, onMilestoneDoubleClick, onChapterDoubleClick, customHalfMs = 0, highlightedIds, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
   ref
 ) {
   const remPx = REM_PX[textSize] || 22
@@ -368,6 +368,7 @@ const Timeline = forwardRef(function Timeline(
                   onMouseEnter={e => setChapterTip({ chapter, x: e.clientX, y: e.clientY })}
                   onMouseLeave={() => setChapterTip(null)}
                   onMouseMove={e => setChapterTip(t => t ? { ...t, x: e.clientX, y: e.clientY } : null)}
+                  onDoubleClick={() => onChapterDoubleClick?.(chapter)}
                 >
                   {/* Bar body */}
                   <rect x={x1} y={barY} width={barW} height={barH}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -15,7 +15,8 @@ import { ZOOM_LEVELS, applyRecurFilter } from '../../utils/timeline'
 import { expandAnnualDates } from '../../utils/recurrence'
 import { loadCategories } from '../../utils/colors'
 import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones, uid } from '../../data/milestones'
-import { listChapters, restoreChapters } from '../../data/chapters'
+import { listChapters, restoreChapters, createChapter, updateChapter, deleteChapter } from '../../data/chapters'
+import ChapterSheet from '../chapter/ChapterSheet'
 import { dbPutMedia, dbPutPhoto, dbDeletePhoto, dbGetPhoto, dbPut } from '../../data/db'
 import { parseIcs }      from '../../utils/icsParser'
 import * as audio from '../../utils/audio'
@@ -81,8 +82,10 @@ export default function TimelineView({ milestones, setMilestones }) {
   )
   const [canUndo,       setCanUndo]       = useState(false)
   const [canRedo,       setCanRedo]       = useState(false)
-  const [chapters,      setChapters]      = useState([])
-  const [newlyAddedId,  setNewlyAddedId]  = useState(null)
+  const [chapters,         setChapters]         = useState([])
+  const [chapterSheetOpen, setChapterSheetOpen] = useState(false)
+  const [editChapter,      setEditChapter]      = useState(null)
+  const [newlyAddedId,     setNewlyAddedId]     = useState(null)
   const [summaryOpen,   setSummaryOpen]   = useState(false)
   const [onThisDayOpen, setOnThisDayOpen] = useState(false)
   const [icsImport,     setIcsImport]     = useState(null)  // { candidates, timedCount } | null
@@ -357,7 +360,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   const keyStateRef = useRef(null)
   keyStateRef.current = {
     pastIdx, futureIdx, past, future, zoom,
-    addOpen, detail, settingsOpen, helpOpen, searchOpen,
+    addOpen, detail, settingsOpen, helpOpen, searchOpen, chapterSheetOpen,
     handlePastNav, handleFutureNav, handleJumpToToday, handleViewMode, closeSheet,
     handleUndo, handleRedo, canUndo, canRedo,
     clustering, setClustering,
@@ -374,7 +377,7 @@ export default function TimelineView({ milestones, setMilestones }) {
       }
       audio.init()   // unlock AudioContext on first keystroke (idempotent)
       const s = keyStateRef.current
-      const anyModal = s.addOpen || !!s.detail || s.settingsOpen || s.helpOpen || s.searchOpen
+      const anyModal = s.addOpen || !!s.detail || s.settingsOpen || s.helpOpen || s.searchOpen || s.chapterSheetOpen
 
       switch (e.key) {
         case 'ArrowLeft': {
@@ -515,11 +518,12 @@ export default function TimelineView({ milestones, setMilestones }) {
             customInputRef.current.blur()
             break
           }
-          if (s.detail)            setDetail(null)
-          else if (s.addOpen)      s.closeSheet()
-          else if (s.settingsOpen) setSettingsOpen(false)
-          else if (s.helpOpen)     setHelpOpen(false)
-          else if (s.searchOpen)   setSearchOpen(false)
+          if (s.detail)                setDetail(null)
+          else if (s.addOpen)          s.closeSheet()
+          else if (s.chapterSheetOpen) { setChapterSheetOpen(false); setEditChapter(null) }
+          else if (s.settingsOpen)     setSettingsOpen(false)
+          else if (s.helpOpen)         setHelpOpen(false)
+          else if (s.searchOpen)       setSearchOpen(false)
           break
         }
         default: break
@@ -672,6 +676,52 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   function openEdit(m)  { setEditTarget(m); setAddOpen(true) }
   function closeSheet() { setAddOpen(false); setEditTarget(null) }
+
+  // ── Chapter CRUD ─────────────────────────────────────────────────────────────
+  function openChapterCreate() { setEditChapter(null); setChapterSheetOpen(true) }
+  function openChapterEdit(ch) { setEditChapter(ch);   setChapterSheetOpen(true) }
+  function closeChapterSheet() { setChapterSheetOpen(false); setEditChapter(null) }
+
+  async function handleChapterSave(data, existing) {
+    const startIso = new Date(data.start).toISOString()
+    const endIso   = new Date(data.end).toISOString()
+
+    if (existing) {
+      const updated = await updateChapter(
+        existing.id,
+        {
+          title:                  data.title,
+          start:                  startIso,
+          end:                    endIso,
+          color:                  data.color,
+          description:            data.description,
+          defaultMemberVisibility: data.defaultMemberVisibility,
+          milestoneIds:           data.milestoneIds,
+        },
+        existing,
+      )
+      setChapters(prev => prev.map(c => c.id === existing.id ? updated : c))
+    } else {
+      const chapter = await createChapter({
+        title:                  data.title,
+        start:                  data.start,
+        end:                    data.end,
+        color:                  data.color,
+        description:            data.description,
+        defaultMemberVisibility: data.defaultMemberVisibility,
+      })
+      // Set member milestones if any were selected
+      const final = data.milestoneIds.length > 0
+        ? await updateChapter(chapter.id, { milestoneIds: data.milestoneIds }, chapter)
+        : chapter
+      setChapters(prev => [...prev, final])
+    }
+  }
+
+  async function handleChapterDelete(id) {
+    await deleteChapter(id)
+    setChapters(prev => prev.filter(c => c.id !== id))
+  }
 
   // ── Export image ─────────────────────────────────────────────────────────────
   async function handleExportImage() {
@@ -1046,6 +1096,7 @@ export default function TimelineView({ milestones, setMilestones }) {
             highlightedIds={highlightedIds}
             onMilestoneClick={handleMilestoneClick}
             onMilestoneDoubleClick={openEdit}
+            onChapterDoubleClick={openChapterEdit}
             panMs={panMs}
             onPanMs={setPanMs}
             viewMode={viewMode}
@@ -1088,6 +1139,9 @@ export default function TimelineView({ milestones, setMilestones }) {
       <div className="timeline-bottom">
         <button className="add-milestone-btn" onClick={() => setAddOpen(true)}>
           + add milestone
+        </button>
+        <button className="add-chapter-btn" onClick={openChapterCreate}>
+          + add chapter
         </button>
 
         {presentCategories.length > 0 && (
@@ -1152,6 +1206,15 @@ export default function TimelineView({ milestones, setMilestones }) {
         <AddMilestoneSheet
           onSave={handleSave} onClose={closeSheet} existing={editTarget}
           categories={categories}
+        />
+      )}
+      {chapterSheetOpen && (
+        <ChapterSheet
+          onSave={handleChapterSave}
+          onClose={closeChapterSheet}
+          onDelete={handleChapterDelete}
+          existing={editChapter}
+          milestones={milestones}
         />
       )}
       {detail && (

--- a/src/index.css
+++ b/src/index.css
@@ -1907,3 +1907,128 @@ button, input, select, textarea {
   from { opacity: 0; transform: translateX(-50%) translateY(8px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+
+/* ─── Chapter sheet ──────────────────────────────────────────────────────────── */
+
+.add-chapter-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  background: transparent;
+  border: 1px solid rgba(200, 169, 110, 0.45);
+  color: rgba(200, 169, 110, 0.75);
+  font-family: var(--font);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  letter-spacing: 0.03em;
+}
+.add-chapter-btn:hover {
+  background: rgba(200, 169, 110, 0.08);
+  color: var(--amber);
+  border-color: var(--amber);
+}
+
+.chapter-date-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+}
+.chapter-date-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  flex: 1;
+}
+.chapter-date-arrow {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding-bottom: 0.45rem;
+  flex-shrink: 0;
+}
+.chapter-date-error {
+  font-size: 0.7rem;
+  color: #E85D75;
+  letter-spacing: 0.02em;
+  margin-top: 0.1rem;
+}
+
+.chapter-color-row {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+}
+.chapter-color-swatch {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.12s;
+  flex-shrink: 0;
+}
+.chapter-color-swatch:hover  { transform: scale(1.2); }
+.chapter-color-swatch.selected {
+  border-color: var(--text);
+  transform: scale(1.2);
+}
+
+.chapter-member-count {
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+.chapter-members-empty {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+  padding: 0.4rem 0;
+}
+.chapter-members-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.5rem;
+}
+.chapter-member-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.2rem 0.1rem;
+  border-radius: 2px;
+}
+.chapter-member-row:hover { background: rgba(232,224,208,0.04); }
+.chapter-member-check {
+  accent-color: var(--amber);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.chapter-member-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.chapter-member-title {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chapter-member-retained {
+  opacity: 0.5;
+}
+.chapter-member-date {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}


### PR DESCRIPTION
- Add ChapterSheet form component (title, date range, color swatch, description, defaultMemberVisibility toggle, member milestone checklist with auto-check on create, preserved membership on edit)
- Wire chapter handlers in TimelineView: openChapterCreate/Edit, closeChapterSheet, handleChapterSave, handleChapterDelete
- Add "+ add chapter" button to timeline bottom bar
- Pass onChapterDoubleClick prop to Timeline for ribbon double-click edit
- Append chapter sheet CSS (add-chapter-btn, date row, color swatches, member list styles) to index.css

https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo