### PR TITLE
fix: lazy DNS resolution for nginx proxy upstream (v2.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.3-green.svg)](../../releases)
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,11 +7,12 @@ server {
     # WebDAV CORS proxy — forwards to the sidecar Node service.
     # Accepts all HTTP methods (PROPFIND, MKCOL, PUT, GET, etc.).
     location /api/webdav-proxy {
-        proxy_pass http://proxy:3001;
+        resolver 127.0.0.11 valid=10s;
+        set $proxy_upstream http://proxy:3001;
+        proxy_pass $proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        # Strip the /api/webdav-proxy prefix; preserve ?url= query string.
         rewrite ^/api/webdav-proxy(.*) $1 break;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

The v2.0.2 image crashes into a restart loop because nginx resolves `proxy_pass` hostnames eagerly at startup. If the `proxy` sidecar isn't up at that exact moment, nginx exits and the container restarts forever.

## Fix

Use Docker's internal DNS resolver (`127.0.0.11`) with a variable for the upstream, which defers resolution to per-request rather than startup:

```nginx
resolver 127.0.0.11 valid=10s;
set $proxy_upstream http://proxy:3001;
proxy_pass $proxy_upstream;
```

## Test plan

- [ ] `docker compose up -d` — both containers start cleanly, no restart loop
- [ ] Cloud sync test connection succeeds with Nextcloud URL

https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W)_