### PR TITLE
v2.0.7 — Fix cloud sync encryption (actually works this time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.6-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.7-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -95,21 +95,21 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
   }
 
   async function handleSave() {
-    if (!isExisting && encrypt) {
-      if (!passphrase) return
-      if (passphrase !== confirmPass) {
-        setTestResult({ ok: false, message: 'Passphrases do not match.' })
-        return
-      }
+    if (!isExisting && encrypt && !passphrase) return
+    if (!isExisting && encrypt && passphrase !== confirmPass) {
+      setTestResult({ ok: false, message: 'Passphrases do not match.' })
+      return
     }
     setSaving(true)
     try {
       const webdavBase = resolveWebdavBase(provider, url, username)
-      const config = { provider, url, username, password, folder, encrypt, encryptionEnabled: encrypt, enabled: true,
-        webdavUrl: webdavBase, nextcloudUrl: url, appPassword: password }
-      engine?.setConfig(config)
+      const baseConfig = {
+        provider, url, username, password, folder, encrypt, enabled: true,
+        webdavUrl: webdavBase, nextcloudUrl: url, appPassword: password,
+      }
       const dirUrl = `${webdavBase}/${folder}/`
       await mkdirp(dirUrl, username, password)
+
       if (encrypt) {
         const cryptoConfig = { cryptoDBName: 'lifeglance-crypto' }
         if (passphrase) {
@@ -117,15 +117,23 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
           await setupEncryptionKey(passphrase, cryptoConfig)
         } else {
           const { initSessionKey } = await import('@glance-apps/sync')
-          const restored = await initSessionKey(cryptoConfig)
-          if (!restored) {
+          const ok = await initSessionKey(cryptoConfig)
+          if (!ok) {
             setTestResult({ ok: false, message: 'Enter your passphrase to activate encryption.' })
             setSaving(false)
             return
           }
         }
+        // Key is loaded — persist config with encryptionEnabled and immediately
+        // upload so the plaintext file on the server is overwritten encrypted.
+        engine?.setConfig({ ...baseConfig, encryptionEnabled: true })
+        await engine?.upload()
+      } else {
+        const { clearEncryptionKey } = await import('@glance-apps/sync')
+        await clearEncryptionKey({ cryptoDBName: 'lifeglance-crypto' })
+        engine?.setConfig({ ...baseConfig, encryptionEnabled: false })
+        engine?.upload().catch(console.error)
       }
-      await engine?.sync()
       onClose()
     } catch (err) {
       console.error('[sync] save failed:', err)

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -110,9 +110,20 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
       engine?.setConfig(config)
       const dirUrl = `${webdavBase}/${folder}/`
       await mkdirp(dirUrl, username, password)
-      if (encrypt && passphrase) {
-        const { setupEncryptionKey } = await import('@glance-apps/sync')
-        await setupEncryptionKey(passphrase)
+      if (encrypt) {
+        const cryptoConfig = { cryptoDBName: 'lifeglance-crypto' }
+        if (passphrase) {
+          const { setupEncryptionKey } = await import('@glance-apps/sync')
+          await setupEncryptionKey(passphrase, cryptoConfig)
+        } else {
+          const { initSessionKey } = await import('@glance-apps/sync')
+          const restored = await initSessionKey(cryptoConfig)
+          if (!restored) {
+            setTestResult({ ok: false, message: 'Enter your passphrase to activate encryption.' })
+            setSaving(false)
+            return
+          }
+        }
       }
       await engine?.sync()
       onClose()


### PR DESCRIPTION
## What was wrong

Cloud sync files were never encrypted despite the UI showing encryption as active. The `@glance-apps/sync` providers gate upload encryption on `config.encryptionEnabled` in the persisted engine config, but `setConfig()` was never including that field — so every upload was plaintext.

Auto-backup was coincidentally working because it uses `hasEncryptionReady()` (in-memory session key check) rather than `config.encryptionEnabled`.

Several failed attempts to fix this in v2.0.6 made things worse before the correct pattern was identified from lastGLANCE.

## What's fixed

**`CloudSyncModal` `handleSave()`** now follows the correct three-step pattern:

- **Enable path:** `setupEncryptionKey(passphrase, { cryptoDBName: 'lifeglance-crypto' })` → `engine.setConfig({ ...config, encryptionEnabled: true })` → `engine.upload()` — immediately overwrites the plaintext file on the server with the encrypted version
- **Disable path:** `clearEncryptionKey(...)` → `engine.setConfig({ ...config, encryptionEnabled: false })` → `engine.upload()` fire-and-forget
- `setupEncryptionKey` now receives the correct `cryptoDBName` so the derived key lands in `lifeglance-crypto` IDB and survives page reloads without re-prompting

**`SyncPassphraseModal`** now calls `setSyncPassphrase(passphrase)` instead of `setupEncryptionKey(passphrase)`. The former just caches the passphrase so `decryptData` can re-derive the key using the salt embedded in the encrypted file. The latter was generating a new random salt, which would produce the wrong key.

**Also in this release:**
- Auto-backup settings now persist across modal close/reopen
- Auto-backup history fixed (was calling wrong method on engine)
- Auto-backup timer added to `App.jsx`; skips if encryption key not loaded to avoid writing plaintext backup files
- ESC closes the Timeline Stats modal

## Deploying

Existing users with encryption enabled must open Cloud Sync settings, enter their passphrase, and hit Save. This triggers the immediate re-upload that overwrites the plaintext sync file with an encrypted one. Simply opening and closing settings is not enough — the passphrase must be entered.

## Test plan

- [ ] Save Cloud Sync settings with encryption enabled + passphrase — confirm server file is `{"v":1,"enc":"AES-GCM-256","data":"..."}`
- [ ] Reload page — confirm passphrase prompt appears and sync succeeds after entry
- [ ] Reload again — confirm no passphrase prompt (key persisted in IDB)
- [ ] Disable encryption — confirm server file reverts to plaintext JSON
- [ ] Auto-backup settings persist after closing and reopening the modal
- [ ] Auto-backup history shows records after a backup runs
- [ ] ESC closes the Timeline Stats modal

https://claude.ai/code/session_01RaHzBxqhgE4zXg1wPxsRJp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaHzBxqhgE4zXg1wPxsRJp)_