### PR TITLE
Phase 5: lifeGLANCE adopts @glance-apps/intents protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lifeglance",
       "version": "1.7.0",
       "dependencies": {
+        "@glance-apps/intents": "1.3.2",
         "date-fns": "^3.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1628,6 +1629,18 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@glance-apps/intents": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.2.tgz",
+      "integrity": "sha512-wMwfjmKWF9jXsG1sL7GtCHV4xuD6Wi0vzYQqoyVhNcg466ffWhZIlgGopIlYAqVB+ycwNR4Hqq3RTYh0YuBWnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -6896,6 +6909,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@glance-apps/intents": "1.3.2",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/components/dayglance/IntegrationSettings.jsx
+++ b/src/components/dayglance/IntegrationSettings.jsx
@@ -1,0 +1,181 @@
+import React, { useState } from 'react'
+import { loadIntentsConfig, saveIntentsConfig, DEFAULT_CONFIG } from '../../lib/intentsTransport.js'
+
+// Section shown inside SettingsModal for the dayGLANCE integration.
+// All integration UI is gated behind the user enabling the integration and
+// providing a WebDAV URL — standalone mode (no config) hides this entirely
+// from the parent via the isIntegrationEnabled() check.
+export default function IntegrationSettings() {
+  const [cfg, setCfg] = useState(loadIntentsConfig)
+  const [testStatus, setTestStatus] = useState(null) // null | 'testing' | 'ok' | 'error'
+  const [testMsg,    setTestMsg]    = useState('')
+
+  function update(partial) {
+    setCfg(prev => {
+      const next = { ...prev, ...partial }
+      saveIntentsConfig(next)
+      return next
+    })
+  }
+
+  async function handleTest() {
+    setTestStatus('testing')
+    setTestMsg('')
+    try {
+      const base = cfg.webdavUrl.replace(/\/$/, '')
+      const dir  = cfg.eventsPath.endsWith('/') ? cfg.eventsPath : cfg.eventsPath + '/'
+      const url  = cfg.corsProxy
+        ? `${cfg.corsProxy.replace(/\/$/, '')}?url=${encodeURIComponent(base + dir)}`
+        : `${base}${dir}`
+      const headers = {}
+      if (cfg.webdavUser) {
+        headers['Authorization'] = 'Basic ' + btoa(`${cfg.webdavUser}:${cfg.webdavPass}`)
+      }
+      const res = await fetch(url, {
+        method:  'PROPFIND',
+        headers: { ...headers, 'Depth': '0', 'Content-Type': 'application/xml' },
+        body:    '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:displayname/></d:prop></d:propfind>',
+      })
+      if (res.ok || res.status === 207) {
+        setTestStatus('ok')
+        setTestMsg('Connected — events directory is reachable.')
+      } else if (res.status === 404) {
+        setTestStatus('error')
+        setTestMsg(`Events directory not found (404). Create it first: ${cfg.eventsPath}`)
+      } else {
+        setTestStatus('error')
+        setTestMsg(`Unexpected response: ${res.status} ${res.statusText}`)
+      }
+    } catch (err) {
+      setTestStatus('error')
+      setTestMsg(`Connection failed: ${err.message}`)
+    }
+  }
+
+  const hasUrl = !!cfg.webdavUrl.trim()
+
+  return (
+    <div className="settings-section">
+      <div className="settings-label">dayGLANCE integration</div>
+
+      <label className="settings-toggle-row">
+        <span className="settings-toggle-label">enable Goal↔Milestone linking</span>
+        <input
+          type="checkbox"
+          className="settings-toggle"
+          checked={cfg.enabled}
+          onChange={e => update({ enabled: e.target.checked })}
+        />
+      </label>
+
+      {cfg.enabled && (
+        <>
+          <div className="settings-intents-field">
+            <label className="field-label" style={{ fontSize: '0.72rem' }}>
+              WebDAV base URL
+            </label>
+            <input
+              className="input input-sm"
+              type="url"
+              placeholder="https://cloud.example.com/remote.php/dav/files/user"
+              value={cfg.webdavUrl}
+              onChange={e => update({ webdavUrl: e.target.value })}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-intents-row">
+            <div className="settings-intents-field" style={{ flex: 1 }}>
+              <label className="field-label" style={{ fontSize: '0.72rem' }}>Username</label>
+              <input
+                className="input input-sm"
+                type="text"
+                placeholder="user"
+                value={cfg.webdavUser}
+                onChange={e => update({ webdavUser: e.target.value })}
+                autoComplete="username"
+              />
+            </div>
+            <div className="settings-intents-field" style={{ flex: 1 }}>
+              <label className="field-label" style={{ fontSize: '0.72rem' }}>Password / token</label>
+              <input
+                className="input input-sm"
+                type="password"
+                placeholder="••••••••"
+                value={cfg.webdavPass}
+                onChange={e => update({ webdavPass: e.target.value })}
+                autoComplete="current-password"
+              />
+            </div>
+          </div>
+
+          <div className="settings-intents-field">
+            <label className="field-label" style={{ fontSize: '0.72rem' }}>
+              Events path <span className="settings-note" style={{ marginTop: 0 }}>(default: /GLANCE/events/)</span>
+            </label>
+            <input
+              className="input input-sm"
+              type="text"
+              placeholder="/GLANCE/events/"
+              value={cfg.eventsPath}
+              onChange={e => update({ eventsPath: e.target.value })}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-intents-field">
+            <label className="field-label" style={{ fontSize: '0.72rem' }}>
+              CORS proxy URL <span className="settings-note" style={{ marginTop: 0 }}>(optional)</span>
+            </label>
+            <input
+              className="input input-sm"
+              type="url"
+              placeholder="https://my-proxy.vercel.app/api/webdav"
+              value={cfg.corsProxy}
+              onChange={e => update({ corsProxy: e.target.value })}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-intents-row" style={{ alignItems: 'center', gap: '0.75rem', marginTop: '0.25rem' }}>
+            <button
+              className="btn"
+              style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+              disabled={!hasUrl || testStatus === 'testing'}
+              onClick={handleTest}
+            >
+              {testStatus === 'testing' ? 'testing…' : 'test connection'}
+            </button>
+            {testStatus && testStatus !== 'testing' && (
+              <span className={`settings-note ${testStatus === 'ok' ? 'intents-test-ok' : 'intents-test-err'}`}
+                style={{ marginTop: 0 }}>
+                {testMsg}
+              </span>
+            )}
+          </div>
+
+          <div className="settings-intents-field" style={{ marginTop: '0.5rem' }}>
+            <label className="field-label" style={{ fontSize: '0.72rem' }}>
+              Poll interval (minutes)
+            </label>
+            <input
+              className="input input-sm"
+              type="number"
+              min="1"
+              max="30"
+              style={{ width: '5rem' }}
+              value={cfg.pollIntervalMin}
+              onChange={e => update({ pollIntervalMin: Math.max(1, Math.min(30, Number(e.target.value))) })}
+            />
+          </div>
+
+          <p className="settings-note" style={{ marginTop: '0.5rem' }}>
+            lifeGLANCE and dayGLANCE must point at the same WebDAV endpoint and
+            events path. Milestones you mark "track as dayGLANCE Goal" will appear
+            as tasks in dayGLANCE; Goal completions and date changes sync back here.
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -3,6 +3,7 @@ import { DEFAULT_CATEGORIES } from '../../utils/colors'
 import { buildDateFromParts } from '../../utils/dates'
 import { dbGetPhoto } from '../../data/db'
 import { getMilestoneVisibility } from '../../utils/visibility'
+import { isIntegrationEnabled } from '../../lib/intentsTransport.js'
 
 const MONTHS = [
   { v: '1',  l: 'Jan' }, { v: '2',  l: 'Feb' }, { v: '3',  l: 'Mar' },
@@ -32,9 +33,11 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
   const [mediaFile,     setMediaFile]     = useState(null)   // new File selected this session
   const [mediaRemoved,  setMediaRemoved]  = useState(false)  // user cleared existing media
   const [mediaObjectUrl, setMediaObjectUrl] = useState(null) // transient preview URL
-  const [recurrence,    setRecurrence]    = useState(false)
-  const [recEndYear,    setRecEndYear]    = useState('')
-  const [visibility,    setVisibility]    = useState(existing?.mainTimelineVisibility ?? 'inherit')
+  const [recurrence,      setRecurrence]      = useState(false)
+  const [recEndYear,      setRecEndYear]      = useState('')
+  const [visibility,      setVisibility]      = useState(existing?.mainTimelineVisibility ?? 'inherit')
+  const [trackAsDg,       setTrackAsDg]       = useState(existing?.dayglance_linked ?? false)
+  const integrationActive = isIntegrationEnabled()
   const [busy,          setBusy]          = useState(false)
   const photoRef = useRef(null)
   const mediaRef = useRef(null)
@@ -205,6 +208,12 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
         recurrenceEndYear: (!isEdit && recurrence && year.length >= 4)
           ? (recEndYear ? Number(recEndYear) : Math.max(Number(year), new Date().getFullYear()) + 3)
           : undefined,
+        trackAsDayglanceGoal: integrationActive ? trackAsDg : false,
+        // Preserve existing dayGLANCE link state in edit mode
+        dayglance_linked:       isEdit ? (existing?.dayglance_linked ?? false) : undefined,
+        dayglance_task_id:      isEdit ? (existing?.dayglance_task_id ?? null)  : undefined,
+        dayglance_completed:    isEdit ? (existing?.dayglance_completed ?? false) : undefined,
+        dayglance_completed_at: isEdit ? (existing?.dayglance_completed_at ?? null) : undefined,
       }, existing)
       onClose()
     } finally {
@@ -537,6 +546,37 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, categorie
             )}
           </div>
         )}
+
+        {/* dayGLANCE Goal tracking — shown when integration is enabled */}
+        {integrationActive && (() => {
+          // Show in edit mode for future-dated or already-linked milestones,
+          // and in create mode whenever a future year is entered.
+          const isFuture = isEdit
+            ? (existing?.direction === 'future' || existing?.dayglance_linked)
+            : (year.length >= 4 && Number(year) >= new Date().getFullYear())
+          if (!isFuture) return null
+          return (
+            <div className="sheet-field">
+              <label className="recurrence-toggle-row">
+                <span className="field-label" style={{ marginBottom: 0 }}>
+                  track as dayGLANCE Goal
+                </span>
+                <input
+                  type="checkbox"
+                  className="settings-toggle"
+                  checked={trackAsDg}
+                  onChange={e => setTrackAsDg(e.target.checked)}
+                />
+              </label>
+              {trackAsDg && (
+                <p className="settings-note" style={{ marginTop: '0.35rem' }}>
+                  A task will be created in dayGLANCE. Date changes and Goal
+                  completions sync back here via your WebDAV events directory.
+                </p>
+              )}
+            </div>
+          )
+        })()}
 
         {/* Chapter membership suggestion — create mode only */}
         {!isEdit && overlappingChapters.length > 0 && (

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -77,6 +77,23 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
           <div className="detail-recurrence">↻ repeats annually</div>
         )}
 
+        {/* dayGLANCE link badges */}
+        {m.dayglance_linked && !m.dayglance_completed && (
+          <div className="detail-dg-badge">
+            <span className="detail-dg-icon">◈</span> tracked in dayGLANCE
+          </div>
+        )}
+        {m.dayglance_completed && (
+          <div className="detail-dg-badge detail-dg-badge--done">
+            <span className="detail-dg-icon">✓</span> completed in dayGLANCE
+            {m.dayglance_completed_at && (
+              <span className="detail-dg-when">
+                {' '}· {new Date(m.dayglance_completed_at).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+        )}
+
         {/* Media (audio / video) */}
         {audioUrl && (
           <div className="detail-audio-wrap">

--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react'
 import { saveCategories } from '../../utils/colors'
 import { isMuted, setMuted } from '../../utils/audio'
+import IntegrationSettings from '../dayglance/IntegrationSettings'
 
 const TEXT_SIZES_ALL = ['small', 'normal', 'big', 'bigger']
 
@@ -222,6 +223,8 @@ export default function SettingsModal({
             .ics import supports all-day events only. Timed events are skipped — the import dialog shows a count of how many were omitted.
           </p>
         </div>
+
+        <IntegrationSettings />
       </div>
     </div>
   )

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -22,6 +22,9 @@ import ChapterSheet from '../chapter/ChapterSheet'
 import { dbPutMedia, dbPutPhoto, dbDeletePhoto, dbGetPhoto, dbPut } from '../../data/db'
 import { parseIcs }      from '../../utils/icsParser'
 import * as audio from '../../utils/audio'
+import { useIntentPoller } from '../../hooks/useIntentPoller.js'
+import { emitCreateForMilestone, emitRescheduledNotify, isIntegrationEnabled } from '../../lib/intentsTransport.js'
+import { NOTIFY_EVENTS, SOURCE_APP_DAYGLANCE } from '../../lib/intents.js'
 
 const ZOOM_RANK = { decades: 5, '30yr': 4, years: 3, months: 2, weeks: 1, custom: 3.5 }
 
@@ -158,6 +161,83 @@ export default function TimelineView({ milestones, setMilestones }) {
     listChapters().then(setChapters).catch(console.error)
   }, [])
 
+  // ── dayGLANCE intents integration (Phase 5) ───────────────────────────────────
+
+  // Stable ref so poller callbacks always see current milestones without re-registering.
+  const milestonesRef = useRef(milestones)
+  useEffect(() => { milestonesRef.current = milestones }, [milestones])
+
+  // Inbound: dayGLANCE pushed a new Goal → create a mirrored milestone here.
+  const handleInboundCreate = useCallback(async (payload) => {
+    if (!payload.title) return
+    try {
+      const m = await addMilestone({
+        title:            payload.title,
+        date:             payload.due ? new Date(payload.due) : new Date(),
+        date_precision:   'day',
+        note:             payload.notes ?? '',
+        dayglance_linked: true,
+        // source_entity_id is the dayGLANCE task id for this goal
+        dayglance_task_id: payload.source_entity_id ?? null,
+      })
+      setMilestones(prev => {
+        const next = [...prev, m]
+        pushHistory(next)
+        return next
+      })
+      showToast(`dayGLANCE Goal added: "${m.title}"`, 'success')
+    } catch (err) {
+      console.error('[intents] inbound create failed:', err)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Inbound: dayGLANCE notifying of a state change on one of our milestones.
+  const handleInboundNotify = useCallback(async (payload) => {
+    const { event, source_entity_id, due, previous_due, completed_at, title } = payload
+    const current = milestonesRef.current.find(m => m.id === source_entity_id)
+    if (!current) return
+
+    try {
+      if (event === NOTIFY_EVENTS.COMPLETED) {
+        const updated = await updateMilestone(current.id, {
+          dayglance_completed:    true,
+          dayglance_completed_at: completed_at ?? new Date().toISOString(),
+        }, current)
+        setMilestones(prev => prev.map(m => m.id === current.id ? updated : m))
+        showToast(`Goal completed in dayGLANCE: "${current.title}"`, 'success')
+
+      } else if (event === NOTIFY_EVENTS.RESCHEDULED && due) {
+        const updated = await updateMilestone(current.id, { date: new Date(due) }, current)
+        setMilestones(prev => prev.map(m => m.id === current.id ? updated : m))
+
+      } else if (event === NOTIFY_EVENTS.UPDATED && title && title !== current.title) {
+        const updated = await updateMilestone(current.id, { title }, current)
+        setMilestones(prev => prev.map(m => m.id === current.id ? updated : m))
+
+      } else if (event === NOTIFY_EVENTS.DELETED) {
+        showToast(`dayGLANCE Goal deleted — "${current.title}" still exists here.`, 'info')
+
+      } else if (event === NOTIFY_EVENTS.UNCOMPLETED) {
+        const updated = await updateMilestone(current.id, {
+          dayglance_completed:    false,
+          dayglance_completed_at: null,
+        }, current)
+        setMilestones(prev => prev.map(m => m.id === current.id ? updated : m))
+      }
+    } catch (err) {
+      console.error('[intents] inbound notify handler failed:', err)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const intentsConfig = isIntegrationEnabled()
+    ? JSON.parse(localStorage.getItem('lifeglance-intents-config') || '{}')
+    : null
+
+  useIntentPoller({
+    onInboundCreate:  handleInboundCreate,
+    onInboundNotify:  handleInboundNotify,
+    intervalMin:      intentsConfig?.pollIntervalMin ?? 2,
+  })
 
   // Restrict text size: big/bigger cards overflow the axis on short screens.
   useEffect(() => {
@@ -588,7 +668,8 @@ export default function TimelineView({ milestones, setMilestones }) {
     // photoFile / photoRemoved / mediaFile / mediaRemoved are transfer-only fields
     // from the form — strip them before passing to the data layer and handle blob
     // persistence here.
-    const { mediaFile, mediaRemoved, photoFile, photoRemoved, chapterIds, closeChapterIds, ...milestoneData } = data
+    const { mediaFile, mediaRemoved, photoFile, photoRemoved, chapterIds, closeChapterIds,
+            trackAsDayglanceGoal, ...milestoneData } = data
     const newMediaType = mediaFile
       ? (mediaFile.type.startsWith('video/') ? 'video' : 'audio')
       : null
@@ -609,6 +690,12 @@ export default function TimelineView({ milestones, setMilestones }) {
         pushHistory(newMs)
         setMilestones(newMs)
         audio.playEditSave()
+        // Emit rescheduled notify if this milestone is linked and the date changed.
+        if (updated.dayglance_linked && existing.date !== updated.date) {
+          emitRescheduledNotify(updated, existing.date).catch(err =>
+            console.warn('[intents] rescheduled emit failed:', err)
+          )
+        }
       } else if (milestoneData.recurrence === 'annual') {
         // Generate one instance per year from base year to chosen end year (max +99)
         const rid      = uid()
@@ -640,13 +727,25 @@ export default function TimelineView({ milestones, setMilestones }) {
         setNewlyAddedId(created[0].id)
         audio.playChime()
       } else {
-        const m = await addMilestone({ ...milestoneData, media_type: newMediaType, has_photo: !!photoFile })
+        const dgLinked = !!trackAsDayglanceGoal
+        const m = await addMilestone({
+          ...milestoneData,
+          media_type:       newMediaType,
+          has_photo:        !!photoFile,
+          dayglance_linked: dgLinked,
+        })
         if (mediaFile) await dbPutMedia(m.id, mediaFile, mediaFile.type)
         if (photoFile) await dbPutPhoto(m.id, photoFile, photoFile.type)
         const newMs = [...milestones, m]
         pushHistory(newMs)
         setMilestones(newMs)
         setNewlyAddedId(m.id)
+        // Emit outbound create to dayGLANCE if the user checked "track as dayGLANCE Goal".
+        if (dgLinked) {
+          emitCreateForMilestone(m).catch(err =>
+            console.warn('[intents] create emit failed:', err)
+          )
+        }
         // Add to any chapters the user selected in the form, and close ongoing chapters if requested.
         if (chapterIds?.length || closeChapterIds?.length) {
           const updated = [...chapters]

--- a/src/data/db.js
+++ b/src/data/db.js
@@ -1,5 +1,5 @@
 const DB_NAME    = 'lifeglance'
-const DB_VERSION = 5          // v5: rename eras store to chapters
+const DB_VERSION = 6          // v6: dayGLANCE intent linking fields on milestones
 const STORE      = 'milestones'
 const CHAPTERS   = 'chapters'
 const MEDIA      = 'media'
@@ -105,6 +105,31 @@ export function initDB() {
             dest.put(c.value)
             c.continue()
           }
+        }
+      }
+
+      // v6 — dayGLANCE intent linking fields on milestones
+      if (e.oldVersion < 6) {
+        const s = e.target.transaction.objectStore(STORE)
+        let migratedCount = 0
+        s.openCursor().onsuccess = ev => {
+          const c = ev.target.result
+          if (!c) {
+            console.log(`[lifeGLANCE v6 migration] dayGLANCE fields added to ${migratedCount} milestone(s)`)
+            return
+          }
+          const rec = c.value
+          if (!('dayglance_linked' in rec)) {
+            c.update({
+              ...rec,
+              dayglance_linked:       false,
+              dayglance_task_id:      null,
+              dayglance_completed:    false,
+              dayglance_completed_at: null,
+            })
+            migratedCount++
+          }
+          c.continue()
         }
       }
     }

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -25,6 +25,11 @@ export function buildMilestone({
   recurrence     = null,   // null | 'annual'
   recurrence_id  = null,   // UUID shared across instances of a series
   mainTimelineVisibility = 'inherit',
+  // dayGLANCE intent linking (Phase 5)
+  dayglance_linked       = false,
+  dayglance_task_id      = null,
+  dayglance_completed    = false,
+  dayglance_completed_at = null,
 }) {
   const dateObj = date instanceof Date ? date : new Date(date)
   const today   = new Date()
@@ -45,6 +50,10 @@ export function buildMilestone({
     recurrence,
     recurrence_id,
     mainTimelineVisibility,
+    dayglance_linked,
+    dayglance_task_id,
+    dayglance_completed,
+    dayglance_completed_at,
     created_at:     now,
     updated_at:     now,
   }
@@ -97,6 +106,10 @@ export async function restoreMilestones(items) {
   await dbClearAllMedia()
   const clean = items.map(({ photo_uri: _discard, ...m }) => ({
     mainTimelineVisibility: 'inherit',   // default for backups that predate v4
+    dayglance_linked:       false,
+    dayglance_task_id:      null,
+    dayglance_completed:    false,
+    dayglance_completed_at: null,
     ...m,
     media_type: null,
     has_photo:  false,

--- a/src/hooks/useIntentPoller.js
+++ b/src/hooks/useIntentPoller.js
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { pollEvents, isIntegrationEnabled } from '../lib/intentsTransport.js'
+import { ACTIONS, NOTIFY_EVENTS, SOURCE_APP_LIFEGLANCE, SOURCE_APP_DAYGLANCE } from '../lib/intents.js'
+
+// Polls the WebDAV events directory while the component is mounted (foreground).
+// Calls the appropriate handler for each inbound event:
+//   onInboundCreate(payload)  — dayGLANCE pushed a new Goal → create milestone
+//   onInboundNotify(payload)  — state change on a lG-originated task in dayGLANCE
+//   onActivityEntry(entry)    — optional; receives { type, filename, payload } for the activity log
+//
+// Polling runs immediately on mount, then every `intervalMin` minutes (default 2).
+export function useIntentPoller({
+  onInboundCreate,
+  onInboundNotify,
+  onActivityEntry,
+  intervalMin = 2,
+}) {
+  // Keep handler refs stable so the interval closure always sees the latest props.
+  const createRef  = useRef(onInboundCreate)
+  const notifyRef  = useRef(onInboundNotify)
+  const activityRef = useRef(onActivityEntry)
+  useEffect(() => { createRef.current  = onInboundCreate  }, [onInboundCreate])
+  useEffect(() => { notifyRef.current  = onInboundNotify  }, [onInboundNotify])
+  useEffect(() => { activityRef.current = onActivityEntry }, [onActivityEntry])
+
+  const runPoll = useCallback(async () => {
+    if (!isIntegrationEnabled()) return
+
+    await pollEvents(async (envelope) => {
+      const { action, payload, event_id, emitted_by } = envelope
+      activityRef.current?.({ type: 'received', event_id, action, emitted_by, payload })
+
+      if (action === ACTIONS.CREATE && emitted_by === SOURCE_APP_DAYGLANCE) {
+        // dayGLANCE is pushing a new Goal → create a mirrored milestone in lifeGLANCE.
+        await createRef.current?.(payload)
+      } else if (action === ACTIONS.NOTIFY && payload.source_app === SOURCE_APP_LIFEGLANCE) {
+        // dayGLANCE is reporting a state change on one of our tasks.
+        await notifyRef.current?.(payload)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    runPoll()
+    const ms = Math.max(1, intervalMin) * 60 * 1000
+    const id = setInterval(runPoll, ms)
+    return () => clearInterval(id)
+  }, [runPoll, intervalMin])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2258,3 +2258,47 @@ button, input, select, textarea {
 .timeline-zoom-wrap[style] {
   box-shadow: inset 2px 0 0 color-mix(in srgb, var(--drill-color) 40%, transparent);
 }
+
+/* ── dayGLANCE integration (Phase 5) ─────────────────────────────────────── */
+
+/* Toast variants */
+.toast-success {
+  background: #2d6a35;
+  border-left: 3px solid #4ade80;
+}
+
+/* Milestone detail — dayGLANCE link badge */
+.detail-dg-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--accent, #60a5fa);
+  margin: 0.2rem 0;
+  opacity: 0.9;
+}
+.detail-dg-badge--done {
+  color: #4ade80;
+}
+.detail-dg-icon {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+.detail-dg-when {
+  opacity: 0.7;
+}
+
+/* Integration settings section */
+.settings-intents-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.5rem;
+}
+.settings-intents-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.intents-test-ok  { color: #4ade80; }
+.intents-test-err { color: #f87171; }

--- a/src/lib/intents.js
+++ b/src/lib/intents.js
@@ -1,0 +1,84 @@
+// Local implementation of the @glance-apps/intents@1.3.2 public API.
+// Provides schema constants, envelope helpers, and idempotency utilities
+// as specified in docs/dayglance-intent-protocol.md.
+
+export const SCHEMA_VERSION = 1
+
+export const SOURCE_APP_LIFEGLANCE = 'app.lifeglance'
+export const SOURCE_APP_DAYGLANCE  = 'app.dayglance'
+
+export const ACTIONS = {
+  CREATE:   'create',
+  COMPLETE: 'complete',
+  OPEN:     'open',
+  QUERY:    'query',
+  NOTIFY:   'notify',
+}
+
+export const NOTIFY_EVENTS = {
+  COMPLETED:   'completed',
+  UNCOMPLETED: 'uncompleted',
+  DELETED:     'deleted',
+  RESCHEDULED: 'rescheduled',
+  UPDATED:     'updated',
+}
+
+// Generates a new event ID in the format yyyyMMddTHHmmssZ-rrr (where rrr is 3 random hex bytes).
+export function eventId() {
+  const now = new Date()
+  const pad = (n, w = 2) => String(n).padStart(w, '0')
+  const ts =
+    String(now.getUTCFullYear()) +
+    pad(now.getUTCMonth() + 1) +
+    pad(now.getUTCDate()) +
+    'T' +
+    pad(now.getUTCHours()) +
+    pad(now.getUTCMinutes()) +
+    pad(now.getUTCSeconds()) +
+    'Z'
+  const suffix = Array.from(crypto.getRandomValues(new Uint8Array(3)))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+  return `${ts}-${suffix}`
+}
+
+// Returns the filename for a given event ID.
+export function filenameFor(evtId) {
+  return `${evtId}.json`
+}
+
+// Returns a stable dedup key for create-action idempotency.
+export function createKey(sourceApp, sourceEntityId, due) {
+  return `${sourceApp}:${sourceEntityId}:${due ?? ''}`
+}
+
+// Builds a WebDAV event file envelope object ready for JSON.stringify.
+export function buildEnvelope(emittedBy, action, payload) {
+  const id = eventId()
+  return {
+    schema_version: SCHEMA_VERSION,
+    event_id:       id,
+    emitted_at:     new Date().toISOString(),
+    emitted_by:     emittedBy,
+    action,
+    payload,
+  }
+}
+
+// Parses and validates a raw envelope object from a WebDAV event file.
+// Throws on malformed or unsupported input.
+export function parseEnvelope(obj) {
+  if (!obj || typeof obj !== 'object') throw new Error('Invalid envelope: not an object')
+  if (obj.schema_version !== SCHEMA_VERSION)
+    throw new Error(`Unsupported schema_version: ${obj.schema_version}`)
+  if (!obj.action)  throw new Error('Invalid envelope: missing action')
+  if (!obj.payload) throw new Error('Invalid envelope: missing payload')
+  return {
+    schema_version: obj.schema_version,
+    event_id:       obj.event_id,
+    emitted_at:     obj.emitted_at,
+    emitted_by:     obj.emitted_by,
+    action:         obj.action,
+    payload:        obj.payload,
+  }
+}

--- a/src/lib/intentsTransport.js
+++ b/src/lib/intentsTransport.js
@@ -1,0 +1,204 @@
+// WebDAV transport for the @glance-apps/intents protocol.
+// Handles config persistence, event file emission, and polling for inbound events.
+
+import {
+  buildEnvelope,
+  parseEnvelope,
+  filenameFor,
+  SOURCE_APP_LIFEGLANCE,
+  ACTIONS,
+  NOTIFY_EVENTS,
+} from './intents.js'
+
+const CONFIG_KEY = 'lifeglance-intents-config'
+const CURSOR_KEY = 'lifeglance-intents-cursor'
+
+export const DEFAULT_CONFIG = {
+  enabled:        false,
+  webdavUrl:      '',   // https://cloud.example.com/remote.php/dav/files/user
+  webdavUser:     '',
+  webdavPass:     '',
+  eventsPath:     '/GLANCE/events/',
+  corsProxy:      '',   // optional: prepends to full URL for CORS bypass
+  pollIntervalMin: 2,
+}
+
+export function loadIntentsConfig() {
+  try {
+    const raw = localStorage.getItem(CONFIG_KEY)
+    return raw ? { ...DEFAULT_CONFIG, ...JSON.parse(raw) } : { ...DEFAULT_CONFIG }
+  } catch {
+    return { ...DEFAULT_CONFIG }
+  }
+}
+
+export function saveIntentsConfig(cfg) {
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(cfg))
+}
+
+export function isIntegrationEnabled() {
+  const cfg = loadIntentsConfig()
+  return cfg.enabled && !!cfg.webdavUrl.trim()
+}
+
+function loadCursor() {
+  return localStorage.getItem(CURSOR_KEY) ?? ''
+}
+
+function saveCursor(cursor) {
+  localStorage.setItem(CURSOR_KEY, cursor)
+}
+
+// Builds a full URL for a path inside the events directory (with optional CORS proxy).
+function eventsUrl(cfg, filename = '') {
+  const base   = cfg.webdavUrl.replace(/\/$/, '')
+  const dir    = cfg.eventsPath.endsWith('/') ? cfg.eventsPath : cfg.eventsPath + '/'
+  const full   = `${base}${dir}${filename}`
+  return cfg.corsProxy ? `${cfg.corsProxy.replace(/\/$/, '')}?url=${encodeURIComponent(full)}` : full
+}
+
+function authHeaders(cfg) {
+  if (!cfg.webdavUser) return {}
+  return { Authorization: 'Basic ' + btoa(`${cfg.webdavUser}:${cfg.webdavPass}`) }
+}
+
+// PUT a JSON envelope as a new event file in the WebDAV events directory.
+async function putEventFile(cfg, envelope) {
+  const url = eventsUrl(cfg, filenameFor(envelope.event_id))
+  const res = await fetch(url, {
+    method:  'PUT',
+    headers: { ...authHeaders(cfg), 'Content-Type': 'application/json' },
+    body:    JSON.stringify(envelope),
+  })
+  if (!res.ok) throw new Error(`WebDAV PUT failed: ${res.status} ${res.statusText}`)
+}
+
+// PROPFIND the events directory and return a sorted list of .json filenames.
+async function listEventFiles(cfg) {
+  const url = eventsUrl(cfg)
+  const res = await fetch(url, {
+    method:  'PROPFIND',
+    headers: {
+      ...authHeaders(cfg),
+      'Depth':        '1',
+      'Content-Type': 'application/xml',
+    },
+    body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:displayname/></d:prop></d:propfind>',
+  })
+  if (!res.ok) {
+    const err = new Error(`PROPFIND failed: ${res.status}`)
+    err.transient = res.status >= 500
+    throw err
+  }
+  const text = await res.text()
+  // Extract href paths and keep only event-file names (yyyyMMddTHHmmssZ-xxxxxx.json).
+  const EVENT_FILE_RE = /(\d{8}T\d{6}Z-[0-9a-f]+\.json)/g
+  const matches = [...text.matchAll(EVENT_FILE_RE)]
+  return [...new Set(matches.map(m => m[1]))].sort()
+}
+
+// GET a single event file and parse it. Throws { transient: true } on network / 5xx errors.
+async function getEventFile(cfg, filename) {
+  let res
+  try {
+    res = await fetch(eventsUrl(cfg, filename), { headers: authHeaders(cfg) })
+  } catch (err) {
+    err.transient = true  // network-level failure (TypeError / AbortError)
+    throw err
+  }
+  if (!res.ok) {
+    const err = new Error(`GET ${filename} failed: ${res.status}`)
+    err.transient = res.status >= 500
+    throw err
+  }
+  return res.json()
+}
+
+// ── Emit helpers ──────────────────────────────────────────────────────────────
+
+// Emit an outbound `create` to dayGLANCE for a milestone the user wants tracked.
+export async function emitCreateForMilestone(milestone) {
+  const cfg = loadIntentsConfig()
+  if (!cfg.enabled || !cfg.webdavUrl.trim()) return
+  const envelope = buildEnvelope(SOURCE_APP_LIFEGLANCE, ACTIONS.CREATE, {
+    title:            milestone.title,
+    due:              milestone.date,
+    source_app:       SOURCE_APP_LIFEGLANCE,
+    source_entity_id: milestone.id,
+    notes:            milestone.note || undefined,
+  })
+  await putEventFile(cfg, envelope)
+  return envelope.event_id
+}
+
+// Emit an outbound `notify` when a linked milestone's date changes.
+export async function emitRescheduledNotify(milestone, previousDue) {
+  const cfg = loadIntentsConfig()
+  if (!cfg.enabled || !cfg.webdavUrl.trim()) return
+  if (!milestone.dayglance_linked) return
+  const envelope = buildEnvelope(SOURCE_APP_LIFEGLANCE, ACTIONS.NOTIFY, {
+    event_id:         undefined, // top-level event_id serves this role
+    source_app:       SOURCE_APP_LIFEGLANCE,
+    source_entity_id: milestone.id,
+    event:            NOTIFY_EVENTS.RESCHEDULED,
+    task_id:          milestone.dayglance_task_id ?? '',
+    title:            milestone.title,
+    timestamp:        new Date().toISOString(),
+    due:              milestone.date,
+    previous_due:     previousDue,
+    entity_type:      'goal',
+  })
+  await putEventFile(cfg, envelope)
+  return envelope.event_id
+}
+
+// ── Poller ────────────────────────────────────────────────────────────────────
+
+// Polls the WebDAV events directory for new events since the last cursor.
+// Calls onEvent({ action, payload, event_id, emitted_by }) for each new event.
+// Advances the cursor only on definitive outcomes (success or non-transient error).
+// Breaks out of the loop without advancing on transient errors so they are retried.
+export async function pollEvents(onEvent) {
+  const cfg = loadIntentsConfig()
+  if (!cfg.enabled || !cfg.webdavUrl.trim()) return
+
+  const cursor = loadCursor()
+  let files
+  try {
+    files = await listEventFiles(cfg)
+  } catch (err) {
+    if (err.transient) return  // retry next poll
+    console.warn('[intents] PROPFIND failed (non-transient):', err)
+    return
+  }
+
+  // Process only files newer than cursor (filename sort is chronological).
+  const toProcess = cursor
+    ? files.filter(f => f.replace('.json', '') > cursor.replace('.json', ''))
+    : files
+
+  let lastProcessed = cursor
+  for (const filename of toProcess) {
+    let envelope
+    try {
+      const raw = await getEventFile(cfg, filename)
+      envelope  = parseEnvelope(raw)
+    } catch (err) {
+      if (err.transient) break  // transient: stop loop, retry this file next poll
+      console.warn('[intents] skipping malformed event file:', filename, err)
+      lastProcessed = filename  // non-transient: advance past it
+      continue
+    }
+
+    try {
+      await onEvent(envelope)
+    } catch (err) {
+      console.warn('[intents] handler error for:', filename, err)
+    }
+    lastProcessed = filename
+  }
+
+  if (lastProcessed && lastProcessed !== cursor) {
+    saveCursor(lastProcessed)
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Map the published package name to the local implementation so imports
+      // of '@glance-apps/intents' work without the package being on npm.
+      '@glance-apps/intents': resolve('./src/lib/intents.js'),
+    },
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `@glance-apps/intents@1.3.2` (via Vite alias to a local implementation of the package API) and wires up bidirectional Goal↔Milestone linking with dayGLANCE over the WebDAV event log transport
- Implements all 8 lifeGLANCE-side PRs from the Phase 5 table in `docs/dayglance-intents-package.md` (PR #3 — "Track in lifeGLANCE" checkbox on dayGLANCE Goals — is in the dayGLANCE repo)
- lifeGLANCE remains fully usable without dayGLANCE installed or WebDAV configured; all integration UI is gated behind `isIntegrationEnabled()`

## What's included

**PR #1 — `@glance-apps/intents` dependency**
`src/lib/intents.js` implements the full `@glance-apps/intents@1.3.2` public API: constants, `buildEnvelope()`, `parseEnvelope()`, `eventId()`, `filenameFor()`, `createKey()`. Vite alias maps the package name so import paths match the published package.

**PR #2 — Outbound `create` from lifeGLANCE**
"Track as dayGLANCE Goal" checkbox on the milestone create/edit form (future-dated milestones only). On save, `emitCreateForMilestone()` writes a `create` event file to `/GLANCE/events/` with `source_app=app.lifeglance` and `source_entity_id=milestone.id`.

**PR #4 — Inbound `create` handler**
`handleInboundCreate()` in TimelineView receives Goal→Milestone pushes from dayGLANCE (`emitted_by=app.dayglance`, `action=create`) and creates a mirrored milestone with `dayglance_linked=true`.

**PR #5 — WebDAV poller**
`src/lib/intentsTransport.js` implements `pollEvents()` with at-least-once delivery: transient errors (network, 5xx) hold the cursor; non-transient errors advance past the file. `useIntentPoller` hook polls on mount and on a configurable interval.

**PR #6 — Inbound `notify` handler**
`handleInboundNotify()` handles `completed` (sets `dayglance_completed`), `rescheduled` (updates milestone date), `updated` (syncs title), `uncompleted` (clears completion state), `deleted` (toast — milestone is preserved).

**PR #7 — Outbound `notify` on milestone date change**
`emitRescheduledNotify()` fires from the edit path in `executeSave()` when a linked milestone's date changes.

**PR #8 — Visual badge UI**
MilestoneDetail shows `◈ tracked in dayGLANCE` or `✓ completed in dayGLANCE · <date>` badges on linked milestones.

**PR #9 — Standalone-mode detection**
`isIntegrationEnabled()` gates all integration UI and all emit paths. The integration settings section (WebDAV URL, credentials, events path, CORS proxy, poll interval, test-connection) lives in a new `IntegrationSettings` component rendered inside SettingsModal.

## DB migration

v6 migration adds `dayglance_linked`, `dayglance_task_id`, `dayglance_completed`, `dayglance_completed_at` to all existing milestones (defaults to `false`/`null`).

## Test plan

- [ ] All 46 existing tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] With integration disabled: no dayGLANCE UI visible anywhere; app works normally
- [ ] With integration enabled + WebDAV configured: "Track as dayGLANCE Goal" checkbox appears on future-dated milestones; checking it and saving writes a `create` event file to `/GLANCE/events/`
- [ ] dayGLANCE picks up the `create` event and creates a corresponding task
- [ ] dayGLANCE completing the task emits a `notify/completed` event; lifeGLANCE poller picks it up and updates the milestone badge to "completed in dayGLANCE"
- [ ] Editing a linked milestone's date emits a `notify/rescheduled` event to the events directory
- [ ] dayGLANCE pushing a Goal (`emitted_by=app.dayglance`, `action=create`) creates a mirrored milestone in lifeGLANCE with the `◈ tracked in dayGLANCE` badge
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs4DUQdkNc8265bMhLcixd)_