### PR TITLE
v2.0.6 — Auto-backup fixes, encryption fix, ESC on stats modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.5-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.6-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",
@@ -1747,7 +1747,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
+        "@nodelib/fs.stat": "2.0.6",
         "run-parallel": "^1.1.9"
       },
       "engines": {
@@ -1755,8 +1755,8 @@
       }
     },
     "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.6.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -4493,8 +4493,8 @@
       }
     },
     "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.6.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
@@ -5559,7 +5559,7 @@
         "call-bound": "^1.0.4",
         "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
+        "isarray": "^2.0.6"
       },
       "engines": {
         "node": ">=0.4"
@@ -5576,7 +5576,7 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
+        "isarray": "^2.0.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6620,7 +6620,7 @@
         "is-generator-function": "^1.0.10",
         "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
+        "isarray": "^2.0.6",
         "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
         "which-typed-array": "^1.1.16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,7 +1747,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nodelib/fs.stat": "2.0.6",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       },
       "engines": {
@@ -1755,8 +1755,8 @@
       }
     },
     "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.6.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -4493,8 +4493,8 @@
       }
     },
     "node_modules/isarray": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.6.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
@@ -5559,7 +5559,7 @@
         "call-bound": "^1.0.4",
         "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
-        "isarray": "^2.0.6"
+        "isarray": "^2.0.5"
       },
       "engines": {
         "node": ">=0.4"
@@ -5576,7 +5576,7 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "isarray": "^2.0.6"
+        "isarray": "^2.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6620,7 +6620,7 @@
         "is-generator-function": "^1.0.10",
         "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
-        "isarray": "^2.0.6",
+        "isarray": "^2.0.5",
         "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
         "which-typed-array": "^1.1.16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,34 @@ export default function App() {
     return () => { clearTimeout(t); clearInterval(id) }
   }, [])
 
+  // Auto-backup timer — checks every 60s if a scheduled backup is due.
+  // Skips if cloud sync encryption is configured but the session key isn't loaded yet
+  // (avoids writing unencrypted backup files).
+  useEffect(() => {
+    const INTERVALS = { hourly: 3_600_000, daily: 86_400_000, weekly: 604_800_000 }
+    const tick = async () => {
+      try {
+        const backupCfg = JSON.parse(localStorage.getItem('lifeglance-auto-backup-config') ?? 'null')
+        if (!backupCfg?.remoteEnabled) return
+        const freq = backupCfg.frequency ?? 'daily'
+        const interval = INTERVALS[freq] ?? INTERVALS.daily
+        const lastKey = `lifeglance-backup-last-${freq}`
+        const last = Number(localStorage.getItem(lastKey) ?? '0')
+        if (Date.now() - last < interval) return
+        const engine = getSyncEngine()
+        const syncCfg = engine?.getConfig()
+        if (!syncCfg?.enabled) return
+        if (syncCfg?.encrypt && !engine?.hasEncryptionReady?.()) return
+        await engine?.runBackup(freq)
+        localStorage.setItem(lastKey, String(Date.now()))
+      } catch (err) {
+        console.error('[auto-backup]', err)
+      }
+    }
+    const id = setInterval(tick, 60_000)
+    return () => clearInterval(id)
+  }, [])
+
   // Upload on data changes (debounced 5s)
   const uploadTimerRef = useRef(null)
   useEffect(() => {

--- a/src/components/stats/SummaryModal.jsx
+++ b/src/components/stats/SummaryModal.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import { formatDateDisplay } from '../../utils/dates'
 
 function formatSpan(ms) {
@@ -12,6 +12,12 @@ function formatSpan(ms) {
 }
 
 export default function SummaryModal({ milestones, onClose }) {
+  useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
   const stats = useMemo(() => {
     if (!milestones.length) return null
 

--- a/src/components/sync/AutoBackupModal.jsx
+++ b/src/components/sync/AutoBackupModal.jsx
@@ -7,19 +7,32 @@ const FREQUENCIES = [
   { value: 'weekly',  label: 'Weekly (keep 12)' },
 ]
 
+const BACKUP_CONFIG_KEY = 'lifeglance-auto-backup-config'
+
+function loadBackupConfig() {
+  try { return JSON.parse(localStorage.getItem(BACKUP_CONFIG_KEY) || 'null') } catch { return null }
+}
+
 function SettingsTab({ onClose }) {
   const engine = getSyncEngine()
   const existingConfig = engine?.getConfig() ?? null
+  const savedBackupConfig = loadBackupConfig()
 
-  const [remoteEnabled, setRemoteEnabled] = useState(false)
+  const [remoteEnabled, setRemoteEnabled] = useState(savedBackupConfig?.remoteEnabled ?? false)
   const [provider,      setProvider]      = useState(existingConfig?.provider ?? 'nextcloud')
   const [url,           setUrl]           = useState(existingConfig?.url ?? '')
   const [username,      setUsername]      = useState(existingConfig?.username ?? '')
   const [password,      setPassword]      = useState(existingConfig?.password ?? '')
-  const [frequency,     setFrequency]     = useState('daily')
+  const [frequency,     setFrequency]     = useState(savedBackupConfig?.frequency ?? 'daily')
   const [testing,       setTesting]       = useState(false)
   const [backingUp,     setBackingUp]     = useState(false)
   const [result,        setResult]        = useState(null)
+
+  function handleSave() {
+    localStorage.setItem(BACKUP_CONFIG_KEY, JSON.stringify({ remoteEnabled, frequency }))
+    setResult({ ok: true, message: 'Settings saved.' })
+    setTimeout(() => { setResult(null); onClose() }, 1200)
+  }
 
   async function handleTest() {
     setTesting(true)
@@ -50,8 +63,23 @@ function SettingsTab({ onClose }) {
     }
   }
 
+  const syncConfigured = !!existingConfig?.enabled
+
   return (
     <div>
+      {!syncConfigured && (
+        <div style={{
+          padding: '0.6rem 1rem',
+          borderRadius: '6px',
+          marginBottom: '0.75rem',
+          fontSize: '0.82rem',
+          background: '#2a1f10',
+          color: '#D4A800',
+        }}>
+          Cloud Sync must be configured first. Auto-backup uploads to the same server.
+        </div>
+      )}
+
       {/* Remote backups */}
       <div className="settings-section">
         <div className="settings-label">remote backups</div>
@@ -62,6 +90,7 @@ function SettingsTab({ onClose }) {
             className="settings-toggle"
             checked={remoteEnabled}
             onChange={e => setRemoteEnabled(e.target.checked)}
+            disabled={!syncConfigured}
           />
         </label>
 
@@ -113,40 +142,69 @@ function SettingsTab({ onClose }) {
                 ))}
               </select>
             </div>
-
-            {result && (
-              <div style={{
-                padding: '0.6rem 1rem',
-                borderRadius: '6px',
-                marginTop: '0.75rem',
-                fontSize: '0.82rem',
-                background: result.ok ? '#0f2a1a' : '#2a1010',
-                color: result.ok ? '#34D399' : '#E85D75',
-              }}>
-                {result.message}
-              </div>
-            )}
-
-            <div className="settings-backup-row" style={{ marginTop: '0.75rem', gap: '0.5rem' }}>
-              <button
-                className="btn"
-                style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
-                onClick={handleTest}
-                disabled={testing || !url || !username}
-              >
-                {testing ? 'testing...' : 'test connection'}
-              </button>
-              <button
-                className="btn btn-filled"
-                style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
-                onClick={handleBackupNow}
-                disabled={backingUp || !url || !username || !password}
-              >
-                {backingUp ? 'backing up...' : 'backup now'}
-              </button>
-            </div>
           </>
         )}
+
+        {!remoteEnabled && syncConfigured && (
+          <div style={{ marginTop: '0.75rem' }}>
+            <div className="settings-label">frequency</div>
+            <select
+              className="input"
+              value={frequency}
+              onChange={e => setFrequency(e.target.value)}
+              style={{ width: '100%' }}
+            >
+              {FREQUENCIES.map(f => (
+                <option key={f.value} value={f.value}>{f.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {result && (
+        <div style={{
+          padding: '0.6rem 1rem',
+          borderRadius: '6px',
+          marginTop: '0.75rem',
+          fontSize: '0.82rem',
+          background: result.ok ? '#0f2a1a' : '#2a1010',
+          color: result.ok ? '#34D399' : '#E85D75',
+        }}>
+          {result.message}
+        </div>
+      )}
+
+      <div className="settings-backup-row" style={{ marginTop: '0.75rem', gap: '0.5rem', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          {remoteEnabled && (
+            <button
+              className="btn"
+              style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+              onClick={handleTest}
+              disabled={testing || !url || !username}
+            >
+              {testing ? 'testing...' : 'test connection'}
+            </button>
+          )}
+          {syncConfigured && (
+            <button
+              className="btn"
+              style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+              onClick={handleBackupNow}
+              disabled={backingUp}
+            >
+              {backingUp ? 'backing up...' : 'backup now'}
+            </button>
+          )}
+        </div>
+        <button
+          className="btn btn-filled"
+          style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+          onClick={handleSave}
+        >
+          save
+        </button>
       </div>
 
       <p className="settings-note" style={{ marginTop: '0.75rem' }}>
@@ -165,7 +223,7 @@ function HistoryTab() {
     async function load() {
       try {
         const engine = getSyncEngine()
-        const backups = await engine?.listBackups?.() ?? []
+        const backups = await engine?.autoBackupDB?.listBackups?.() ?? []
         setRecords(backups)
       } catch {
         setRecords([])

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -105,7 +105,7 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
     setSaving(true)
     try {
       const webdavBase = resolveWebdavBase(provider, url, username)
-      const config = { provider, url, username, password, folder, encrypt, enabled: true,
+      const config = { provider, url, username, password, folder, encrypt, encryptionEnabled: encrypt, enabled: true,
         webdavUrl: webdavBase, nextcloudUrl: url, appPassword: password }
       engine?.setConfig(config)
       const dirUrl = `${webdavBase}/${folder}/`

--- a/src/components/sync/SyncPassphraseModal.jsx
+++ b/src/components/sync/SyncPassphraseModal.jsx
@@ -11,8 +11,8 @@ export default function SyncPassphraseModal({ onClose, onUnlocked }) {
     setLoading(true)
     setError(null)
     try {
-      const { setupEncryptionKey } = await import('@glance-apps/sync')
-      await setupEncryptionKey(passphrase)
+      const { setSyncPassphrase } = await import('@glance-apps/sync')
+      setSyncPassphrase(passphrase)
       onUnlocked()
     } catch (err) {
       setError('Incorrect passphrase. Please try again.')


### PR DESCRIPTION
## Summary

- **Auto-backup settings not persisting** — `remoteEnabled` and `frequency` are now saved to `lifeglance-auto-backup-config` in localStorage and loaded on modal open. Added a Save button. Added a warning when Cloud Sync isn't configured (backup uses the same WebDAV credentials).
- **Auto-backup history always empty** — `HistoryTab` was calling `engine.listBackups()` which doesn't exist on the engine; fixed to use `engine.autoBackupDB.listBackups()`.
- **Auto-backup never ran on a schedule** — Added a 60-second timer in `App.jsx` that checks if a backup is due for the configured frequency and calls `runBackup()`. The timer skips if cloud sync encryption is configured but the session key isn't loaded yet, preventing unencrypted backup files from being written.
- **Encryption not applied to sync or backup files** — `CloudSyncModal` was saving `encrypt: true` but the sync provider checks `config.encryptionEnabled`. Added `encryptionEnabled: encrypt` to the saved config so encryption is actually applied. This was also causing `hasEncryptionReady()` to stay false after page reload (no encrypted file → no passphrase prompt → no session key → backup always plaintext).
- **Passphrase modal using wrong function** — `SyncPassphraseModal` was calling `setupEncryptionKey(passphrase)` (first-time setup, generates a new random salt) instead of `setSyncPassphrase(passphrase)` (caches passphrase for `decryptData` to re-derive the key using the salt embedded in the encrypted file).
- **ESC doesn't close Timeline Stats modal** — Added a `keydown` listener to `SummaryModal`.

## Notes for deployment

- **Existing users must re-save Cloud Sync settings** after deploying to write `encryptionEnabled: true` into their stored config. Until then, uploads remain plaintext.
- On first sync after re-saving, the plaintext sync file on the server is overwritten with the encrypted version.
- Secondary devices also need to re-save Cloud Sync settings, after which they'll be prompted for the passphrase once on next sync.

## Test plan

- [ ] Open auto-backup modal, toggle remote backups on, set frequency, save — reopen modal and confirm settings are retained
- [ ] Run a manual backup, open history tab and confirm the record appears
- [ ] Confirm auto-backup timer fires and records a backup after the configured interval
- [ ] Re-save Cloud Sync settings with encryption enabled, reload, confirm passphrase prompt appears and sync succeeds
- [ ] Confirm backup files on server are in `{ "v": 1, "enc": "AES-GCM-256", "data": "..." }` format after encryption is active
- [ ] Confirm ESC closes the Timeline Stats modal

https://claude.ai/code/session_01RaHzBxqhgE4zXg1wPxsRJp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaHzBxqhgE4zXg1wPxsRJp)_