### PR TITLE
Fix double-ESC to exit drill-in and breadcrumb logo styling

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -750,6 +750,11 @@ export default function TimelineView({ milestones, setMilestones }) {
     // regardless of which render's closure calls it.
     predrillRef.current = { zoom, customYears, panMs }
 
+    // Set drilledChapter immediately (before the animation) so that keyStateRef
+    // reflects the drilled state right away — this means ESC works during the
+    // enter animation rather than requiring a second press after it completes.
+    setDrilledChapter(chapter)
+
     // Compute zoom-to-fit: center on the chapter with 15% padding each side.
     const startMs         = new Date(chapter.start).getTime()
     const endMs           = new Date(chapter.end).getTime()
@@ -763,7 +768,6 @@ export default function TimelineView({ milestones, setMilestones }) {
       setCustomYears(Math.max(0.1, halfYears))
       setPanMs(chapterCenterMs - Date.now())
       setZoomAnim('')
-      setDrilledChapter(chapter)
     }, ZOOM_ANIM_MS)
   }
 
@@ -1027,7 +1031,7 @@ export default function TimelineView({ milestones, setMilestones }) {
         {drilledChapter ? (
           <div className="drill-breadcrumb" style={{ '--drill-color': drilledChapter.color }}>
             <button className="drill-breadcrumb-life" onClick={() => exitDrillIn()}>
-              life<span className="logo-glance" style={{ fontSize: '0.7em' }}>GLANCE</span>
+              <span className="logo-life">life</span><span className="logo-glance">GLANCE</span>
             </button>
             <span className="drill-breadcrumb-sep">›</span>
             <TypewriterText

--- a/src/index.css
+++ b/src/index.css
@@ -2100,13 +2100,15 @@ button, input, select, textarea {
   border: none;
   cursor: pointer;
   font-family: var(--font);
-  font-size: 0.82rem;
-  color: var(--text-muted);
   padding: 0;
   line-height: 1;
-  transition: color 0.15s;
+  display: inline-flex;
+  align-items: baseline;
+  transition: opacity 0.15s;
 }
-.drill-breadcrumb-life:hover { color: var(--text-dim); }
+.drill-breadcrumb-life .logo-life   { font-size: 1.1rem; }
+.drill-breadcrumb-life .logo-glance { font-size: 1.2rem; }
+.drill-breadcrumb-life:hover { opacity: 0.7; }
 .drill-breadcrumb-sep {
   color: var(--text-muted);
   font-size: 0.8rem;


### PR DESCRIPTION
Double-ESC: setDrilledChapter was deferred inside the 380ms animation timeout. Pressing ESC during the animation saw drilledChapter=null in keyStateRef (stale from the pre-click render) and did nothing. Moving setDrilledChapter before the animation ensures the drilled state is reflected in keyStateRef immediately, so one ESC press always works.

Breadcrumb logo: 'life' was plain text inheriting var(--text-muted) from the button, and the logo-glance span had its font-size stomped by an inline 0.7em style (~0.57rem). Replaced with proper logo-life/logo-glance spans sized via CSS (1.1rem / 1.2rem), matching the header logo pattern.

https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo