### PR TITLE
feat(chapters): Phase 4 — Cascade visibility + endpoint floor

### DIFF
--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -227,24 +227,37 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
             <div className="chapter-members-empty">no milestones in this date range</div>
           ) : (
             <div className="chapter-members-list">
-              {displayMilestones.map(m => (
-                <label key={m.id} className="chapter-member-row">
-                  <input
-                    type="checkbox"
-                    className="chapter-member-check"
-                    checked={checkedIds.has(m.id)}
-                    onChange={() => toggleId(m.id)}
-                  />
-                  <span
-                    className="chapter-member-dot"
-                    style={{ background: m.color ?? 'var(--text-muted)' }}
-                  />
-                  <span className={`chapter-member-title${isEdit && !inRangeIds.has(m.id) ? ' chapter-member-retained' : ''}`}>
-                    {m.title}
-                  </span>
-                  <span className="chapter-member-date">{fmtDate(m)}</span>
-                </label>
-              ))}
+              {displayMilestones.map(m => {
+                // Endpoint: milestone date matches the chapter's start or end (day-level comparison).
+                // Only checked members can be endpoints — unchecked milestones aren't members yet.
+                const mDay      = m.date?.slice(0, 10)
+                const startDay  = start
+                const endDay    = end
+                const isEndpoint = checkedIds.has(m.id) &&
+                  mDay && (mDay === startDay || mDay === endDay)
+
+                return (
+                  <label key={m.id} className="chapter-member-row">
+                    <input
+                      type="checkbox"
+                      className="chapter-member-check"
+                      checked={checkedIds.has(m.id)}
+                      onChange={() => toggleId(m.id)}
+                    />
+                    <span
+                      className="chapter-member-dot"
+                      style={{ background: m.color ?? 'var(--text-muted)' }}
+                    />
+                    <span className={`chapter-member-title${isEdit && !inRangeIds.has(m.id) ? ' chapter-member-retained' : ''}`}>
+                      {m.title}
+                    </span>
+                    {isEndpoint && (
+                      <span className="chapter-member-endpoint" title="endpoint — always shown on main timeline">⚓</span>
+                    )}
+                    <span className="chapter-member-date">{fmtDate(m)}</span>
+                  </label>
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react'
 import { DEFAULT_CATEGORIES } from '../../utils/colors'
 import { buildDateFromParts } from '../../utils/dates'
 import { dbGetPhoto } from '../../data/db'
+import { getMilestoneVisibility } from '../../utils/visibility'
 
 const MONTHS = [
   { v: '1',  l: 'Jan' }, { v: '2',  l: 'Feb' }, { v: '3',  l: 'Mar' },
@@ -10,7 +11,7 @@ const MONTHS = [
   { v: '10', l: 'Oct' }, { v: '11', l: 'Nov' }, { v: '12', l: 'Dec' },
 ]
 
-export default function AddMilestoneSheet({ onSave, onClose, existing, categories = DEFAULT_CATEGORIES }) {
+export default function AddMilestoneSheet({ onSave, onClose, existing, categories = DEFAULT_CATEGORIES, chapters = [], visibilityPrecomputed = { endpointChapterNames: new Map() } }) {
   const isEdit = !!existing
 
   const [title,      setTitle]      = useState(existing?.title     ?? '')
@@ -33,9 +34,18 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
   const [mediaObjectUrl, setMediaObjectUrl] = useState(null) // transient preview URL
   const [recurrence,    setRecurrence]    = useState(false)
   const [recEndYear,    setRecEndYear]    = useState('')
+  const [visibility,    setVisibility]    = useState(existing?.mainTimelineVisibility ?? 'inherit')
   const [busy,          setBusy]          = useState(false)
   const photoRef = useRef(null)
   const mediaRef = useRef(null)
+
+  // Compute visibility status for the edit-mode info panel. Re-runs when
+  // visibility setting changes (existing.date stays constant during a session).
+  const visInfo = React.useMemo(() => {
+    if (!isEdit || !existing) return null
+    const provisional = { ...existing, mainTimelineVisibility: visibility }
+    return getMilestoneVisibility(provisional, chapters, visibilityPrecomputed, 'main')
+  }, [isEdit, existing, visibility, chapters, visibilityPrecomputed])
 
   // Load existing photo blob from IndexedDB for edit mode
   React.useEffect(() => {
@@ -126,6 +136,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         mediaFile,
         mediaRemoved,
         url: url.trim(),
+        mainTimelineVisibility: visibility,
         recurrence: (!isEdit && recurrence) ? 'annual' : (existing?.recurrence ?? null),
         recurrence_id: existing?.recurrence_id ?? null,
         recurrenceEndYear: (!isEdit && recurrence && year.length >= 4)
@@ -405,6 +416,62 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         {isEdit && existing?.recurrence === 'annual' && (
           <div className="sheet-field">
             <div className="detail-recurrence-warn">↻ repeats annually — editing this instance only</div>
+          </div>
+        )}
+
+        {/* Visibility (edit mode only) */}
+        {isEdit && (
+          <div className="sheet-field">
+            <label className="field-label">main timeline visibility</label>
+
+            {/* Endpoint override notice — shown when a chapter's start/end anchors this milestone */}
+            {visInfo?.reason === 'endpoint' && (
+              <div className="vis-endpoint-notice">
+                <span className="vis-endpoint-icon">⚓</span>
+                <span>
+                  endpoint of {visInfo.endpointChapters.map(t => `'${t}'`).join(', ')} —
+                  always shown regardless of setting below
+                </span>
+              </div>
+            )}
+
+            {/* Three-way toggle: inherit / shown / hidden */}
+            <div className="vis-toggle-row">
+              {['inherit', 'shown', 'hidden'].map(v => (
+                <button
+                  key={v}
+                  type="button"
+                  className={`vis-tab${visibility === v ? ' active' : ''}`}
+                  onClick={() => setVisibility(v)}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+
+            {/* Status line — explains the resolved behavior */}
+            {visInfo && (
+              <div className={`vis-status ${visInfo.visible ? 'vis-status-shown' : 'vis-status-hidden'}`}>
+                {visInfo.reason === 'endpoint' && (
+                  'shown (endpoint floor — overrides setting above)'
+                )}
+                {visInfo.reason === 'milestone-shown' && (
+                  'shown (set explicitly)'
+                )}
+                {visInfo.reason === 'milestone-hidden' && (
+                  'hidden (set explicitly)'
+                )}
+                {visInfo.reason === 'cascade-shown' && (
+                  `shown (inheriting — ${visInfo.inheritSource})`
+                )}
+                {visInfo.reason === 'cascade-hidden' && (
+                  `hidden (inheriting — ${visInfo.inheritSource})`
+                )}
+                {visInfo.reason === 'no-chapters' && (
+                  'shown (inheriting — not a member of any chapter)'
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -14,6 +14,7 @@ import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS, applyRecurFilter } from '../../utils/timeline'
 import { expandAnnualDates } from '../../utils/recurrence'
 import { loadCategories } from '../../utils/colors'
+import { getMilestoneVisibility, precomputeEndpoints } from '../../utils/visibility'
 import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones, uid } from '../../data/milestones'
 import { listChapters, restoreChapters, createChapter, updateChapter, deleteChapter } from '../../data/chapters'
 import ChapterSheet from '../chapter/ChapterSheet'
@@ -191,13 +192,23 @@ export default function TimelineView({ milestones, setMilestones }) {
     return () => el.removeEventListener('wheel', onWheel)
   }, [])
 
+  // ── Visibility precomputation ─────────────────────────────────────────────────
+  // Precompute endpoint data once per chapters change. This is O(chapters × members)
+  // and avoids re-scanning chapters for every milestone on every render.
+  const visibilityPrecomputed = React.useMemo(() => precomputeEndpoints(chapters), [chapters])
+
   // ── Filter ───────────────────────────────────────────────────────────────────
   const presentCategories = categories.filter(cat =>
     milestones.some(m => m.category === cat.id)
   )
   const hasRecurring = milestones.some(m => m.recurrence_id)
   const categoryFiltered = filter === 'all' ? milestones : milestones.filter(m => m.category === filter)
-  const filteredMilestones = applyRecurFilter(categoryFiltered, recurFilter)
+  const recurFiltered = applyRecurFilter(categoryFiltered, recurFilter)
+  // Apply cascade visibility — hidden milestones are excluded entirely from the
+  // main timeline render (no layout space, not in the DOM, not hoverable).
+  const filteredMilestones = recurFiltered.filter(m =>
+    getMilestoneVisibility(m, chapters, visibilityPrecomputed, 'main').visible
+  )
 
   function cycleRecurFilter() {
     setRecurFilter(f => ({ next: 'all', all: 'past', past: 'future', future: 'next' }[f]))
@@ -1206,6 +1217,8 @@ export default function TimelineView({ milestones, setMilestones }) {
         <AddMilestoneSheet
           onSave={handleSave} onClose={closeSheet} existing={editTarget}
           categories={categories}
+          chapters={chapters}
+          visibilityPrecomputed={visibilityPrecomputed}
         />
       )}
       {chapterSheetOpen && (

--- a/src/index.css
+++ b/src/index.css
@@ -2032,3 +2032,58 @@ button, input, select, textarea {
   color: var(--text-muted);
   flex-shrink: 0;
 }
+.chapter-member-endpoint {
+  font-size: 0.6rem;
+  opacity: 0.7;
+  flex-shrink: 0;
+  margin-left: auto;
+  cursor: default;
+}
+
+/* ─── Phase 4: Visibility control in milestone edit form ───────────────────── */
+.vis-toggle-row {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  align-self: flex-start;
+}
+.vis-tab {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  border-right: 1px solid var(--border);
+}
+.vis-tab:last-child { border-right: none; }
+.vis-tab:hover { color: var(--text-dim); background: rgba(232,224,208,0.06); }
+.vis-tab.active {
+  background: rgba(200,169,110,0.15);
+  color: var(--amber);
+}
+.vis-status {
+  font-size: 0.68rem;
+  margin-top: 0.35rem;
+  opacity: 0.85;
+  line-height: 1.4;
+}
+.vis-status-shown { color: rgba(100,200,120,0.9); }
+.vis-status-hidden { color: rgba(200,100,100,0.9); }
+.vis-endpoint-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  font-size: 0.68rem;
+  color: var(--amber);
+  background: rgba(200,169,110,0.08);
+  border: 1px solid rgba(200,169,110,0.2);
+  border-radius: 4px;
+  padding: 0.35rem 0.5rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+.vis-endpoint-icon { flex-shrink: 0; font-style: normal; }

--- a/src/utils/visibility.js
+++ b/src/utils/visibility.js
@@ -1,0 +1,128 @@
+/**
+ * Cascade visibility model with endpoint floor.
+ *
+ * Priority order (highest wins):
+ *   1. Endpoint floor  — milestone date matches a member chapter's start or end → always shown
+ *   2. Milestone override — mainTimelineVisibility 'shown' or 'hidden' → use directly
+ *   3. Chapter cascade — when 'inherit': any member chapter with defaultMemberVisibility
+ *      'shown' → shown; all member chapters 'hidden' → hidden; no chapters → shown
+ *
+ * The drill-in context ('chapterDrilldown') bypasses all rules and always returns 'shown'
+ * so Phase 5 can use this function directly without modifications.
+ */
+
+/**
+ * Precomputes a Set of milestone IDs that are endpoints of any chapter.
+ * Also returns a Map from milestoneId → array of chapter names it anchors.
+ *
+ * Precomputing avoids O(chapters) work per milestone on every render.
+ * Call once when chapters change, then pass the result to getMilestoneVisibility.
+ *
+ * @param {Array} chapters
+ * @returns {{ endpointIds: Set<string>, endpointChapterNames: Map<string, string[]> }}
+ */
+export function precomputeEndpoints(chapters) {
+  const endpointIds          = new Set()
+  const endpointChapterNames = new Map()
+
+  for (const chapter of chapters) {
+    const startDay = chapter.start.slice(0, 10)
+    const endDay   = chapter.end.slice(0, 10)
+
+    for (const milestoneId of chapter.milestoneIds) {
+      // Endpoint status requires both date match AND membership — checked by
+      // the caller when building milestoneIds, so here we trust the list.
+      // We still need to compare dates when resolving, so store chapter refs.
+      // But the precomputation is driven by chapter.start/end vs milestone.date,
+      // which we resolve below using the milestone's own date field.
+      //
+      // We can't fully resolve here without the milestones array, so we store
+      // the chapter's start/end dates per member and let getMilestoneVisibility
+      // do the final date comparison cheaply.
+      if (!endpointChapterNames.has(milestoneId)) {
+        endpointChapterNames.set(milestoneId, [])
+      }
+      // Store { chapterTitle, startDay, endDay } so getMilestoneVisibility can
+      // check date match without re-scanning chapters.
+      endpointChapterNames.get(milestoneId).push({ title: chapter.title, startDay, endDay })
+    }
+  }
+
+  return { endpointChapterNames }
+}
+
+/**
+ * Returns visibility info for a single milestone.
+ *
+ * @param {Object} milestone  — must have .date, .mainTimelineVisibility, .id
+ * @param {Array}  chapters   — all chapters (used for cascade; not for endpoint, see below)
+ * @param {Object} precomputed — result of precomputeEndpoints(chapters)
+ * @param {'main'|'chapterDrilldown'} context
+ * @returns {{
+ *   visible: boolean,
+ *   reason: 'endpoint'|'milestone-shown'|'milestone-hidden'|'cascade-shown'|'cascade-hidden'|'no-chapters',
+ *   endpointChapters: string[],   // chapter titles this milestone anchors (may be empty)
+ *   inheritedResolution: 'shown'|'hidden'|null,  // resolved value when setting is 'inherit'
+ *   inheritSource: string|null,   // human-readable explanation of the cascade result
+ * }}
+ */
+export function getMilestoneVisibility(milestone, chapters, precomputed, context = 'main') {
+  if (context === 'chapterDrilldown') {
+    return { visible: true, reason: 'drilldown', endpointChapters: [], inheritedResolution: null, inheritSource: null }
+  }
+
+  const milestoneDay = milestone.date ? milestone.date.slice(0, 10) : null
+  const candidateChapters = precomputed.endpointChapterNames.get(milestone.id) ?? []
+
+  // Endpoint chapters: member chapters whose start or end date matches this milestone's date.
+  const endpointChapters = milestoneDay
+    ? candidateChapters
+        .filter(c => c.startDay === milestoneDay || c.endDay === milestoneDay)
+        .map(c => c.title)
+    : []
+
+  // 1. Endpoint floor
+  if (endpointChapters.length > 0) {
+    return { visible: true, reason: 'endpoint', endpointChapters, inheritedResolution: null, inheritSource: null }
+  }
+
+  // 2. Explicit milestone override
+  const setting = milestone.mainTimelineVisibility ?? 'inherit'
+
+  if (setting === 'shown') {
+    return { visible: true, reason: 'milestone-shown', endpointChapters: [], inheritedResolution: null, inheritSource: null }
+  }
+  if (setting === 'hidden') {
+    return { visible: false, reason: 'milestone-hidden', endpointChapters: [], inheritedResolution: null, inheritSource: null }
+  }
+
+  // 3. Cascade from chapters (setting === 'inherit')
+  const memberChapters = chapters.filter(c => c.milestoneIds.includes(milestone.id))
+
+  if (memberChapters.length === 0) {
+    return { visible: true, reason: 'no-chapters', endpointChapters: [], inheritedResolution: 'shown', inheritSource: 'not a member of any chapter' }
+  }
+
+  const anyShown = memberChapters.some(c => c.defaultMemberVisibility === 'shown')
+
+  if (anyShown) {
+    const shownChapter = memberChapters.find(c => c.defaultMemberVisibility === 'shown')
+    return {
+      visible: true,
+      reason: 'cascade-shown',
+      endpointChapters: [],
+      inheritedResolution: 'shown',
+      inheritSource: `member of '${shownChapter.title}'`,
+    }
+  }
+
+  // All member chapters are hidden-by-default
+  const hiddenNames = memberChapters.map(c => `'${c.title}'`).join(', ')
+  return {
+    visible: false,
+    reason: 'cascade-hidden',
+    endpointChapters: [],
+    inheritedResolution: 'hidden',
+    inheritSource: `all member chapters set to hidden (${hiddenNames})`,
+  }
+}


### PR DESCRIPTION
Implements the full cascade visibility model. Hidden milestones are excluded entirely from the main timeline render (not just faded).

## Visibility logic (src/utils/visibility.js)

getMilestoneVisibility(milestone, chapters, precomputed, context):
  1. Endpoint floor — milestone date matches a member chapter's start or end → always shown regardless of other settings
  2. Milestone override — mainTimelineVisibility 'shown'|'hidden'
  3. Chapter cascade — 'inherit': any-shown-wins across member chapters; no chapters → shown context='chapterDrilldown' bypasses all rules (Phase 5 hook).

precomputeEndpoints(chapters) builds a Map<milestoneId, candidateChapters> once per chapters change, avoiding O(chapters) work per milestone per render.

## TimelineView.jsx

- Imports getMilestoneVisibility + precomputeEndpoints
- visibilityPrecomputed = useMemo(precomputeEndpoints, [chapters])
- filteredMilestones now filters out getMilestoneVisibility(...).visible===false
- Passes chapters + visibilityPrecomputed to AddMilestoneSheet

## AddMilestoneSheet.jsx

- Accepts chapters + visibilityPrecomputed props
- Adds mainTimelineVisibility state (default: existing value or 'inherit')
- Includes field in onSave payload so executeSave writes it to IDB
- Edit mode: three-way toggle (inherit / shown / hidden), resolved-status line in green/red, amber endpoint override notice naming the chapter(s)

## ChapterSheet.jsx

- Member list marks endpoint milestones with ⚓ icon (date matches chapter start or end AND milestone is checked/member)

## index.css

- .vis-toggle-row / .vis-tab / .vis-tab.active
- .vis-status / .vis-status-shown / .vis-status-hidden
- .vis-endpoint-notice / .vis-endpoint-icon
- .chapter-member-endpoint

https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo