### PR TITLE
fix: sync drilledChapter after adding a milestone while drilled in

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -666,6 +666,11 @@ export default function TimelineView({ milestones, setMilestones }) {
             )
           }
           setChapters(updated)
+          // Sync drilledChapter if it was modified (new member or closed).
+          if (drilledChapter) {
+            const refreshed = updated.find(c => c.id === drilledChapter.id)
+            if (refreshed) setDrilledChapter(refreshed)
+          }
         }
         audio.playChime()
       }


### PR DESCRIPTION
When a milestone was added to a chapter (or used to close an ongoing chapter) while drilled in, the chapters[] array was updated but drilledChapter was left stale. drillMilestones filters by drilledChapter.milestoneIds, so the new milestone never appeared and any end-date change wasn't reflected until drill-out.

https://claude.ai/code/session_015ueZ3ip1w2ZtFM9V1bCWsh