### PR TITLE
v1.5.0 — Chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Built for people who want to map their life without handing their data to a cloud service. lifeGLANCE is a privacy-first progressive web app that runs entirely in the browser. There is no account, no server, no sync — your data never leaves your device.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.2-brightgreen.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.5.0-brightgreen.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "1.0.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "1.0.2",
+      "version": "1.5.0",
       "dependencies": {
         "date-fns": "^3.6.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "1.0.2",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Completes all six phases of the v1.5 Chapters spec.

- **Phase 1** — Chapter data model: `id`, `title`, `start`, `end`, `color`, `description`, `defaultMemberVisibility`, `parentChapterId` (reserved). Milestone `mainTimelineVisibility` field. Many-to-many membership via `milestoneIds`. Full CRUD + IndexedDB persistence (v5 migration).
- **Phase 2** — Chapter ribbon rendering on the main timeline: stacked via greedy interval coloring, zoom-aware labels (bar / title / date markers), hover tooltip, click to drill in.
- **Phase 3** — Chapter creation/edit UI: date range pickers (milestone-style month/day/year + precision tabs), color picker, description, `defaultMemberVisibility` toggle, member checklist pre-populated from date overlap, delete with confirmation.
- **Phase 4** — Cascade visibility + endpoint floor: `defaultMemberVisibility` cascades to members via `mainTimelineVisibility: 'inherit'`; endpoint milestones (date matches chapter start/end) are always shown regardless of cascade. Milestone edit form surfaces visibility state and endpoint status.
- **Phase 5** — Drill-in: click chapter → zoom-to-fit animation, non-members hidden, time axis recalibrates, TypewriterText re-fires, accent colour tint, breadcrumb with chapter metadata (date range · member count · description, hidden on mobile ≤1080px), ESC or logo click to exit and restore prior zoom/pan.
- **Phase 6** — Milestone creation auto-suggest: overlapping chapters shown as a checklist when adding a milestone; defaults to the drilled chapter checked (if drilled in) or nothing (if on main timeline).

### Polish added beyond spec

- Chapter bands in the minimap (greedy-stacked, same colour as ribbon, capped at 3 rows)
- Chapter membership tags in search results (coloured pills per chapter)
- Drill-in/out sound effects via existing Web Audio system (ascending/descending sine sweep + landing piano note); respects mute toggle
- Multi-select category filter — chips now toggle independently; compact dropdown stays open for multi-select; shows "N categories" label
- `⇧N` keyboard shortcut opens new chapter sheet; `n` unchanged for new milestone
- Chapter metadata subtitle in breadcrumb (hidden on mobile)

### Bugs fixed

- Drill-in exit now restores prior zoom/pan (stale closure via `predrillRef`)
- Double-ESC to exit resolved (custom zoom input focus; `autoFocus={!drilledChapter}`)
- Double-click on chapter no longer drills in behind the edit modal
- ESC dismisses open modal before exiting drill-in
- Zoom animation JS/CSS timing aligned (380ms → 420ms to match `0.42s` CSS transition)
- Chapter delete wrapped in try/catch; UI state only mutated on success
- `buildDateFromParts` now uses `Date.UTC()` — dates round-trip correctly in all timezones (UTC+ users previously saw dates shift by one day on reopen)
- Endpoint indicator (⚓) now shows dimly on unchecked milestones whose date matches the chapter boundary, so the warning is visible *before* unchecking rather than disappearing at the moment it would matter
- Fixed `@returns` docstring in `visibility.js` (phantom `endpointIds` field removed)

## Test plan

- [ ] Create a chapter, verify ribbon appears and stacks correctly with overlapping chapters
- [ ] Drill into a chapter — zoom animates, non-members disappear, breadcrumb shows title + metadata, accent tint applied
- [ ] ESC exits drill-in and restores prior zoom/pan; ESC while modal open closes modal first
- [ ] Create a milestone while drilled in — drilled chapter pre-checked; milestone appears in chapter
- [ ] Edit a milestone that is a chapter endpoint — visibility override UI shows correctly; ⚓ icon visible
- [ ] Edit a chapter — uncheck a boundary-date milestone and verify ⚓ shows dimly before unchecking
- [ ] Category filter: select multiple categories; verify combined results; "all" resets
- [ ] `n` opens add milestone, `⇧N` opens add chapter, `?` shows updated shortcuts
- [ ] Minimap shows coloured chapter bands
- [ ] Search a milestone belonging to a chapter — coloured chapter pill shown in result

https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkJsHhLaHer5aZU1smrdgo)_