### PR TITLE
Release 2.3.0: bump @glance-apps/sync to 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.2.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.3.0-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lifeglance",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.1.2",
+        "@glance-apps/sync": "^1.1.3",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1647,9 +1647,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.2.tgz",
-      "integrity": "sha512-BlfzcgyVLz+3xdWWa1f+oin0p3fJTmCuCprurRX+CaOpr366eCrTKa4DR0Z3EaoHmXS/qck/WM0qYz0EbjPzCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.3.tgz",
+      "integrity": "sha512-tvtaGlRFILVwX+6LG29omq2e1SCuegLQsfo3kpZwCSgwivE7TNZLE6Hnh88CZdcnUerdKHFQn0LsWbz/8uqoJA==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "type": "module",
   "engines": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.1.2",
+    "@glance-apps/sync": "^1.1.3",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
Release prep for **2.3.0**.

## Changes
- **`@glance-apps/sync` 1.1.2 → 1.1.3** (`package.json` + `package-lock.json`; resolved + integrity verified to 1.1.3).
- **Version 2.2.0 → 2.3.0** in `package.json` and the README version badge.

2.3.0 is a minor bump whose headline feature is **idle / watch mode** (#139, already merged to `main`), plus the iOS standalone status-bar fix (#138, also merged). This branch is based on the current `main`, so it sits on top of both — merging it lands `main` at 2.3.0 with everything present. No special merge order needed.

## Verification
- `npm install` updates the lockfile to sync 1.1.3 cleanly.
- `vite build` passes; all 46 tests green.

https://claude.ai/code/session_01V44WcFqkrbQ6dnhMaoyZdy