### PR TITLE
fix: add WebDAV proxy sidecar for Docker self-hosting

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,3 +47,25 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Extract proxy metadata
+        id: proxy-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/krelltunez/lifeglance-proxy
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push proxy
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.proxy
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.proxy-meta.outputs.tags }}
+          labels: ${{ steps.proxy-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY proxy/package.json ./
+COPY proxy/server.js ./
+EXPOSE 3001
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.1-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.2-green.svg)](../../releases)
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,9 @@ services:
     ports:
       - "6868:80"
     restart: unless-stopped
+    depends_on:
+      - proxy
+
+  proxy:
+    image: ghcr.io/krelltunez/lifeglance-proxy:latest
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # WebDAV CORS proxy — forwards to the sidecar Node service.
+    # Accepts all HTTP methods (PROPFIND, MKCOL, PUT, GET, etc.).
+    location /api/webdav-proxy {
+        proxy_pass http://proxy:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        # Strip the /api/webdav-proxy prefix; preserve ?url= query string.
+        rewrite ^/api/webdav-proxy(.*) $1 break;
+    }
+
     # SPA fallback — all routes serve index.html
     location / {
         try_files $uri $uri/ /index.html;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lifeglance-webdav-proxy",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js"
+}

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,0 +1,76 @@
+import http from 'http'
+import https from 'https'
+import { URL } from 'url'
+
+const PORT = 3001
+const PRIVATE_IP = /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|::1$|localhost)/i
+
+const FORWARD_REQ_HEADERS = [
+  'authorization', 'x-webdav-auth', 'content-type',
+  'if-match', 'depth', 'destination',
+]
+const FORWARD_RES_HEADERS = [
+  'content-type', 'etag', 'last-modified', 'dav', 'allow',
+]
+
+http.createServer(async (req, res) => {
+  // Support both ?url= (used by @glance-apps/sync) and X-WebDAV-Url header (used by intents transport)
+  const qs = new URL(req.url, 'http://localhost').searchParams
+  const target = qs.get('url') || req.headers['x-webdav-url']
+
+  if (!target) {
+    res.writeHead(400, { 'Content-Type': 'application/json' })
+    return res.end(JSON.stringify({ error: 'Missing target URL' }))
+  }
+
+  let url
+  try { url = new URL(target) } catch {
+    res.writeHead(400, { 'Content-Type': 'application/json' })
+    return res.end(JSON.stringify({ error: 'Invalid URL' }))
+  }
+
+  if (PRIVATE_IP.test(url.hostname)) {
+    res.writeHead(403, { 'Content-Type': 'application/json' })
+    return res.end(JSON.stringify({ error: 'Private IP blocked' }))
+  }
+
+  const headers = {}
+  for (const h of FORWARD_REQ_HEADERS) {
+    if (req.headers[h]) headers[h] = req.headers[h]
+    // x-webdav-auth carries credentials — map to Authorization for the upstream
+    if (h === 'x-webdav-auth' && req.headers[h] && !req.headers['authorization']) {
+      headers['authorization'] = req.headers[h]
+    }
+  }
+
+  const chunks = []
+  for await (const chunk of req) chunks.push(chunk)
+  const body = chunks.length ? Buffer.concat(chunks) : null
+
+  const lib = url.protocol === 'https:' ? https : http
+  const upstreamReq = lib.request(
+    target,
+    { method: req.method, headers },
+    (upstreamRes) => {
+      const resHeaders = {}
+      for (const h of FORWARD_RES_HEADERS) {
+        const v = upstreamRes.headers[h]
+        if (v) resHeaders[h] = v
+      }
+      res.writeHead(upstreamRes.statusCode, resHeaders)
+      upstreamRes.pipe(res)
+    }
+  )
+
+  upstreamReq.on('error', (err) => {
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Upstream error', detail: err.message }))
+    }
+  })
+
+  if (body) upstreamReq.write(body)
+  upstreamReq.end()
+}).listen(PORT, () => {
+  console.log(`WebDAV proxy listening on :${PORT}`)
+})


### PR DESCRIPTION
## Problem

The Docker image is nginx-only (pure static). There's no backend, so `/api/webdav-proxy` doesn't exist — nginx returns 405 for PROPFIND/MKCOL, breaking cloud sync and the dayGLANCE intents integration entirely.

## Solution

Adds a minimal Node.js proxy sidecar (`proxy/server.js`) as a second Docker Compose service. nginx forwards `/api/webdav-proxy` to it. The proxy supports both request conventions used by the codebase:
- `?url=` query param — used by `@glance-apps/sync`
- `X-WebDAV-Url` header — used by `intentsTransport.js`

A new `Dockerfile.proxy` builds the sidecar image, and the CI workflow now builds and pushes `ghcr.io/krelltunez/lifeglance-proxy` alongside the main image on each release.

## Changes

- `proxy/server.js` — standalone Node HTTP server that proxies WebDAV requests, blocks private IPs
- `proxy/package.json` — minimal ESM package descriptor
- `Dockerfile.proxy` — builds the proxy image from `node:20-alpine`
- `nginx.conf` — adds `/api/webdav-proxy` location that proxies to the `proxy` sidecar
- `docker-compose.yml` — adds `proxy` service, `lifeglance` depends on it
- `.github/workflows/docker.yml` — builds and pushes `lifeglance-proxy` image on release

## To update your running stack

```sh
docker compose pull
docker compose up -d
```

## Test plan

- [ ] `docker compose up` starts both `lifeglance` and `proxy` services
- [ ] Cloud sync test connection succeeds with a bare Nextcloud URL
- [ ] PROPFIND and MKCOL reach the upstream Nextcloud server (no 405)
- [ ] Private IP addresses are blocked by the proxy (returns 403)

https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W)_