### PR TITLE
feat: show chapter duration in timeline labels when space allows

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -394,8 +394,12 @@ const Timeline = forwardRef(function Timeline(
               const labelFontPx  = remPx * 0.45
               const labelCharW   = labelFontPx * 0.60
               const labelMaxCh   = Math.floor((visW - 14) / labelCharW)
+              const durText      = chapterSpan(chapter.start, chapter.end)
+              const fullLabel    = `${chapter.title} · ${durText}`
               const labelText    = labelMaxCh > 2
-                ? (chapter.title.length <= labelMaxCh ? chapter.title : chapter.title.slice(0, labelMaxCh - 1) + '…')
+                ? (fullLabel.length <= labelMaxCh
+                    ? fullLabel
+                    : (chapter.title.length <= labelMaxCh ? chapter.title : chapter.title.slice(0, labelMaxCh - 1) + '…'))
                 : ''
 
               const startYear = new Date(chapter.start).getFullYear()


### PR DESCRIPTION
Appends the duration (e.g. "3y 5mo" or "ongoing") to each chapter bar label as "Title · duration". If the combined text is too wide for the bar, only the title is shown (truncated as before); duration is the first thing dropped when space is limited.

https://claude.ai/code/session_012uthzqoWqcJBZZuuPzRxzN