### PR TITLE
v1.5.3 — timezone fixes and category label display

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Built for people who want to map their life without handing their data to a cloud service. lifeGLANCE is a privacy-first progressive web app that runs entirely in the browser. There is no account, no server, no sync — your data never leaves your device.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.5.2-brightgreen.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.5.3-brightgreen.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "date-fns": "^3.6.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -125,13 +125,14 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
     return () => { if (mediaObjectUrl) URL.revokeObjectURL(mediaObjectUrl) }
   }, [mediaObjectUrl])
 
-  // Pre-fill date from existing
+  // Pre-fill date from existing — use UTC methods so the form shows the same
+  // calendar date that was stored, regardless of the user's local UTC offset.
   React.useEffect(() => {
     if (existing?.date) {
       const d = new Date(existing.date)
-      setMonth(String(d.getMonth() + 1))
-      setDay(String(d.getDate()))
-      setYear(String(d.getFullYear()))
+      setMonth(String(d.getUTCMonth() + 1))
+      setDay(String(d.getUTCDate()))
+      setYear(String(d.getUTCFullYear()))
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
 
-export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday }) {
+export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday, categories = [] }) {
   const [audioUrl,  setAudioUrl]  = useState(null)
   const [photoUrl,  setPhotoUrl]  = useState(null)
   const [confirm,   setConfirm]   = useState(null) // null | 'single' | 'series'
@@ -69,7 +69,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
         {/* Category */}
         <div className="detail-category">
           <div className="detail-cat-dot" style={{ background: m.color }} />
-          {m.category}
+          {categories.find(c => c.id === m.category)?.label ?? m.category}
         </div>
 
         {/* Recurrence badge */}

--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -167,7 +167,7 @@ export default function SettingsModal({
               type="date"
               className="settings-birthday-input"
               value={birthday}
-              max={new Date().toISOString().slice(0, 10)}
+              max={(() => { const t = new Date(); return `${t.getFullYear()}-${String(t.getMonth()+1).padStart(2,'0')}-${String(t.getDate()).padStart(2,'0')}` })()}
               onChange={e => onBirthdayChange(e.target.value)}
             />
           </div>

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -491,7 +491,8 @@ const Timeline = forwardRef(function Timeline(
           const tDate    = today.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }).toLowerCase()
           const tYear    = today.getFullYear()
           const centered = Math.abs(panMs) < 1
-          const todayAge = birthday ? ageAtDate(birthday, today.toISOString().slice(0, 10)) : null
+          const todayLocalDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+          const todayAge = birthday ? ageAtDate(birthday, todayLocalDate) : null
           const lineY1   = todayAge !== null ? 68 : 54
           return (
             <g style={{

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1399,6 +1399,7 @@ export default function TimelineView({ milestones, setMilestones }) {
           onDelete={handleDelete}
           onDeleteSeries={handleDeleteSeries}
           birthday={birthday}
+          categories={categories}
         />
       )}
       {searchOpen && (

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -17,8 +17,16 @@ export function ageAtDate(birthdayStr, targetDateStr) {
   return differenceInYears(target, born)
 }
 
+// Converts a UTC-midnight ISO date string to a local Date at noon on the same
+// calendar date, so date-fns comparisons use the intended day regardless of
+// the user's UTC offset.
+function toLocalNoon(dateStr) {
+  const d = new Date(dateStr)
+  return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 12, 0, 0)
+}
+
 export function relativeLabel(dateStr, precision = 'day') {
-  const date = new Date(dateStr)
+  const date = toLocalNoon(dateStr)
   const now  = new Date()
   const past = isPast(date) && date < now
 
@@ -44,7 +52,7 @@ export function relativeLabel(dateStr, precision = 'day') {
 }
 
 export function formatDateDisplay(dateStr, precision = 'day') {
-  const date = new Date(dateStr)
+  const date = toLocalNoon(dateStr)
   if (precision === 'year')  return format(date, 'yyyy')
   if (precision === 'month') return format(date, 'MMMM yyyy')
   return format(date, 'MMMM d, yyyy')
@@ -52,7 +60,7 @@ export function formatDateDisplay(dateStr, precision = 'day') {
 
 // Returns { years, months } elapsed/remaining for count-up animation
 export function getYearsMonths(dateStr) {
-  const date = new Date(dateStr)
+  const date = toLocalNoon(dateStr)
   const now  = new Date()
   const past = date < now
   const a = past ? date : now


### PR DESCRIPTION
## Summary

- Fix timezone off-by-one causing milestone dates to display as the wrong calendar day for users outside UTC
- Fix milestone detail popup showing the internal category ID (e.g. `concerts-l3m3`) instead of the display name
- Bump version to 1.5.3

## Changes

### Timezone awareness (`src/utils/dates.js`, `AddMilestoneSheet.jsx`, `Timeline.jsx`, `SettingsModal.jsx`)

Milestone dates are stored as UTC-midnight ISO strings. Several display paths were interpreting them with local-timezone `Date` methods, causing an off-by-one day depending on the user's UTC offset.

- Added `toLocalNoon()` helper in `dates.js` that reconstructs a local `Date` from the UTC year/month/day (at noon, to sidestep DST edge cases). Applied to `formatDateDisplay`, `relativeLabel`, and `getYearsMonths`.
- Edit mode in `AddMilestoneSheet` was pre-filling the form with `getDate()`/`getMonth()`/`getFullYear()` (local time) — switched to `getUTCDate()`/`getUTCMonth()`/`getUTCFullYear()` so the stored date round-trips correctly.
- `Timeline.jsx` age display was calling `toISOString().slice(0, 10)` for "today's" date, which gives the UTC date (wrong after ~8–10 PM for users behind UTC). Fixed to use local year/month/day.
- `SettingsModal.jsx` birthday `max` attribute had the same `toISOString` issue.

### Category label in milestone detail (`MilestoneDetail.jsx`, `TimelineView.jsx`)

The detail popup rendered `m.category` directly, which is the internal ID. Custom categories have IDs like `concerts-l3m3` — not human-readable. Fixed by passing the `categories` list down from `TimelineView` and resolving the display label via lookup, with a fallback to the raw ID.

## Test plan

- [ ] Add a milestone with today's date late in the evening — confirm it appears on today, not yesterday/tomorrow
- [ ] Edit an existing milestone — confirm the date fields pre-fill with the correct calendar date
- [ ] Create a custom category, attach it to a milestone, open the detail popup — confirm the label shows the category name, not the ID
- [ ] Verify built-in categories (personal, travel, etc.) still display correctly in the detail popup

https://claude.ai/code/session_01AT9M4c8ea9Y8ANahVTJYFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AT9M4c8ea9Y8ANahVTJYFV)_