### PR TITLE
v2.1.1 — GLANCEvault forward-compat media ID slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.1.1-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import TimelineView from './components/timeline/TimelineView'
 import CloudSyncModal from './components/sync/CloudSyncModal'
 import SyncPassphraseModal from './components/sync/SyncPassphraseModal'
 import { initDB, dbGetAll, dbGetAllChapters } from './data/db'
+import { backfillMediaIds } from './data/milestones'
 import { initSyncEngine, getSyncEngine } from './sync/engine'
 
 export default function App() {
@@ -42,7 +43,7 @@ export default function App() {
       .then(() => {
         if (import.meta.env.DEV) import('./data/devtools').then(m => m.registerDevtools())
         navigator.storage?.persist?.()
-        return Promise.all([dbGetAll(), dbGetAllChapters()])
+        return backfillMediaIds().then(() => Promise.all([dbGetAll(), dbGetAllChapters()]))
       })
       .then(([all, allChapters]) => {
         setMilestones(all)

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -119,9 +119,6 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
         )}
         {m.media_type && !audioUrl && (
           <div className="detail-audio-wrap detail-media-unavailable">
-            <span className="detail-media-unavailable-icon">
-              {m.media_type === 'video' ? '&#127916;' : '&#127911;'}
-            </span>
             <span className="detail-media-unavailable-label">{t('mediaSyncedFromDevice')}</span>
           </div>
         )}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -717,7 +717,13 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         const hasPhoto  = photoFile    ? true
                         : photoRemoved ? false
                         : (existing.has_photo ?? false)
-        const updated = await updateMilestone(existing.id, { ...milestoneData, media_type: mediaType, has_photo: hasPhoto }, existing)
+        const mediaId   = mediaFile    ? existing.id
+                        : mediaRemoved ? null
+                        : (existing.media_id ?? (existing.media_type ? existing.id : null))
+        const photoId   = photoFile    ? `${existing.id}-photo`
+                        : photoRemoved ? null
+                        : (existing.photo_id ?? (existing.has_photo ? `${existing.id}-photo` : null))
+        const updated = await updateMilestone(existing.id, { ...milestoneData, media_type: mediaType, has_photo: hasPhoto, media_id: mediaId, photo_id: photoId }, existing)
         if (mediaFile)    await dbPutMedia(updated.id, mediaFile, mediaFile.type)
         if (photoFile)    await dbPutPhoto(updated.id, photoFile, photoFile.type)
         if (photoRemoved) await dbDeletePhoto(updated.id)

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -109,6 +109,11 @@ export async function updateMilestone(id, updates, existing) {
 // One-time backfill: stamp media_id / photo_id on existing milestones that
 // pre-date the schema addition. Skips milestones that already have values or
 // have no media. thumbnail_id intentionally left null for all records.
+//
+// updated_at is deliberately NOT bumped. Each device runs this backfill
+// independently at startup and derives the same deterministic IDs, so sync
+// propagation is unnecessary. Bumping would cause a one-time churn where
+// every media milestone appears "newer" and triggers a full re-upload.
 export async function backfillMediaIds() {
   const all = await dbGetAll()
   for (const m of all) {

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -23,6 +23,10 @@ export function buildMilestone({
   note           = '',
   has_photo      = false,
   media_type     = null,   // null | 'audio' | 'video'
+  // GLANCEvault forward-compat slots — null until a blob store is wired up
+  media_id       = null,   // stable ref for the audio/video blob
+  photo_id       = null,   // stable ref for the photo blob
+  thumbnail_id   = null,   // reserved; no thumbnail generation yet
   url            = '',
   recurrence     = null,   // null | 'annual'
   recurrence_id  = null,   // UUID shared across instances of a series
@@ -48,6 +52,9 @@ export function buildMilestone({
     note,
     has_photo,
     media_type,
+    media_id,
+    photo_id,
+    thumbnail_id,
     url,
     recurrence,
     recurrence_id,

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -106,6 +106,23 @@ export async function updateMilestone(id, updates, existing) {
   return m
 }
 
+// One-time backfill: stamp media_id / photo_id on existing milestones that
+// pre-date the schema addition. Skips milestones that already have values or
+// have no media. thumbnail_id intentionally left null for all records.
+export async function backfillMediaIds() {
+  const all = await dbGetAll()
+  for (const m of all) {
+    const needsMedia = m.media_type && m.media_id  == null
+    const needsPhoto = m.has_photo  && m.photo_id  == null
+    if (!needsMedia && !needsPhoto) continue
+    await dbPut({
+      ...m,
+      ...(needsMedia ? { media_id: m.id }             : {}),
+      ...(needsPhoto ? { photo_id: `${m.id}-photo` }  : {}),
+    })
+  }
+}
+
 export async function deleteMilestone(id) {
   writeMilestoneTombstone(id)
   await dbDelete(id)

--- a/src/data/milestones.js
+++ b/src/data/milestones.js
@@ -74,6 +74,10 @@ export async function loadMilestones() {
 
 export async function addMilestone(data) {
   const m = buildMilestone(data)
+  // Stamp reference IDs to match the local blob-key convention so the eventual
+  // GLANCEvault cutover is a transport swap with no entity migration.
+  if (m.media_type && m.media_id  == null) m.media_id  = m.id
+  if (m.has_photo  && m.photo_id  == null) m.photo_id  = `${m.id}-photo`
   await dbAdd(m)
   return m
 }

--- a/src/locales/en/milestone.json
+++ b/src/locales/en/milestone.json
@@ -40,6 +40,6 @@
   "deleteSeries": "delete series",
   "trackedInDayglance": "tracked in dayGLANCE",
   "completedInDayglance": "completed in dayGLANCE",
-  "photoSyncedFromDevice": "Photo synced from another device",
-  "mediaSyncedFromDevice": "Media synced from another device"
+  "photoSyncedFromDevice": "📷 Photo stored on originating device",
+  "mediaSyncedFromDevice": "🎬 Photo/video/audio stored on originating device"
 }

--- a/src/locales/en/milestone.json
+++ b/src/locales/en/milestone.json
@@ -41,5 +41,5 @@
   "trackedInDayglance": "tracked in dayGLANCE",
   "completedInDayglance": "completed in dayGLANCE",
   "photoSyncedFromDevice": "📷 Photo stored on originating device",
-  "mediaSyncedFromDevice": "🎬 Photo/video/audio stored on originating device"
+  "mediaSyncedFromDevice": "🎬 Audio/video stored on originating device"
 }

--- a/src/locales/fr/milestone.json
+++ b/src/locales/fr/milestone.json
@@ -40,6 +40,6 @@
   "deleteSeries": "supprimer la série",
   "trackedInDayglance": "suivi dans dayGLANCE",
   "completedInDayglance": "accompli dans dayGLANCE",
-  "photoSyncedFromDevice": "Photo synchronisée depuis un autre appareil",
-  "mediaSyncedFromDevice": "Média synchronisé depuis un autre appareil"
+  "photoSyncedFromDevice": "📷 Photo stockée sur l'appareil d'origine",
+  "mediaSyncedFromDevice": "🎬 Photo/vidéo/audio stockée sur l'appareil d'origine"
 }

--- a/src/locales/fr/milestone.json
+++ b/src/locales/fr/milestone.json
@@ -41,5 +41,5 @@
   "trackedInDayglance": "suivi dans dayGLANCE",
   "completedInDayglance": "accompli dans dayGLANCE",
   "photoSyncedFromDevice": "📷 Photo stockée sur l'appareil d'origine",
-  "mediaSyncedFromDevice": "🎬 Photo/vidéo/audio stockée sur l'appareil d'origine"
+  "mediaSyncedFromDevice": "🎬 Audio/vidéo stocké sur l'appareil d'origine"
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds three nullable fields to the milestone schema (`media_id`, `photo_id`, `thumbnail_id`) as forward-compatibility slots for the upcoming GLANCEvault content-addressed blob store
- Wires `media_id` and `photo_id` on milestone creation and edit paths, mirroring the existing IndexedDB blob-key convention (`<id>` and `<id>-photo`)
- One-time startup backfill (`backfillMediaIds`) stamps existing milestones that have media flags but no reference IDs yet; deliberately does not bump `updated_at` (each device self-heals independently, avoiding sync churn)
- Fixes raw HTML entity strings in `MilestoneDetail` and updates en/fr i18n labels for the media-unavailable placeholder
- Bumps version to 2.1.1

`thumbnail_id` is reserved and intentionally unused — no thumbnail generation until the GLANCEvault media phase.

No changes to `@glance-apps/sync`. The field-agnostic merge carries the new fields automatically.

## Test plan

- [ ] Create a new milestone with a photo — confirm `photo_id` is set to `<id>-photo` in IDB
- [ ] Create a new milestone with audio/video — confirm `media_id` is set to `<id>` in IDB
- [ ] Edit an existing milestone to add/remove media — confirm IDs update/clear correctly
- [ ] On a fresh profile with existing milestones, confirm backfill runs once at startup and is a no-op on subsequent loads
- [ ] Confirm media-unavailable placeholder text renders correctly in en and fr

https://claude.ai/code/session_01JZPpozaGR7jyupWLrVWXuq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZPpozaGR7jyupWLrVWXuq)_