### PR TITLE
fix: nginx body size limit, bare-URI 500, and real CI round-trip test (v2.0.5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,93 @@
 name: Build & Push to GHCR
 
 on:
+  push:
+    branches: ['**']
+  pull_request:
   release:
     types: [published]
 
 jobs:
-  build-push:
+  # Runs on every push and PR so broken images never reach GHCR.
+  smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: lifeglance:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start containers
+        run: |
+          docker network create test-net
+          docker run -d --name webdav --network test-net \
+            -e AUTH_TYPE=Basic \
+            -e USERNAME=testuser \
+            -e PASSWORD=testpass \
+            bytemark/webdav
+          docker run -d --name lifeglance --network test-net \
+            -p 8080:80 lifeglance:smoke
+          sleep 5
+
+      - name: WebDAV round-trip
+        run: |
+          PROXY="http://localhost:8080/api/webdav-proxy"
+          DAV_FILE=$(python3 -c "import urllib.parse; print(urllib.parse.quote('http://webdav/testfile.bin', safe=''))")
+          DAV_ROOT=$(python3 -c "import urllib.parse; print(urllib.parse.quote('http://webdav/', safe=''))")
+          AUTH="Authorization: Basic $(printf '%s' 'testuser:testpass' | base64 -w 0)"
+
+          # 5 MB test payload
+          dd if=/dev/urandom bs=1M count=5 of=/tmp/payload.bin 2>/dev/null
+          PAYLOAD_SIZE=$(wc -c < /tmp/payload.bin)
+
+          # 1. PUT 5 MB -- expect 201 or 204
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X PUT -H "$AUTH" -H "Content-Type: application/octet-stream" \
+            --data-binary @/tmp/payload.bin \
+            "$PROXY/?url=$DAV_FILE")
+          echo "PUT: $STATUS"
+          [ "$STATUS" = "201" ] || [ "$STATUS" = "204" ] \
+            || { echo "FAIL: PUT returned $STATUS, expected 201 or 204"; docker logs lifeglance; exit 1; }
+
+          # 2. PROPFIND Depth:1 -- expect 207
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X PROPFIND -H "$AUTH" -H "Depth: 1" \
+            "$PROXY/?url=$DAV_ROOT")
+          echo "PROPFIND: $STATUS"
+          [ "$STATUS" = "207" ] \
+            || { echo "FAIL: PROPFIND returned $STATUS, expected 207"; docker logs lifeglance; exit 1; }
+
+          # 3. GET -- expect 200 and body size matches what was PUT
+          curl -s -o /tmp/got.bin -H "$AUTH" "$PROXY/?url=$DAV_FILE"
+          GOT_SIZE=$(wc -c < /tmp/got.bin)
+          echo "GET: expected ${PAYLOAD_SIZE} bytes, got ${GOT_SIZE} bytes"
+          [ "$GOT_SIZE" = "$PAYLOAD_SIZE" ] \
+            || { echo "FAIL: body size mismatch"; docker logs lifeglance; exit 1; }
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f lifeglance webdav || true
+          docker network rm test-net || true
+
+  # Only runs on release, and only if smoke-test passes.
+  publish:
+    needs: smoke-test
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -36,38 +118,6 @@ jobs:
             type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
-      # ── Smoke test ────────────────────────────────────────────────────────────
-      # Build locally first (amd64 only) and verify the container starts before
-      # publishing anything to GHCR.
-
-      - name: Build image locally for smoke test
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: lifeglance:smoke
-          cache-from: type=gha
-
-      - name: Run smoke test
-        run: |
-          docker run -d --name lifeglance -p 8080:80 lifeglance:smoke
-          sleep 3
-
-          # SPA serves index.html
-          curl -sf http://localhost:8080/ | grep -q 'id="root"' \
-            || { echo "SPA check failed"; docker logs lifeglance; exit 1; }
-
-          # /api/webdav-proxy is reachable — proxy process is up inside the container
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "http://localhost:8080/api/webdav-proxy/?url=https%3A%2F%2Fexample.com%2F")
-          [ "$STATUS" != "405" ] && [ "$STATUS" != "502" ] \
-            || { echo "Proxy endpoint returned $STATUS"; docker logs lifeglance; exit 1; }
-
-          docker rm -f lifeglance
-
-      # ── Publish ───────────────────────────────────────────────────────────────
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,12 @@ jobs:
           [ "$GOT_SIZE" = "$PAYLOAD_SIZE" ] \
             || { echo "FAIL: body size mismatch"; docker logs lifeglance; exit 1; }
 
+          # 4. Bare /api/webdav-proxy with no ?url= -- expect 400, not 500
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PROXY")
+          echo "Bare proxy: $STATUS"
+          [ "$STATUS" = "400" ] \
+            || { echo "FAIL: bare proxy returned $STATUS, expected 400"; docker logs lifeglance; exit 1; }
+
       - name: Cleanup
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.5-green.svg)](../../releases)
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,7 +10,7 @@ server {
         proxy_pass http://127.0.0.1:3001;
         proxy_http_version 1.1;
         client_max_body_size 100m;
-        rewrite ^/api/webdav-proxy(.*) $1 break;
+        rewrite ^/api/webdav-proxy/?(.*)$ /$1 break;
     }
 
     # SPA fallback — all routes serve index.html

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ server {
     location /api/webdav-proxy {
         proxy_pass http://127.0.0.1:3001;
         proxy_http_version 1.1;
-        client_max_body_size 1m;
+        client_max_body_size 100m;
         rewrite ^/api/webdav-proxy(.*) $1 break;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,7 @@ server {
     location /api/webdav-proxy {
         proxy_pass http://127.0.0.1:3001;
         proxy_http_version 1.1;
+        client_max_body_size 1m;
         rewrite ^/api/webdav-proxy(.*) $1 break;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Changes

**`client_max_body_size 100m`** on the WebDAV proxy location. The nginx default of 1m was rejecting sync file uploads with 413.

**Rewrite fix** for bare `/api/webdav-proxy` (no trailing slash). The old pattern produced an empty URI which caused nginx to 500. The new pattern always passes at least `/` to the upstream, so the Node proxy returns a clean 400.

**Real WebDAV round-trip CI test** replacing the shallow proxy-reachable check that let both of the above ship. A `bytemark/webdav` container is stood up on the same Docker network and the following are asserted through the proxy before any image is published to GHCR:

1. PUT 5 MB -- expect 201 or 204 (catches body size limits)
2. PROPFIND Depth:1 -- expect 207 (catches method routing)
3. GET the file back -- expect exact byte count (catches truncation)
4. Bare `/api/webdav-proxy` with no `?url=` -- expect 400, not 500 (catches empty-URI rewrite)

CI now triggers on every push and PR, not just release. The publish job is gated on smoke-test passing.

## Test plan

- [ ] All four CI assertions pass (confirmed green before this PR was opened)
- [ ] Cloud sync completes without 413 errors
- [ ] No 500 on bare proxy requests

https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W)_