### PR TITLE
ci: rename jobs to test and publish-to-ghcr for clarity

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,8 +8,9 @@ on:
     types: [published]
 
 jobs:
-  # Runs on every push and PR so broken images never reach GHCR.
-  smoke-test:
+  # Runs on every push and PR to verify the image builds and passes the
+  # WebDAV round-trip test before anything reaches GHCR.
+  test:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -90,9 +91,9 @@ jobs:
           docker rm -f lifeglance webdav || true
           docker network rm test-net || true
 
-  # Only runs on release, and only if smoke-test passes.
-  publish:
-    needs: smoke-test
+  # Runs on release only, gated on test passing.
+  publish-to-ghcr:
+    needs: test
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Renames `smoke-test` to `test` and `publish` to `publish-to-ghcr` so the Actions tab makes it obvious which job runs on push/PR and which only runs on release.

https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaUTs97ppN8eC3vfnpWx5W)_