### PR TITLE
fix: call audio.init() on chapter ribbon click to unlock AudioContext

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -795,6 +795,7 @@ export default function TimelineView({ milestones, setMilestones }) {
 
   // ── Drill-in (Phase 5) ───────────────────────────────────────────────────────
   function handleChapterClick(chapter) {
+    audio.init()  // chapter clicks may be the first gesture after page load
     // Clicking the ribbon while drilled in acts as a toggle — drill back out.
     if (drilledChapter) { exitDrillIn(); return }
 


### PR DESCRIPTION
playDrillIn/Out were silent if a chapter click was the first user gesture after page load — ctx was still null so getCtx() returned null and the sounds were no-ops. audio.init() is idempotent so this is safe to call on every click.

https://claude.ai/code/session_015ueZ3ip1w2ZtFM9V1bCWsh