### PR TITLE
Chapters: ongoing (no end date) support — v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Built for people who want to map their life without handing their data to a cloud service. lifeGLANCE is a privacy-first progressive web app that runs entirely in the browser. There is no account, no server, no sync — your data never leaves your device.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.5.0-brightgreen.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.5.1-brightgreen.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "date-fns": "^3.6.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Ongoing chapters** — chapters can now be marked "ongoing (no end date)" via a toggle in the chapter form; `end` is stored as `null` in the data model
- **Ribbon fade** — ongoing chapter ribbons render solid up to the today marker, then fade to transparent over 50px via SVG `linearGradient` ("future is unseen")
- **Close at milestone** — when adding a milestone whose date falls within an ongoing chapter, a new "close ongoing chapter at this date" section appears (unchecked by default), letting the milestone serve as the chapter's end date
- **Multiple ongoing chapters** supported; row assignment, minimap bands, visibility endpoint logic, and drill-in all updated to handle `null` end
- **Drill-in fixes** — chapter edits and new milestone additions now reflect immediately while drilled in (stale `drilledChapter` snapshot was the root cause); single-click the ribbon while drilled in to drill back out
- **Audio fix** — `audio.init()` now called on chapter ribbon click, so drill sounds work even if it's the first gesture after page load

## Test plan

- [ ] Create a chapter with "ongoing" checked — form saves, ribbon renders with fade past today
- [ ] Edit an existing chapter and toggle ongoing on/off — end date inputs appear/disappear correctly
- [ ] Add a milestone inside an ongoing chapter and check "close ongoing chapter at this date" — chapter gets an end date, ribbon no longer fades
- [ ] Drill into an ongoing chapter — breadcrumb shows "ongoing", zoom-to-fit uses today as effective end
- [ ] Edit a chapter while drilled in — changes appear immediately without drilling out
- [ ] Add a milestone while drilled in — milestone appears in the drilled view immediately
- [ ] Click the chapter ribbon while drilled in — drills back out with sound
- [ ] Refresh the page, click a chapter ribbon as the first action — drill-in sound plays

https://claude.ai/code/session_015ueZ3ip1w2ZtFM9V1bCWsh
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_015ueZ3ip1w2ZtFM9V1bCWsh)_