### PR TITLE
Fix single-ESC exit and breadcrumb logo sizing

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -529,6 +529,10 @@ export default function TimelineView({ milestones, setMilestones }) {
           break
         }
         case 'Escape': {
+          // Drill-in exit takes priority — entering drill-in sets zoom='custom' which
+          // auto-focuses the custom zoom input, causing the first ESC to only blur
+          // the input rather than exit the chapter view.
+          if (anyDrillIn) { s.exitDrillIn(); break }
           if (customInputRef.current && document.activeElement === customInputRef.current) {
             customInputRef.current.blur()
             break
@@ -539,7 +543,6 @@ export default function TimelineView({ milestones, setMilestones }) {
           else if (s.settingsOpen)     setSettingsOpen(false)
           else if (s.helpOpen)         setHelpOpen(false)
           else if (s.searchOpen)       setSearchOpen(false)
-          else if (anyDrillIn)         s.exitDrillIn()
           break
         }
         default: break
@@ -1077,7 +1080,7 @@ export default function TimelineView({ milestones, setMilestones }) {
               {zoom === 'custom' && (
                 <div className="custom-zoom-row">
                   <span>±</span>
-                  <input ref={customInputRef} autoFocus
+                  <input ref={customInputRef} autoFocus={!drilledChapter}
                     className="custom-zoom-input" type="number" min="1" max="200"
                     value={customYears}
                     onChange={e => {
@@ -1119,7 +1122,7 @@ export default function TimelineView({ milestones, setMilestones }) {
                   {zoom === 'custom' ? (
                     <div className="custom-zoom-row">
                       <span>±</span>
-                      <input ref={customInputRef} autoFocus
+                      <input ref={customInputRef} autoFocus={!drilledChapter}
                         className="custom-zoom-input" type="number" min="1" max="200"
                         value={customYears}
                         onChange={e => {

--- a/src/index.css
+++ b/src/index.css
@@ -2106,8 +2106,8 @@ button, input, select, textarea {
   align-items: baseline;
   transition: opacity 0.15s;
 }
-.drill-breadcrumb-life .logo-life   { font-size: 1.1rem; }
-.drill-breadcrumb-life .logo-glance { font-size: 1.2rem; }
+.drill-breadcrumb-life .logo-life   { font-size: 0.78rem; font-weight: 400; color: var(--text); }
+.drill-breadcrumb-life .logo-glance { font-size: 0.85rem; font-weight: 700; font-style: italic; color: var(--indigo); }
 .drill-breadcrumb-life:hover { opacity: 0.7; }
 .drill-breadcrumb-sep {
   color: var(--text-muted);


### PR DESCRIPTION
ESC required two presses because entering drill-in calls setZoom('custom'), which mounts the custom zoom input with autoFocus. The first ESC hit the customInputRef.current.blur() guard and broke early. Fix: move anyDrillIn before the input-blur check so drill-in exit always fires in one press. Also add autoFocus={!drilledChapter} to both custom zoom inputs so they don't steal focus when drill-in sets zoom='custom'.

Breadcrumb logo was still header-sized (1.1/1.2rem ≈ logo-sm). It should be breadcrumb-sized to match the chapter name (~0.82rem). Set life/GLANCE explicitly to 0.78rem/0.85rem with correct weights and colors so the logo reads as a nav item rather than a full header.

https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo