### PR TITLE
Filter sibling-app events (lastGLANCE chores) out of the activity log

### DIFF
--- a/src/hooks/useIntentPoller.js
+++ b/src/hooks/useIntentPoller.js
@@ -2,6 +2,18 @@ import { useEffect, useRef, useCallback } from 'react'
 import { pollEvents, isIntegrationEnabled } from '../lib/intentsTransport.js'
 import { ACTIONS, SOURCE_APPS } from '@glance-apps/intents'
 
+// Whether an inbound envelope is something lifeGLANCE actually handles:
+//   - a Goal that dayGLANCE pushed to us (create), or
+//   - a state-change notify about a task that originated here.
+// The sibling apps (dayGLANCE, lastGLANCE) share the same WebDAV events
+// directory, so we also see their traffic — e.g. lastGLANCE chore events.
+// Those aren't actionable here and shouldn't clutter the activity log.
+export function isRelevantInboundEvent({ action, emitted_by, payload } = {}) {
+  if (action === ACTIONS.CREATE && emitted_by === SOURCE_APPS.DAYGLANCE) return true
+  if (action === ACTIONS.NOTIFY && payload?.source_app === SOURCE_APPS.LIFEGLANCE) return true
+  return false
+}
+
 // Polls the WebDAV events directory while the component is mounted (foreground).
 // Calls the appropriate handler for each inbound event:
 //   onInboundCreate(payload)  — dayGLANCE pushed a new Goal → create milestone
@@ -28,6 +40,12 @@ export function useIntentPoller({
 
     await pollEvents(async (envelope) => {
       const { action, payload, event_id, emitted_by } = envelope
+
+      // Skip events from sibling apps that share the events directory (e.g.
+      // lastGLANCE chores) — they're not actionable here. The cursor still
+      // advances for them inside pollEvents; we just don't surface them.
+      if (!isRelevantInboundEvent(envelope)) return
+
       activityRef.current?.({ type: 'received', event_id, action, emitted_by, payload })
 
       if (action === ACTIONS.CREATE && emitted_by === SOURCE_APPS.DAYGLANCE) {

--- a/src/hooks/useIntentPoller.test.js
+++ b/src/hooks/useIntentPoller.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { ACTIONS, EVENTS, SOURCE_APPS } from '@glance-apps/intents'
+import { isRelevantInboundEvent } from './useIntentPoller.js'
+
+describe('isRelevantInboundEvent', () => {
+  it('accepts a Goal create pushed by dayGLANCE', () => {
+    expect(isRelevantInboundEvent({
+      action: ACTIONS.CREATE,
+      emitted_by: SOURCE_APPS.DAYGLANCE,
+      payload: { title: 'Run a marathon', entity_type: 'goal' },
+    })).toBe(true)
+  })
+
+  it('accepts a notify about a lifeGLANCE-originated task', () => {
+    expect(isRelevantInboundEvent({
+      action: ACTIONS.NOTIFY,
+      emitted_by: SOURCE_APPS.DAYGLANCE,
+      payload: { source_app: SOURCE_APPS.LIFEGLANCE, event: EVENTS.COMPLETED },
+    })).toBe(true)
+  })
+
+  it('ignores lastGLANCE chore traffic in the shared events directory', () => {
+    expect(isRelevantInboundEvent({
+      action: ACTIONS.CREATE,
+      emitted_by: SOURCE_APPS.LASTGLANCE,
+      payload: { title: 'Algae Discs', entity_type: 'task' },
+    })).toBe(false)
+  })
+
+  it('ignores a notify whose task did not originate in lifeGLANCE', () => {
+    expect(isRelevantInboundEvent({
+      action: ACTIONS.NOTIFY,
+      emitted_by: SOURCE_APPS.LASTGLANCE,
+      payload: { source_app: SOURCE_APPS.LASTGLANCE, event: EVENTS.COMPLETED },
+    })).toBe(false)
+  })
+
+  it('ignores a create that did not come from dayGLANCE', () => {
+    expect(isRelevantInboundEvent({
+      action: ACTIONS.CREATE,
+      emitted_by: SOURCE_APPS.LIFEGLANCE,
+      payload: { title: 'Self-echo' },
+    })).toBe(false)
+  })
+
+  it('is safe on empty / malformed input', () => {
+    expect(isRelevantInboundEvent()).toBe(false)
+    expect(isRelevantInboundEvent({})).toBe(false)
+    expect(isRelevantInboundEvent({ action: ACTIONS.NOTIFY })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

The dayGLANCE activity log was filling up with chore entries like `Received "Algae Discs" from dayGLANCE` — often several duplicates at the same timestamp — that have nothing to do with lifeGLANCE.

## Cause

dayGLANCE, lastGLANCE, and lifeGLANCE all share a single WebDAV events directory. In `src/hooks/useIntentPoller.js`, the poller wrote **every** inbound envelope to the activity log *before* checking relevance, then only routed `create` (from dayGLANCE) and `notify` (about lifeGLANCE-origin tasks) for actual processing. So **lastGLANCE** chore events were logged but never acted on — pure noise.

Two contributing details worth noting:
- The log label is hardcoded to *"from dayGLANCE"* (`logReceived` string), which is why lastGLANCE events appeared to come from dayGLANCE.
- These events were **not** creating milestones — milestone creation already requires `emitted_by === dayGLANCE` — so this was a display-only bug.

## Fix

Record and route only events that are actually relevant to lifeGLANCE:
- a Goal `create` pushed by dayGLANCE, or
- a `notify` about a task that originated in lifeGLANCE (`payload.source_app === lifeGLANCE`).

Everything else (lastGLANCE chores, self-echoes, etc.) is skipped. The poll cursor still advances for skipped events inside `pollEvents`, so they're not reprocessed on later polls.

The relevance check is factored into a pure, exported `isRelevantInboundEvent()` helper with unit tests.

## Verification
- `npm test` — 52 passing (6 new tests for the helper, covering dayGLANCE goal creates, lifeGLANCE-origin notifies, lastGLANCE chores, non-dayGLANCE creates, and malformed input).
- `npm run build` succeeds.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_