### PR TITLE
Chapter duration format harmonization and persistent storage prompt

### DIFF
--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import { saveCategories } from '../../utils/colors'
 import { isMuted, setMuted } from '../../utils/audio'
 
@@ -25,11 +25,23 @@ export default function SettingsModal({
   onClose,
   ultraCompact = false,
 }) {
-  const [newLabel,  setNewLabel]  = useState('')
-  const [newColor,  setNewColor]  = useState(COLOR_PALETTE[0])
-  const [soundOn,   setSoundOn]   = useState(() => !isMuted())
+  const [newLabel,   setNewLabel]   = useState('')
+  const [newColor,   setNewColor]   = useState(COLOR_PALETTE[0])
+  const [soundOn,    setSoundOn]    = useState(() => !isMuted())
+  const [persisted,  setPersisted]  = useState(null)
   const fileRef    = useRef(null)
   const icsFileRef = useRef(null)
+
+  useEffect(() => {
+    navigator.storage?.persisted?.()
+      .then(p => setPersisted(p))
+      .catch(() => {})
+  }, [])
+
+  async function handleRequestPersist() {
+    const granted = await navigator.storage?.persist?.()
+    setPersisted(!!granted)
+  }
 
   const usedIds = new Set(milestones.map(m => m.category))
 
@@ -194,6 +206,18 @@ export default function SettingsModal({
             <input ref={icsFileRef} type="file" accept=".ics"
               style={{ display: 'none' }} onChange={handleIcsFileChange} />
           </div>
+          {persisted === false && (
+            <div className="settings-persist-notice">
+              <span className="settings-note" style={{ marginTop: 0 }}>
+                allow persistent storage so the browser never silently clears your data.
+              </span>
+              <button
+                className="btn"
+                style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem', flexShrink: 0 }}
+                onClick={handleRequestPersist}
+              >allow persistent storage</button>
+            </div>
+          )}
           <p className="settings-note" style={{ marginTop: '0.5rem' }}>
             .ics import supports all-day events only. Timed events are skipped — the import dialog shows a count of how many were omitted.
           </p>

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -27,17 +27,17 @@ function assignChapterRows(chapters) {
   })
 }
 
-// Human-readable duration string, e.g. "4y 2mo" or "8mo". Returns "ongoing" for open-ended chapters.
+// Human-readable elapsed duration, e.g. "3 yrs, 6 mo" or "8 mo".
+// For ongoing chapters (endIso is null) uses today as the end.
 function chapterSpan(startIso, endIso) {
-  if (!endIso) return 'ongoing'
-  const s = new Date(startIso), e = new Date(endIso)
+  const s = new Date(startIso), e = endIso ? new Date(endIso) : new Date()
   const totalMonths = (e.getFullYear() - s.getFullYear()) * 12 + (e.getMonth() - s.getMonth())
   const yrs = Math.floor(totalMonths / 12)
   const mos = totalMonths % 12
-  if (yrs > 0 && mos > 0) return `${yrs}y ${mos}mo`
-  if (yrs > 0)             return `${yrs}y`
-  if (mos > 0)             return `${mos}mo`
-  return '< 1mo'
+  if (yrs > 0 && mos > 0) return `${yrs} yr${yrs !== 1 ? 's' : ''}, ${mos} mo`
+  if (yrs > 0)             return `${yrs} yr${yrs !== 1 ? 's' : ''}`
+  if (mos > 0)             return `${mos} mo`
+  return '< 1 mo'
 }
 
 // Word-wrap title to at most 2 lines given a max-chars-per-line limit.
@@ -395,7 +395,9 @@ const Timeline = forwardRef(function Timeline(
               const labelCharW   = labelFontPx * 0.60
               const labelMaxCh   = Math.floor((visW - 14) / labelCharW)
               const durText      = chapterSpan(chapter.start, chapter.end)
-              const fullLabel    = `${chapter.title} · ${durText}`
+              const fullLabel    = chapter.end
+                ? `${chapter.title} · ${durText}`
+                : `${chapter.title} · ${durText} · ongoing`
               const labelText    = labelMaxCh > 2
                 ? (fullLabel.length <= labelMaxCh
                     ? fullLabel
@@ -871,7 +873,7 @@ const Timeline = forwardRef(function Timeline(
             {chapterTip.chapter.title}
           </div>
           <div style={{ fontSize: '0.55rem', color: 'rgba(232,224,208,0.55)', marginTop: 2 }}>
-            {chapterTip.chapter.end ? chapterSpan(chapterTip.chapter.start, chapterTip.chapter.end) : 'ongoing'}
+            {chapterSpan(chapterTip.chapter.start, chapterTip.chapter.end)}{!chapterTip.chapter.end && ' · ongoing'}
           </div>
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -1485,6 +1485,18 @@ button, input, select, textarea {
   flex-wrap: wrap;
 }
 
+.settings-persist-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 /* ─── ICS Import Modal ──────────────────────────────────────────────────────── */
 /* The base .sheet already provides overflow-y: auto + max-height: 88vh.
    The actions bar is sticky so cancel/import stay visible while scrolling. */


### PR DESCRIPTION
## Summary

- **Format harmonization** (#99, #110) — chapter durations now use the same `yr`/`yrs`, `mo` style as milestone relative labels; ongoing chapters show elapsed time + `· ongoing` in both the bar label and tooltip (e.g. `College years · 3 yrs, 6 mo · ongoing`)
- **Persistent storage prompt** (#108) — Settings now detects when the browser hasn't granted persistent storage and shows a one-click notice to request it; disappears once granted, never shown again

## Test plan

- [ ] Open a closed chapter — bar label shows `Title · N yr(s)[, M mo]`; tooltip matches
- [ ] Open an ongoing chapter — bar label shows `Title · N yr(s)[, M mo] · ongoing`; tooltip matches
- [ ] Open Settings with persistence not yet granted — notice appears with button; clicking it grants and dismisses it
- [ ] Open Settings with persistence already granted — no notice shown

https://claude.ai/code/session_018Tzud2SfYwy8y6qiPGDr2H