### PR TITLE
feat: support ongoing chapters with no end date

### DIFF
--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -46,6 +46,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
   const [startDay,       setStartDay]       = useState(initStart.day)
   const [startYear,      setStartYear]      = useState(initStart.year)
   const [startPrecision, setStartPrecision] = useState('month')
+  const [ongoing,        setOngoing]        = useState(existing ? !existing.end : false)
   const [endMonth,       setEndMonth]       = useState(initEnd.month)
   const [endDay,         setEndDay]         = useState(initEnd.day)
   const [endYear,        setEndYear]        = useState(initEnd.year)
@@ -68,14 +69,15 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
   const startIso = startDate ? startDate.toISOString() : null
   const endIso   = endDate   ? endDate.toISOString()   : null
 
-  // Milestones whose dates fall within [startDate, endDate]
+  // Milestones whose dates fall within [startDate, effectiveEndDate]
+  const effectiveEndDate = ongoing ? new Date() : endDate
   const inRange = useMemo(() => {
-    if (!startDate || !endDate) return []
-    if (startDate >= endDate) return []
+    if (!startDate || !effectiveEndDate) return []
+    if (startDate >= effectiveEndDate) return []
     return milestones
-      .filter(m => { const d = new Date(m.date); return d >= startDate && d <= endDate })
+      .filter(m => { const d = new Date(m.date); return d >= startDate && d <= effectiveEndDate })
       .sort((a, b) => new Date(a.date) - new Date(b.date))
-  }, [startIso, endIso, milestones])
+  }, [startIso, endIso, ongoing, milestones])
 
   const inRangeIds = useMemo(() => new Set(inRange.map(m => m.id)), [inRange])
 
@@ -108,15 +110,18 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
   function clearDateError() { setDateError(null) }
 
   function validateDates() {
-    if (!startIso || !endIso) { setDateError('both dates are required'); return false }
-    if (new Date(startIso) >= new Date(endIso)) {
-      setDateError('end date must be after start date')
-      return false
+    if (!startIso) { setDateError('start date is required'); return false }
+    if (!ongoing) {
+      if (!endIso) { setDateError('end date is required, or mark this chapter as ongoing'); return false }
+      if (new Date(startIso) >= new Date(endIso)) {
+        setDateError('end date must be after start date')
+        return false
+      }
     }
     return true
   }
 
-  const canSave = title.trim() && startIso && endIso && !busy
+  const canSave = title.trim() && startIso && (ongoing || endIso) && !busy
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -127,7 +132,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
         {
           title:                  title.trim(),
           start:                  startIso,
-          end:                    endIso,
+          end:                    ongoing ? null : endIso,
           color,
           description:            desc.trim(),
           defaultMemberVisibility: defVis,
@@ -230,55 +235,68 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
             ))}
           </div>
 
-          {/* End date */}
-          <label className="field-label" style={{ marginTop: '0.75rem' }}>to</label>
-          <div className="date-grid">
-            {endPrecision !== 'year' && (
-              <div>
-                <label className="field-label">month</label>
-                <select
-                  className="input input-sm"
-                  value={endMonth}
-                  onChange={e => { setEndMonth(e.target.value); clearDateError() }}
-                  style={{ cursor: 'pointer' }}
-                >
-                  {MONTHS.map(m => <option key={m.v} value={m.v}>{m.l}</option>)}
-                </select>
+          {/* Ongoing toggle */}
+          <label className="settings-toggle-row" style={{ marginTop: '0.75rem' }}>
+            <span className="field-label" style={{ marginBottom: 0 }}>ongoing (no end date)</span>
+            <input
+              type="checkbox"
+              className="settings-toggle"
+              checked={ongoing}
+              onChange={e => { setOngoing(e.target.checked); clearDateError() }}
+            />
+          </label>
+
+          {!ongoing && (
+            <>
+              <div className="date-grid">
+                {endPrecision !== 'year' && (
+                  <div>
+                    <label className="field-label">month</label>
+                    <select
+                      className="input input-sm"
+                      value={endMonth}
+                      onChange={e => { setEndMonth(e.target.value); clearDateError() }}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      {MONTHS.map(m => <option key={m.v} value={m.v}>{m.l}</option>)}
+                    </select>
+                  </div>
+                )}
+                {endPrecision === 'day' && (
+                  <div>
+                    <label className="field-label">day</label>
+                    <input
+                      className="input input-sm"
+                      type="number"
+                      placeholder="15"
+                      value={endDay}
+                      onChange={e => { setEndDay(e.target.value); clearDateError() }}
+                      min="1" max="31"
+                    />
+                  </div>
+                )}
+                <div>
+                  <label className="field-label">year</label>
+                  <input
+                    className="input input-sm"
+                    type="number"
+                    placeholder="2024"
+                    value={endYear}
+                    onChange={e => { setEndYear(e.target.value); clearDateError() }}
+                    min="1900" max="2100"
+                  />
+                </div>
               </div>
-            )}
-            {endPrecision === 'day' && (
-              <div>
-                <label className="field-label">day</label>
-                <input
-                  className="input input-sm"
-                  type="number"
-                  placeholder="15"
-                  value={endDay}
-                  onChange={e => { setEndDay(e.target.value); clearDateError() }}
-                  min="1" max="31"
-                />
+              <div className="precision-tabs">
+                {['day', 'month', 'year'].map(p => (
+                  <button key={p} type="button"
+                    className={`precision-tab ${endPrecision === p ? 'active' : ''}`}
+                    onClick={() => setEndPrecision(p)}
+                  >{p}</button>
+                ))}
               </div>
-            )}
-            <div>
-              <label className="field-label">year</label>
-              <input
-                className="input input-sm"
-                type="number"
-                placeholder="2024"
-                value={endYear}
-                onChange={e => { setEndYear(e.target.value); clearDateError() }}
-                min="1900" max="2100"
-              />
-            </div>
-          </div>
-          <div className="precision-tabs">
-            {['day', 'month', 'year'].map(p => (
-              <button key={p} type="button"
-                className={`precision-tab ${endPrecision === p ? 'active' : ''}`}
-                onClick={() => setEndPrecision(p)}
-              >{p}</button>
-            ))}
-          </div>
+            </>
+          )}
 
           {dateError && <div className="chapter-date-error">{dateError}</div>}
         </div>
@@ -337,7 +355,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
               <span className="chapter-member-count"> — {[...checkedIds].filter(id => displayMilestones.some(m => m.id === id)).length} selected</span>
             )}
           </label>
-          {!startIso || !endIso ? (
+          {!startIso || (!ongoing && !endIso) ? (
             <div className="chapter-members-empty">set a date range above to see milestones</div>
           ) : displayMilestones.length === 0 ? (
             <div className="chapter-members-empty">no milestones in this date range</div>
@@ -348,8 +366,8 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
                 // Only checked members can be endpoints — unchecked milestones aren't members yet.
                 const mDay        = m.date?.slice(0, 10)
                 const sDay        = startDate?.toISOString().slice(0, 10)
-                const eDay        = endDate?.toISOString().slice(0, 10)
-                const isDateMatch = !!(mDay && (mDay === sDay || mDay === eDay))
+                const eDay        = ongoing ? null : endDate?.toISOString().slice(0, 10)
+                const isDateMatch = !!(mDay && (mDay === sDay || (!ongoing && mDay === eDay)))
                 const isEndpoint  = checkedIds.has(m.id) && isDateMatch
 
                 return (

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -45,7 +45,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
     if (isEdit || year.length < 4) return []
     const date = buildDateFromParts(month, year, precision, day)
     if (!date) return []
-    return chapters.filter(ch => date >= new Date(ch.start) && date <= new Date(ch.end))
+    return chapters.filter(ch => date >= new Date(ch.start) && (ch.end === null || date <= new Date(ch.end)))
   }, [isEdit, month, day, year, precision, chapters])
 
   const [selectedChapterIds, setSelectedChapterIds] = React.useState(() => new Set())
@@ -64,6 +64,31 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
 
   function toggleChapter(id) {
     setSelectedChapterIds(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  // Ongoing chapters that this milestone's date could close (date >= chapter.start, chapter.end === null).
+  // Only in create mode; unchecked by default.
+  const closableChapters = React.useMemo(() => {
+    if (isEdit || year.length < 4) return []
+    const date = buildDateFromParts(month, year, precision, day)
+    if (!date) return []
+    return chapters.filter(ch => ch.end === null && date >= new Date(ch.start))
+  }, [isEdit, month, day, year, precision, chapters])
+
+  const [closeChapterIds, setCloseChapterIds] = React.useState(() => new Set())
+
+  // Reset close selections when the date changes
+  React.useEffect(() => {
+    if (isEdit) return
+    setCloseChapterIds(new Set())
+  }, [closableChapters, isEdit])
+
+  function toggleCloseChapter(id) {
+    setCloseChapterIds(prev => {
       const next = new Set(prev)
       next.has(id) ? next.delete(id) : next.add(id)
       return next
@@ -169,6 +194,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         url: url.trim(),
         mainTimelineVisibility: visibility,
         chapterIds: isEdit ? undefined : [...selectedChapterIds],
+        closeChapterIds: isEdit ? undefined : [...closeChapterIds],
         recurrence: (!isEdit && recurrence) ? 'annual' : (existing?.recurrence ?? null),
         recurrence_id: existing?.recurrence_id ?? null,
         recurrenceEndYear: (!isEdit && recurrence && year.length >= 4)
@@ -519,6 +545,27 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
                     className="chapter-member-check"
                     checked={selectedChapterIds.has(ch.id)}
                     onChange={() => toggleChapter(ch.id)}
+                  />
+                  <span className="chapter-member-dot" style={{ background: ch.color }} />
+                  <span className="chapter-member-title">{ch.title}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Close ongoing chapters at this milestone's date — create mode only, unchecked by default */}
+        {!isEdit && closableChapters.length > 0 && (
+          <div className="sheet-field">
+            <label className="field-label">close ongoing chapter at this date</label>
+            <div className="chapter-members-list">
+              {closableChapters.map(ch => (
+                <label key={ch.id} className="chapter-member-row">
+                  <input
+                    type="checkbox"
+                    className="chapter-member-check"
+                    checked={closeChapterIds.has(ch.id)}
+                    onChange={() => toggleCloseChapter(ch.id)}
                   />
                   <span className="chapter-member-dot" style={{ background: ch.color }} />
                   <span className="chapter-member-title">{ch.title}</span>

--- a/src/components/minimap/MinimapBar.jsx
+++ b/src/components/minimap/MinimapBar.jsx
@@ -50,14 +50,14 @@ export default function MinimapBar({ milestones, chapters = [], panMs, onPanDire
     const rowEnds = []
     return sorted.map(ch => {
       const s = new Date(ch.start).getTime()
-      const e = new Date(ch.end).getTime()
+      const e = ch.end ? new Date(ch.end).getTime() : todayMs
       let row = rowEnds.findIndex(end => end <= s)
       if (row === -1) row = rowEnds.length
       if (row >= MAX_ROWS) row = MAX_ROWS - 1  // clamp overflow into last row
       rowEnds[row] = e
       return { ...ch, _row: row }
     })
-  }, [chapters])
+  }, [chapters, todayMs])
 
   // Drag / click
   const drag = useRef({ active: false, startX: 0, startPan: 0, moved: false })
@@ -97,8 +97,9 @@ export default function MinimapBar({ milestones, chapters = [], panMs, onPanDire
 
         {/* Chapter bands — below the axis, stacked by row */}
         {chapterRows.map(ch => {
-          const x1 = Math.max(0, msToX(new Date(ch.start).getTime()))
-          const x2 = Math.min(w, msToX(new Date(ch.end).getTime()))
+          const x1      = Math.max(0, msToX(new Date(ch.start).getTime()))
+          const endMs_  = ch.end ? new Date(ch.end).getTime() : todayMs
+          const x2      = Math.min(w, msToX(endMs_))
           if (x2 <= x1) return null
           const y = BAND_TOP + ch._row * (BAND_H + BAND_GAP)
           return (

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -14,11 +14,12 @@ const REM_PX = { small: 19, normal: 22, big: 26, bigger: 30 }
 // Greedy interval-graph colouring: assigns each chapter the lowest row index that
 // doesn't conflict with an already-placed chapter in the same row.
 function assignChapterRows(chapters) {
+  const todayMs = Date.now()
   const sorted = [...chapters].sort((a, b) => new Date(a.start) - new Date(b.start))
   const rowEnds = [] // rowEnds[i] = end-time of the last chapter placed in row i
   return sorted.map(chapter => {
     const s = new Date(chapter.start).getTime()
-    const e = new Date(chapter.end).getTime()
+    const e = chapter.end ? new Date(chapter.end).getTime() : todayMs
     let row = rowEnds.findIndex(end => end <= s)
     if (row === -1) { row = rowEnds.length; rowEnds.push(e) }
     else rowEnds[row] = e
@@ -26,8 +27,9 @@ function assignChapterRows(chapters) {
   })
 }
 
-// Human-readable duration string, e.g. "4y 2mo" or "8mo".
+// Human-readable duration string, e.g. "4y 2mo" or "8mo". Returns "ongoing" for open-ended chapters.
 function chapterSpan(startIso, endIso) {
+  if (!endIso) return 'ongoing'
   const s = new Date(startIso), e = new Date(endIso)
   const totalMonths = (e.getFullYear() - s.getFullYear()) * 12 + (e.getMonth() - s.getMonth())
   const yrs = Math.floor(totalMonths / 12)
@@ -336,33 +338,68 @@ const Timeline = forwardRef(function Timeline(
             <line x1={0} y1={msAxisY} x2={w} y2={msAxisY}
               stroke="rgba(232,224,208,0.08)" strokeWidth={1} />
 
+            {/* Gradient defs for ongoing chapter fade-out past today */}
+            <defs>
+              {chaptersWithRows.filter(ch => !ch.end).map(ch => (
+                <linearGradient
+                  key={`fade-${ch.id}`}
+                  id={`chapter-fade-${ch.id}`}
+                  x1={todayX} y1={0}
+                  x2={todayX + 50} y2={0}
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop offset="0%" stopColor={ch.color} stopOpacity={0.18} />
+                  <stop offset="100%" stopColor={ch.color} stopOpacity={0} />
+                </linearGradient>
+              ))}
+            </defs>
+
             {chaptersWithRows.map(chapter => {
               const chapterStartX = dateToX(new Date(chapter.start).getTime(), startMs, endMs, w)
-              const chapterEndX   = dateToX(new Date(chapter.end).getTime(),   startMs, endMs, w)
+              const isOngoing     = !chapter.end
+
+              // For ongoing chapters the bar extends to todayX + fade width; for bounded, to chapterEndX.
+              const chapterEndX = isOngoing
+                ? todayX + 50
+                : dateToX(new Date(chapter.end).getTime(), startMs, endMs, w)
 
               // Skip chapters that are entirely off-screen
               if (chapterEndX < -10 || chapterStartX > w + 10) return null
-
-              // Clamp visible portion to viewport
-              const x1   = Math.max(0, chapterStartX)
-              const x2   = Math.min(w, chapterEndX)
-              const barW = x2 - x1
-              if (barW < 1) return null
+              // Skip ongoing chapters whose start date is still in the future (nothing has happened yet)
+              if (isOngoing && chapterStartX > todayX + 5) return null
 
               const barY = msAxisY + CHAPTER_BAND_PAD + chapter._row * (CHAPTER_ROW_H + CHAPTER_ROW_GAP)
               const barH = CHAPTER_ROW_H
+
+              // For ongoing: solid portion ends at todayX; fade portion starts there.
+              const solidX1 = Math.max(0, chapterStartX)
+              const solidX2 = isOngoing
+                ? Math.min(w, Math.max(solidX1, todayX))
+                : Math.min(w, chapterEndX)
+              const solidW  = solidX2 - solidX1
+              if (!isOngoing && solidW < 1) return null
+
+              // Fade rect for ongoing chapters (visible only when today is on-screen)
+              const fadeX1 = Math.max(0, todayX)
+              const fadeX2 = Math.min(w, todayX + 50)
+              const fadeW  = Math.max(0, fadeX2 - fadeX1)
+              const showFade = isOngoing && todayX < w && fadeW > 0
+
+              // Total visible width for label purposes
+              const visX2  = showFade ? Math.max(solidX2, fadeX2) : solidX2
+              const visW   = visX2 - solidX1
 
               // Label truncation: Courier Prime is monospace.
               // At 0.45em, char width ≈ remPx * 0.45 * 0.60 px
               const labelFontPx  = remPx * 0.45
               const labelCharW   = labelFontPx * 0.60
-              const labelMaxCh   = Math.floor((barW - 14) / labelCharW)
+              const labelMaxCh   = Math.floor((visW - 14) / labelCharW)
               const labelText    = labelMaxCh > 2
                 ? (chapter.title.length <= labelMaxCh ? chapter.title : chapter.title.slice(0, labelMaxCh - 1) + '…')
                 : ''
 
               const startYear = new Date(chapter.start).getFullYear()
-              const endYear   = new Date(chapter.end).getFullYear()
+              const endYear   = chapter.end ? new Date(chapter.end).getFullYear() : null
 
               return (
                 <g key={chapter.id}
@@ -382,11 +419,20 @@ const Timeline = forwardRef(function Timeline(
                     onChapterDoubleClick?.(chapter)
                   }}
                 >
-                  {/* Bar body */}
-                  <rect x={x1} y={barY} width={barW} height={barH}
-                    fill={chapter.color} fillOpacity={0.18}
-                    stroke={chapter.color} strokeOpacity={0.32} strokeWidth={0.5}
-                    rx={2} />
+                  {/* Solid bar body */}
+                  {solidW > 0 && (
+                    <rect x={solidX1} y={barY} width={solidW} height={barH}
+                      fill={chapter.color} fillOpacity={0.18}
+                      stroke={chapter.color} strokeOpacity={0.32} strokeWidth={0.5}
+                      rx={2} />
+                  )}
+
+                  {/* Fade tail — ongoing chapters only, past the today marker */}
+                  {showFade && (
+                    <rect x={fadeX1} y={barY} width={fadeW} height={barH}
+                      fill={`url(#chapter-fade-${chapter.id})`}
+                      rx={2} />
+                  )}
 
                   {/* Left-edge accent stripe — only when the chapter start is on-screen */}
                   {chapterStartX >= 0 && chapterStartX < w && (
@@ -395,9 +441,9 @@ const Timeline = forwardRef(function Timeline(
                   )}
 
                   {/* Title label — years zoom or closer, and bar at least 7% of viewport */}
-                  {daysPerPx < 6.0 && barW >= w * 0.07 && labelText && (
+                  {daysPerPx < 6.0 && visW >= w * 0.07 && labelText && (
                     <text
-                      x={(x1 + x2) / 2}
+                      x={(solidX1 + Math.min(solidX2, w)) / 2}
                       textAnchor="middle"
                       y={barY + Math.round(barH * 0.73)}
                       fill={chapter.color}
@@ -408,7 +454,7 @@ const Timeline = forwardRef(function Timeline(
                   )}
 
                   {/* Start/end year markers — months zoom or closer, bar at least 45% of viewport */}
-                  {daysPerPx < 0.8 && barW >= w * 0.45 && chapterStartX >= 4 && (
+                  {daysPerPx < 0.8 && visW >= w * 0.45 && chapterStartX >= 4 && (
                     <text
                       x={chapterStartX + 4}
                       y={barY + barH - 2}
@@ -418,7 +464,7 @@ const Timeline = forwardRef(function Timeline(
                       opacity={0.60}
                     >{startYear}</text>
                   )}
-                  {daysPerPx < 0.8 && barW >= w * 0.45 && chapterEndX <= w - 4 && (
+                  {!isOngoing && daysPerPx < 0.8 && visW >= w * 0.45 && chapterEndX <= w - 4 && (
                     <text
                       x={chapterEndX - 4}
                       y={barY + barH - 2}
@@ -820,7 +866,7 @@ const Timeline = forwardRef(function Timeline(
             {chapterTip.chapter.title}
           </div>
           <div style={{ fontSize: '0.55rem', color: 'rgba(232,224,208,0.55)', marginTop: 2 }}>
-            {chapterSpan(chapterTip.chapter.start, chapterTip.chapter.end)}
+            {chapterTip.chapter.end ? chapterSpan(chapterTip.chapter.start, chapterTip.chapter.end) : 'ongoing'}
           </div>
         </div>
       )}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -585,7 +585,7 @@ export default function TimelineView({ milestones, setMilestones }) {
     // photoFile / photoRemoved / mediaFile / mediaRemoved are transfer-only fields
     // from the form — strip them before passing to the data layer and handle blob
     // persistence here.
-    const { mediaFile, mediaRemoved, photoFile, photoRemoved, chapterIds, ...milestoneData } = data
+    const { mediaFile, mediaRemoved, photoFile, photoRemoved, chapterIds, closeChapterIds, ...milestoneData } = data
     const newMediaType = mediaFile
       ? (mediaFile.type.startsWith('video/') ? 'video' : 'audio')
       : null
@@ -644,15 +644,24 @@ export default function TimelineView({ milestones, setMilestones }) {
         pushHistory(newMs)
         setMilestones(newMs)
         setNewlyAddedId(m.id)
-        // Add to any chapters the user selected in the form.
-        if (chapterIds?.length) {
+        // Add to any chapters the user selected in the form, and close ongoing chapters if requested.
+        if (chapterIds?.length || closeChapterIds?.length) {
           const updated = [...chapters]
-          for (const chId of chapterIds) {
+          for (const chId of (chapterIds ?? [])) {
             const idx = updated.findIndex(c => c.id === chId)
             if (idx === -1 || updated[idx].milestoneIds.includes(m.id)) continue
             updated[idx] = await updateChapter(
               chId,
               { milestoneIds: [...updated[idx].milestoneIds, m.id] },
+              updated[idx],
+            )
+          }
+          for (const chId of (closeChapterIds ?? [])) {
+            const idx = updated.findIndex(c => c.id === chId)
+            if (idx === -1 || updated[idx].end !== null) continue
+            updated[idx] = await updateChapter(
+              chId,
+              { end: m.date },
               updated[idx],
             )
           }
@@ -731,7 +740,7 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   async function handleChapterSave(data, existing) {
     const startIso = new Date(data.start).toISOString()
-    const endIso   = new Date(data.end).toISOString()
+    const endIso   = data.end ? new Date(data.end).toISOString() : null
 
     if (existing) {
       const updated = await updateChapter(
@@ -752,7 +761,7 @@ export default function TimelineView({ milestones, setMilestones }) {
       const chapter = await createChapter({
         title:                  data.title,
         start:                  data.start,
-        end:                    data.end,
+        end:                    data.end,   // null for ongoing
         color:                  data.color,
         description:            data.description,
         defaultMemberVisibility: data.defaultMemberVisibility,
@@ -793,8 +802,9 @@ export default function TimelineView({ milestones, setMilestones }) {
     audio.playDrillIn()
 
     // Compute zoom-to-fit: center on the chapter with 15% padding each side.
+    // For ongoing chapters use today as the effective end.
     const startMs         = new Date(chapter.start).getTime()
-    const endMs           = new Date(chapter.end).getTime()
+    const endMs           = chapter.end ? new Date(chapter.end).getTime() : Date.now()
     const chapterCenterMs = (startMs + endMs) / 2
     const halfMs          = (endMs - startMs) / 2 * 1.15
     const halfYears       = halfMs / (365.25 * 24 * 3600 * 1000)
@@ -1090,7 +1100,7 @@ export default function TimelineView({ milestones, setMilestones }) {
               <button className="drill-breadcrumb-close" onClick={() => exitDrillIn()} title="exit chapter view">✕</button>
             </div>
             <div className="drill-breadcrumb-meta">
-              <span>{fmtChapterDate(drilledChapter.start)} – {fmtChapterDate(drilledChapter.end)}</span>
+              <span>{fmtChapterDate(drilledChapter.start)} – {drilledChapter.end ? fmtChapterDate(drilledChapter.end) : 'ongoing'}</span>
               <span className="drill-breadcrumb-dot">·</span>
               <span>{drilledChapter.milestoneIds.length} member{drilledChapter.milestoneIds.length !== 1 ? 's' : ''}</span>
               {drilledChapter.description && <>

--- a/src/data/chapters.js
+++ b/src/data/chapters.js
@@ -8,7 +8,7 @@ import { uid } from './milestones'
 export function buildChapter({
   title,
   start,
-  end,
+  end = null,
   color,
   description               = '',
   defaultMemberVisibility   = 'shown',
@@ -19,7 +19,7 @@ export function buildChapter({
     id:                     uid(),
     title:                  title.trim(),
     start:                  start instanceof Date ? start.toISOString() : new Date(start).toISOString(),
-    end:                    end instanceof Date   ? end.toISOString()   : new Date(end).toISOString(),
+    end:                    end === null ? null : (end instanceof Date ? end.toISOString() : new Date(end).toISOString()),
     color,
     description,
     defaultMemberVisibility,

--- a/src/utils/visibility.js
+++ b/src/utils/visibility.js
@@ -27,7 +27,7 @@ export function precomputeEndpoints(chapters) {
 
   for (const chapter of chapters) {
     const startDay = chapter.start.slice(0, 10)
-    const endDay   = chapter.end.slice(0, 10)
+    const endDay   = chapter.end ? chapter.end.slice(0, 10) : null  // null for ongoing chapters
 
     for (const milestoneId of chapter.milestoneIds) {
       // Endpoint status requires both date match AND membership — checked by
@@ -43,7 +43,7 @@ export function precomputeEndpoints(chapters) {
         endpointChapterNames.set(milestoneId, [])
       }
       // Store { chapterTitle, startDay, endDay } so getMilestoneVisibility can
-      // check date match without re-scanning chapters.
+      // check date match without re-scanning chapters. endDay is null for ongoing.
       endpointChapterNames.get(milestoneId).push({ title: chapter.title, startDay, endDay })
     }
   }
@@ -75,9 +75,10 @@ export function getMilestoneVisibility(milestone, chapters, precomputed, context
   const candidateChapters = precomputed.endpointChapterNames.get(milestone.id) ?? []
 
   // Endpoint chapters: member chapters whose start or end date matches this milestone's date.
+  // Ongoing chapters (endDay === null) can only match via their start day.
   const endpointChapters = milestoneDay
     ? candidateChapters
-        .filter(c => c.startDay === milestoneDay || c.endDay === milestoneDay)
+        .filter(c => c.startDay === milestoneDay || (c.endDay && c.endDay === milestoneDay))
         .map(c => c.title)
     : []
 


### PR DESCRIPTION
Chapters can now be marked as "ongoing" (end: null) instead of requiring a fixed end date.

- ChapterSheet: "ongoing (no end date)" toggle hides the end-date inputs; validation relaxes accordingly; milestone range uses today as the effective end when ongoing
- Timeline: ongoing ribbons render solid up to the today marker then fade to transparent over 50px via SVG linearGradient; row assignment and span label handle null end; tooltip shows "ongoing"
- MinimapBar: chapter bands clamp to today for null-end chapters
- visibility.js: endDay guarded against null (ongoing chapters have no end endpoint)
- AddMilestoneSheet: overlap detection treats null end as open-ended; new "close ongoing chapter at this date" section (unchecked by default) lets a future milestone serve as a chapter's end date
- TimelineView: closeChapterIds processed on save; drill-in uses today as effective end for zoom-to-fit; breadcrumb shows "ongoing"

https://claude.ai/code/session_015ueZ3ip1w2ZtFM9V1bCWsh