### PR TITLE
fix: remove debug logs, gate devtools to dev, validate day-of-month

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import Onboarding   from './components/onboarding/Onboarding'
 import TimelineView from './components/timeline/TimelineView'
 import { initDB, dbGetAll } from './data/db'
-import { registerDevtools } from './data/devtools'
 
 export default function App() {
   const [screen,      setScreen]      = useState('loading')  // loading | onboarding | timeline
@@ -20,7 +19,11 @@ export default function App() {
 
   useEffect(() => {
     initDB()
-      .then(() => { registerDevtools(); navigator.storage?.persist?.(); return dbGetAll() })
+      .then(() => {
+        if (import.meta.env.DEV) import('./data/devtools').then(m => m.registerDevtools())
+        navigator.storage?.persist?.()
+        return dbGetAll()
+      })
       .then((all) => {
         setMilestones(all)
         setScreen(all.length === 0 ? 'onboarding' : 'timeline')

--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -111,8 +111,22 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
 
   function validateDates() {
     if (!startIso) { setDateError('start date is required'); return false }
+    if (startPrecision === 'day' && startYear.length >= 4) {
+      const maxDay = new Date(Number(startYear), Number(startMonth), 0).getDate()
+      if (Number(startDay) < 1 || Number(startDay) > maxDay) {
+        setDateError(`start day must be between 1 and ${maxDay} for the selected month`)
+        return false
+      }
+    }
     if (!ongoing) {
       if (!endIso) { setDateError('end date is required, or mark this chapter as ongoing'); return false }
+      if (endPrecision === 'day' && endYear.length >= 4) {
+        const maxDay = new Date(Number(endYear), Number(endMonth), 0).getDate()
+        if (Number(endDay) < 1 || Number(endDay) > maxDay) {
+          setDateError(`end day must be between 1 and ${maxDay} for the selected month`)
+          return false
+        }
+      }
       if (new Date(startIso) >= new Date(endIso)) {
         setDateError('end date must be after start date')
         return false

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -147,7 +147,11 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
     }
   }, [recurrence, year])
 
-  const canSave = title.trim() && year.length >= 4
+  const dayValid = precision !== 'day' || (
+    day && Number(day) >= 1 &&
+    Number(day) <= new Date(Number(year), Number(month), 0).getDate()
+  )
+  const canSave = title.trim() && year.length >= 4 && dayValid
 
   // Determine what to show in the photo section
   const previewUrl    = photoFile ? photoObjectUrl : (!photoRemoved ? existingPhotoUrl : null)

--- a/src/data/chapters.js
+++ b/src/data/chapters.js
@@ -32,15 +32,12 @@ export function buildChapter({
 
 export async function createChapter(data) {
   const chapter = buildChapter(data)
-  console.log('[chapters] createChapter writing:', chapter)
   await dbAddChapter(chapter)
   return chapter
 }
 
 export async function getChapter(id) {
-  const chapter = await dbGetChapter(id)
-  console.log('[chapters] getChapter read:', chapter)
-  return chapter
+  return dbGetChapter(id)
 }
 
 export async function listChapters() {
@@ -54,13 +51,11 @@ export async function updateChapter(id, updates, existing) {
     id,
     updated_at: new Date().toISOString(),
   }
-  console.log('[chapters] updateChapter writing:', chapter)
   await dbPutChapter(chapter)
   return chapter
 }
 
 export async function deleteChapter(id) {
-  console.log('[chapters] deleteChapter id:', id)
   await dbDeleteChapter(id)
 }
 
@@ -74,7 +69,6 @@ export async function addMilestoneToChapter(chapterId, milestoneId) {
     milestoneIds: [...chapter.milestoneIds, milestoneId],
     updated_at:   new Date().toISOString(),
   }
-  console.log('[chapters] addMilestoneToChapter writing:', updated)
   await dbPutChapter(updated)
   return updated
 }
@@ -88,7 +82,6 @@ export async function removeMilestoneFromChapter(chapterId, milestoneId) {
     milestoneIds: chapter.milestoneIds.filter(id => id !== milestoneId),
     updated_at:   new Date().toISOString(),
   }
-  console.log('[chapters] removeMilestoneFromChapter writing:', updated)
   await dbPutChapter(updated)
   return updated
 }


### PR DESCRIPTION
- chapters.js: remove 6 console.log statements left from development
- App.jsx: load devtools via dynamic import gated on import.meta.env.DEV so window.lg is never attached in production builds
- AddMilestoneSheet: canSave now rejects day values that exceed the month's actual length (e.g. Feb 30 blocks the save button)
- ChapterSheet: validateDates now checks start/end day bounds against the selected month and surfaces a descriptive error message

https://claude.ai/code/session_012uthzqoWqcJBZZuuPzRxzN