### PR TITLE
Split help modal into Help & Feedback and Keyboard Shortcuts (v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.5.3-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.7.0-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "date-fns": "^3.6.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/help/HelpModal.jsx
+++ b/src/components/help/HelpModal.jsx
@@ -1,27 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react'
 import { version as VERSION } from '../../../package.json'
 
-const SHORTCUTS = [
-  { keys: ['←', '→'],        desc: 'cycle past / future milestones'   },
-  { keys: ['↑', '↓'],        desc: 'zoom out / in'                     },
-  { keys: ['1–9'],            desc: 'custom zoom to N years'            },
-  { keys: ['C'],              desc: 'custom zoom (focus input)'         },
-  { keys: ['T'],              desc: 'jump to today'                     },
-  { keys: ['P'],              desc: 'past view'                         },
-  { keys: ['A'],              desc: 'all view'                          },
-  { keys: ['F'],              desc: 'future view'                       },
-  { keys: ['⌘Z', 'Ctrl+Z'],  desc: 'undo'                              },
-  { keys: ['⌘⇧Z', 'Ctrl+Y'], desc: 'redo'                              },
-  { keys: ['M'],              desc: 'mute / unmute sound'               },
-  { keys: ['n'],              desc: 'new milestone'                     },
-  { keys: ['⇧N'],            desc: 'new chapter'                       },
-  { keys: ['E'],              desc: 'export image'                      },
-  { keys: ['/'],              desc: 'search milestones'                 },
-  { keys: ['S'],              desc: 'settings'                          },
-  { keys: ['?'],              desc: 'help'                              },
-  { keys: ['Esc'],            desc: 'close modal / exit chapter / exit input' },
-]
-
 function fmtBytes(n) {
   if (n == null) return '—'
   if (n < 1024)        return `${n} B`
@@ -30,7 +9,6 @@ function fmtBytes(n) {
   return `${(n / 1024 ** 3).toFixed(2)} GB`
 }
 
-// localStorage — synchronous, just settings/prefs (a few KB)
 function useLocalStorageSize() {
   return useMemo(() => {
     try {
@@ -42,7 +20,6 @@ function useLocalStorageSize() {
   }, [])
 }
 
-// IndexedDB — async via Storage API; where milestones + media blobs live
 function useIndexedDBEstimate() {
   const [est, setEst] = useState(null)
   useEffect(() => {
@@ -68,44 +45,58 @@ export default function HelpModal({ onClose }) {
           <button className="sheet-close" onClick={onClose}>✕</button>
         </div>
 
-        {/* ── Keyboard shortcuts ──────────────────────────────────────────── */}
+        {/* ── About ───────────────────────────────────────────────────────── */}
         <div className="settings-section">
-          <div className="settings-label">keyboard shortcuts</div>
-          <table className="help-shortcuts-table">
-            <tbody>
-              {SHORTCUTS.map(({ keys, desc }) => (
-                <tr key={desc}>
-                  <td className="help-keys">
-                    {keys.map(k => <kbd key={k} className="help-kbd">{k}</kbd>)}
-                  </td>
-                  <td className="help-desc">{desc}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="settings-label">about</div>
+          <p className="help-about-text">
+            <strong className="help-about-name">lifeGLANCE</strong> is a personal
+            timeline for your milestones and life chapters — all stored locally
+            in your browser, never sent anywhere.
+          </p>
+          <p className="help-about-text">
+            Add milestones with <kbd className="help-kbd">n</kbd>, create chapters
+            with <kbd className="help-kbd">⇧N</kbd>, and navigate your timeline
+            with the arrow keys. Press <kbd className="help-kbd">?</kbd> to see
+            all keyboard shortcuts.
+          </p>
+        </div>
+
+        {/* ── Data & privacy ──────────────────────────────────────────────── */}
+        <div className="settings-section">
+          <div className="settings-label">data &amp; privacy</div>
+          <p className="help-about-text">
+            Everything lives in your browser — milestones, photos, and settings.
+            Clearing site data will erase all your entries. Export a backup
+            anytime with <kbd className="help-kbd">E</kbd>.
+          </p>
+        </div>
+
+        {/* ── Storage ─────────────────────────────────────────────────────── */}
+        <div className="settings-section">
+          <div className="settings-label">storage</div>
+          <div className="help-storage-grid">
+            <span className="help-storage-label">indexedDB</span>
+            <span className="help-storage-value">
+              {idbEst ? `${fmtBytes(idbEst.usage)} used` : '…'}
+              {idbEst && (
+                <span className="help-storage-dim">
+                  {' '}/ {fmtBytes(idbEst.quota)} available
+                </span>
+              )}
+            </span>
+            <span className="help-storage-label">localStorage</span>
+            <span className="help-storage-value">
+              {localSize}
+              <span className="help-storage-dim"> (settings only)</span>
+            </span>
+          </div>
         </div>
 
         {/* ── Footer ──────────────────────────────────────────────────────── */}
         <div className="help-footer">
-          <div className="help-footer-storage">
-            <span className="help-footer-meta">
-              indexedDB&ensp;
-              <span className="help-footer-value">
-                {idbEst ? `${fmtBytes(idbEst.usage)} used` : '…'}
-              </span>
-              {idbEst && (
-                <>
-                  <span className="help-footer-dim"> / </span>
-                  <span className="help-footer-value">{fmtBytes(idbEst.quota)} available</span>
-                </>
-              )}
-            </span>
-            <span className="help-footer-meta">
-              localStorage&ensp;
-              <span className="help-footer-value">{localSize}</span>
-              <span className="help-footer-dim"> (settings only)</span>
-            </span>
-          </div>
+          <span className="help-footer-meta">
+            all data stays on your device
+          </span>
           <span className="help-footer-meta help-footer-version">v{VERSION}</span>
         </div>
 

--- a/src/components/help/HelpModal.jsx
+++ b/src/components/help/HelpModal.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { version as VERSION } from '../../../package.json'
 
 function fmtBytes(n) {
@@ -7,17 +7,6 @@ function fmtBytes(n) {
   if (n < 1024 ** 2)   return `${(n / 1024).toFixed(1)} KB`
   if (n < 1024 ** 3)   return `${(n / 1024 ** 2).toFixed(1)} MB`
   return `${(n / 1024 ** 3).toFixed(2)} GB`
-}
-
-function useLocalStorageSize() {
-  return useMemo(() => {
-    try {
-      const bytes = Object.keys(localStorage).reduce(
-        (sum, k) => sum + (localStorage.getItem(k)?.length ?? 0) * 2, 0
-      )
-      return fmtBytes(bytes)
-    } catch { return '—' }
-  }, [])
 }
 
 function useIndexedDBEstimate() {
@@ -31,9 +20,21 @@ function useIndexedDBEstimate() {
   return est
 }
 
-export default function HelpModal({ onClose }) {
-  const localSize = useLocalStorageSize()
-  const idbEst    = useIndexedDBEstimate()
+function ExternalLinkIcon() {
+  return (
+    <svg className="help-ext-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      <path d="M9 2h5v5M14 2 8 8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+export default function HelpModal({ onClose, onOpenShortcuts }) {
+  const idbEst = useIndexedDBEstimate()
+
+  const now = new Date()
+  const dateStr = now.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+  const timeStr = now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 
   return (
     <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
@@ -41,63 +42,63 @@ export default function HelpModal({ onClose }) {
 
         {/* ── Header ──────────────────────────────────────────────────────── */}
         <div className="sheet-header">
-          <span className="sheet-title">help</span>
+          <div className="help-header-title">
+            <svg className="help-header-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1.6"/>
+              <path d="M9.5 9.5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5c0 1.5-1.5 2-2.5 2.5v.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+              <circle cx="12" cy="16.5" r="0.75" fill="currentColor"/>
+            </svg>
+            <span className="sheet-title">help &amp; feedback</span>
+          </div>
           <button className="sheet-close" onClick={onClose}>✕</button>
         </div>
 
-        {/* ── About ───────────────────────────────────────────────────────── */}
+        {/* ── Contact & Issues ─────────────────────────────────────────────── */}
         <div className="settings-section">
-          <div className="settings-label">about</div>
-          <p className="help-about-text">
-            <strong className="help-about-name">lifeGLANCE</strong> is a personal
-            timeline for your milestones and life chapters — all stored locally
-            in your browser, never sent anywhere.
-          </p>
-          <p className="help-about-text">
-            Add milestones with <kbd className="help-kbd">n</kbd>, create chapters
-            with <kbd className="help-kbd">⇧N</kbd>, and navigate your timeline
-            with the arrow keys. Press <kbd className="help-kbd">?</kbd> to see
-            all keyboard shortcuts.
-          </p>
-        </div>
-
-        {/* ── Data & privacy ──────────────────────────────────────────────── */}
-        <div className="settings-section">
-          <div className="settings-label">data &amp; privacy</div>
-          <p className="help-about-text">
-            Everything lives in your browser — milestones, photos, and settings.
-            Clearing site data will erase all your entries. Export a backup
-            anytime with <kbd className="help-kbd">E</kbd>.
-          </p>
-        </div>
-
-        {/* ── Storage ─────────────────────────────────────────────────────── */}
-        <div className="settings-section">
-          <div className="settings-label">storage</div>
-          <div className="help-storage-grid">
-            <span className="help-storage-label">indexedDB</span>
-            <span className="help-storage-value">
-              {idbEst ? `${fmtBytes(idbEst.usage)} used` : '…'}
-              {idbEst && (
-                <span className="help-storage-dim">
-                  {' '}/ {fmtBytes(idbEst.quota)} available
-                </span>
-              )}
-            </span>
-            <span className="help-storage-label">localStorage</span>
-            <span className="help-storage-value">
-              {localSize}
-              <span className="help-storage-dim"> (settings only)</span>
-            </span>
+          <div className="settings-label">contact &amp; issues</div>
+          <div className="help-links">
+            <a
+              className="help-ext-link"
+              href="mailto:support@glance-apps.com"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <ExternalLinkIcon />
+              support@glance-apps.com
+            </a>
+            <a
+              className="help-ext-link"
+              href="https://github.com/krelltunez/lifeGLANCE/issues"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <ExternalLinkIcon />
+              Report an issue on GitHub
+            </a>
           </div>
         </div>
 
         {/* ── Footer ──────────────────────────────────────────────────────── */}
         <div className="help-footer">
-          <span className="help-footer-meta">
-            all data stays on your device
-          </span>
-          <span className="help-footer-meta help-footer-version">v{VERSION}</span>
+          <div className="help-footer-storage">
+            <span className="help-footer-meta">
+              Storage:&ensp;
+              <span className="help-footer-value">
+                {idbEst ? `${fmtBytes(idbEst.usage)} / ~${fmtBytes(idbEst.quota)}` : '…'}
+              </span>
+            </span>
+            <span className="help-footer-meta">
+              <span className="help-footer-value">v{VERSION}</span>
+              <span className="help-footer-dim"> · {dateStr}, {timeStr}</span>
+            </span>
+          </div>
+          <button
+            className="help-shortcuts-btn"
+            onClick={() => { onClose(); onOpenShortcuts() }}
+          >
+            <kbd className="help-kbd">?</kbd>
+            shortcuts
+          </button>
         </div>
 
       </div>

--- a/src/components/help/KeyboardShortcutsModal.jsx
+++ b/src/components/help/KeyboardShortcutsModal.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+const SHORTCUTS = [
+  { keys: ['←', '→'],        desc: 'cycle past / future milestones'        },
+  { keys: ['↑', '↓'],        desc: 'zoom out / in'                          },
+  { keys: ['1–9'],            desc: 'custom zoom to N years'                 },
+  { keys: ['C'],              desc: 'custom zoom (focus input)'              },
+  { keys: ['T'],              desc: 'jump to today'                          },
+  { keys: ['P'],              desc: 'past view'                              },
+  { keys: ['A'],              desc: 'all view'                               },
+  { keys: ['F'],              desc: 'future view'                            },
+  { keys: ['⌘Z', 'Ctrl+Z'],  desc: 'undo'                                   },
+  { keys: ['⌘⇧Z', 'Ctrl+Y'], desc: 'redo'                                   },
+  { keys: ['M'],              desc: 'mute / unmute sound'                    },
+  { keys: ['n'],              desc: 'new milestone'                          },
+  { keys: ['⇧N'],            desc: 'new chapter'                            },
+  { keys: ['E'],              desc: 'export image'                           },
+  { keys: ['/'],              desc: 'search milestones'                      },
+  { keys: ['S'],              desc: 'settings'                               },
+  { keys: ['?'],              desc: 'keyboard shortcuts'                     },
+  { keys: ['Esc'],            desc: 'close modal / exit chapter / exit input'},
+]
+
+export default function KeyboardShortcutsModal({ onClose }) {
+  return (
+    <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="sheet kbd-sheet">
+
+        <div className="sheet-header">
+          <span className="sheet-title">keyboard shortcuts</span>
+          <button className="sheet-close" onClick={onClose}>✕</button>
+        </div>
+
+        <table className="help-shortcuts-table">
+          <tbody>
+            {SHORTCUTS.map(({ keys, desc }) => (
+              <tr key={desc}>
+                <td className="help-keys">
+                  {keys.map(k => <kbd key={k} className="help-kbd">{k}</kbd>)}
+                </td>
+                <td className="help-desc">{desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+  )
+}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -4,7 +4,8 @@ import StatsPanel        from '../stats/StatsPanel'
 import AddMilestoneSheet from '../milestone/AddMilestoneSheet'
 import MilestoneDetail   from '../milestone/MilestoneDetail'
 import SettingsModal     from '../settings/SettingsModal'
-import HelpModal         from '../help/HelpModal'
+import HelpModal                from '../help/HelpModal'
+import KeyboardShortcutsModal  from '../help/KeyboardShortcutsModal'
 import SearchModal       from '../search/SearchModal'
 import SummaryModal      from '../stats/SummaryModal'
 import OnThisDayModal    from './OnThisDayModal'
@@ -56,6 +57,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   const [highlightsActive, setHighlightsActive] = useState(true)
   const [settingsOpen,  setSettingsOpen]  = useState(false)
   const [helpOpen,      setHelpOpen]      = useState(false)
+  const [kbdOpen,       setKbdOpen]       = useState(false)
   const [searchOpen,    setSearchOpen]    = useState(false)
   const [viewMode,      setViewMode]      = useState('all')
   const [recurFilter,   setRecurFilter]   = useState('next')
@@ -383,7 +385,7 @@ export default function TimelineView({ milestones, setMilestones }) {
   const keyStateRef = useRef(null)
   keyStateRef.current = {
     pastIdx, futureIdx, past, future, zoom,
-    addOpen, detail, settingsOpen, helpOpen, searchOpen, chapterSheetOpen, drilledChapter,
+    addOpen, detail, settingsOpen, helpOpen, kbdOpen, searchOpen, chapterSheetOpen, drilledChapter,
     handlePastNav, handleFutureNav, handleJumpToToday, handleViewMode, closeSheet,
     handleUndo, handleRedo, canUndo, canRedo,
     clustering, setClustering,
@@ -401,7 +403,7 @@ export default function TimelineView({ milestones, setMilestones }) {
       }
       audio.init()   // unlock AudioContext on first keystroke (idempotent)
       const s = keyStateRef.current
-      const anyModal = s.addOpen || !!s.detail || s.settingsOpen || s.helpOpen || s.searchOpen || s.chapterSheetOpen
+      const anyModal = s.addOpen || !!s.detail || s.settingsOpen || s.helpOpen || s.kbdOpen || s.searchOpen || s.chapterSheetOpen
       const anyDrillIn = !!s.drilledChapter
 
       switch (e.key) {
@@ -495,8 +497,8 @@ export default function TimelineView({ milestones, setMilestones }) {
           break
         }
         case '?': {
-          if (s.addOpen || !!s.detail || s.settingsOpen || s.searchOpen) break
-          if (!s.helpOpen) setHelpOpen(true)
+          if (s.addOpen || !!s.detail || s.settingsOpen || s.helpOpen || s.searchOpen) break
+          if (!s.kbdOpen) setKbdOpen(true)
           break
         }
         case '1': case '2': case '3': case '4': case '5':
@@ -555,6 +557,7 @@ export default function TimelineView({ milestones, setMilestones }) {
           if (s.chapterSheetOpen)      { setChapterSheetOpen(false); setEditChapter(null); break }
           if (s.settingsOpen)          { setSettingsOpen(false); break }
           if (s.helpOpen)              { setHelpOpen(false); break }
+          if (s.kbdOpen)               { setKbdOpen(false); break }
           if (s.searchOpen)            { setSearchOpen(false); break }
           if (anyDrillIn)              { s.exitDrillIn(); break }
           break
@@ -1412,6 +1415,9 @@ export default function TimelineView({ milestones, setMilestones }) {
       )}
       {helpOpen && (
         <HelpModal onClose={() => setHelpOpen(false)} />
+      )}
+      {kbdOpen && (
+        <KeyboardShortcutsModal onClose={() => setKbdOpen(false)} />
       )}
       {summaryOpen && (
         <SummaryModal

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1414,7 +1414,10 @@ export default function TimelineView({ milestones, setMilestones }) {
         />
       )}
       {helpOpen && (
-        <HelpModal onClose={() => setHelpOpen(false)} />
+        <HelpModal
+          onClose={() => setHelpOpen(false)}
+          onOpenShortcuts={() => setKbdOpen(true)}
+        />
       )}
       {kbdOpen && (
         <KeyboardShortcutsModal onClose={() => setKbdOpen(false)} />

--- a/src/index.css
+++ b/src/index.css
@@ -1610,7 +1610,42 @@ button, input, select, textarea {
 }
 
 /* ─── Help modal ───────────────────────────────────────────────────────────── */
-.help-sheet { max-width: 420px; }
+.help-sheet { max-width: 440px; }
+
+.help-about-text {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  line-height: 1.65;
+  margin: 0 0 0.6rem;
+}
+.help-about-text:last-child { margin-bottom: 0; }
+.help-about-name {
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.help-storage-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 0.75rem;
+  align-items: baseline;
+}
+.help-storage-label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.help-storage-value {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+}
+.help-storage-dim {
+  opacity: 0.55;
+}
+
+/* ─── Keyboard shortcuts modal ─────────────────────────────────────────────── */
+.kbd-sheet { max-width: 380px; }
 
 .help-shortcuts-table {
   width: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -1610,7 +1610,7 @@ button, input, select, textarea {
 }
 
 /* ─── Help modal ───────────────────────────────────────────────────────────── */
-.help-sheet { max-width: 420px; }
+.help-sheet { max-width: 483px; }
 
 .help-header-title {
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -1610,7 +1610,7 @@ button, input, select, textarea {
 }
 
 /* ─── Help modal ───────────────────────────────────────────────────────────── */
-.help-sheet { max-width: 483px; }
+.help-sheet { max-width: 450px; }
 
 .help-header-title {
   display: flex;
@@ -1676,6 +1676,7 @@ button, input, select, textarea {
   gap: 0.25rem;
   font-family: var(--font);
   font-size: 0.58rem;
+  margin-top: 0.35rem;
   color: var(--text-dim);
   background: rgba(232, 224, 208, 0.06);
   border: 1px solid rgba(232, 224, 208, 0.14);

--- a/src/index.css
+++ b/src/index.css
@@ -1672,14 +1672,14 @@ button, input, select, textarea {
 .help-shortcuts-btn {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.25rem;
   font-family: var(--font);
-  font-size: 0.68rem;
+  font-size: 0.58rem;
   color: var(--text-dim);
   background: rgba(232, 224, 208, 0.06);
   border: 1px solid rgba(232, 224, 208, 0.14);
-  border-radius: 6px;
-  padding: 0.3rem 0.65rem 0.3rem 0.5rem;
+  border-radius: 4px;
+  padding: 0.2rem 0.4rem 0.2rem 0.3rem;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   white-space: nowrap;
@@ -1688,6 +1688,11 @@ button, input, select, textarea {
 .help-shortcuts-btn:hover {
   background: rgba(232, 224, 208, 0.1);
   color: var(--text);
+}
+.help-shortcuts-btn .help-kbd {
+  font-size: 0.52rem;
+  padding: 0.1em 0.35em;
+  margin-right: 0;
 }
 
 /* ─── Keyboard shortcuts modal ─────────────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -1648,7 +1648,7 @@ button, input, select, textarea {
 .help-footer {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   padding-top: 0.75rem;
   margin-top: 0.5rem;
   border-top: 1px solid var(--border);

--- a/src/index.css
+++ b/src/index.css
@@ -1610,38 +1610,84 @@ button, input, select, textarea {
 }
 
 /* ─── Help modal ───────────────────────────────────────────────────────────── */
-.help-sheet { max-width: 440px; }
+.help-sheet { max-width: 420px; }
 
-.help-about-text {
-  font-size: 0.75rem;
-  color: var(--text-dim);
-  line-height: 1.65;
-  margin: 0 0 0.6rem;
+.help-header-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 }
-.help-about-text:last-child { margin-bottom: 0; }
-.help-about-name {
-  color: var(--text);
-  font-weight: 600;
-  letter-spacing: 0.01em;
+.help-header-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  color: var(--amber);
+  flex-shrink: 0;
 }
 
-.help-storage-grid {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.3rem 0.75rem;
-  align-items: baseline;
+.help-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
 }
-.help-storage-label {
-  font-size: 0.68rem;
+.help-ext-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--amber);
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+.help-ext-link:hover { opacity: 0.75; }
+.help-ext-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex-shrink: 0;
+}
+
+.help-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  gap: 1rem;
+}
+.help-footer-storage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.help-footer-meta {
+  font-size: 0.62rem;
   color: var(--text-muted);
-  white-space: nowrap;
 }
-.help-storage-value {
-  font-size: 0.68rem;
+.help-footer-value {
   color: var(--text-dim);
 }
-.help-storage-dim {
+.help-footer-dim {
   opacity: 0.55;
+}
+.help-shortcuts-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font);
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  background: rgba(232, 224, 208, 0.06);
+  border: 1px solid rgba(232, 224, 208, 0.14);
+  border-radius: 6px;
+  padding: 0.3rem 0.65rem 0.3rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.help-shortcuts-btn:hover {
+  background: rgba(232, 224, 208, 0.1);
+  color: var(--text);
 }
 
 /* ─── Keyboard shortcuts modal ─────────────────────────────────────────────── */
@@ -1675,42 +1721,6 @@ button, input, select, textarea {
   font-size: 0.72rem;
   color: var(--text-dim);
   vertical-align: middle;
-}
-
-.help-note {
-  font-size: 0.72rem;
-  color: var(--text-dim);
-  line-height: 1.55;
-  margin-top: 0.4rem;
-}
-
-.help-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  padding-top: 0.75rem;
-  margin-top: 0.5rem;
-  border-top: 1px solid var(--border);
-  gap: 1rem;
-}
-.help-footer-storage {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-.help-footer-meta {
-  font-size: 0.62rem;
-  color: var(--text-muted);
-}
-.help-footer-value {
-  color: var(--text-dim);
-}
-.help-footer-dim {
-  opacity: 0.55;
-}
-.help-footer-version {
-  white-space: nowrap;
-  flex-shrink: 0;
 }
 
 /* ─── Search palette ───────────────────────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -1647,14 +1647,15 @@ button, input, select, textarea {
 
 .help-footer {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-end;
   padding-top: 0.75rem;
   margin-top: 0.5rem;
   border-top: 1px solid var(--border);
-  gap: 1rem;
+  gap: 0.6rem;
 }
 .help-footer-storage {
+  align-self: flex-start;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Splits the old `?` modal** into two separate modals:
  - **Help & Feedback** (toolbar `?` button) — circle `?` icon header, contact & issues section with `support@glance-apps.com` and GitHub issues links, storage/version/date footer, and a centered shortcuts button
  - **Keyboard Shortcuts** (`?` key) — compact, focused shortcuts table
- Redesigned the help modal to match the lastGLANCE Help & Feedback layout, adapted to lifeGLANCE's amber/parchment theme
- Bumps version to **1.7.0**

## Test plan

- [ ] Press `?` → keyboard shortcuts modal opens; Escape closes it
- [ ] Click `?` in toolbar → help & feedback modal opens; Escape closes it
- [ ] Shortcuts button in help footer closes help and opens keyboard shortcuts modal
- [ ] External links (email, GitHub issues) open in a new tab
- [ ] Neither modal opens when another modal is already active
- [ ] Version badge in README and in-app footer both read `1.7.0`

https://claude.ai/code/session_01SM8SMdbpdEMemZfghRh3nu
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SM8SMdbpdEMemZfghRh3nu)_