### PR TITLE
fix: nginx 413 and 500 errors in WebDAV proxy (v2.0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.5-green.svg)](../../releases)
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,8 @@ server {
     location /api/webdav-proxy {
         proxy_pass http://127.0.0.1:3001;
         proxy_http_version 1.1;
-        rewrite ^/api/webdav-proxy(.*) $1 break;
+        client_max_body_size 0;
+        rewrite ^/api/webdav-proxy/?(.*)$ /$1 break;
     }
 
     # SPA fallback — all routes serve index.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problems

- **413 Content Too Large** — nginx's default 1MB body size limit was rejecting sync file uploads. Fixed with `client_max_body_size 0` on the proxy location.
- **500** on requests to bare `/api/webdav-proxy` — the rewrite produced an empty URI when no trailing slash was present. Fixed by ensuring the rewrite always produces at least `/`.

## Test plan

- [ ] Single container starts cleanly
- [ ] Cloud sync completes without 413 errors
- [ ] No 500 errors on WebDAV proxy requests

https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W)_