### PR TITLE
Release 2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.3.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.3.1-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the version to **2.3.1** across `package.json`, `package-lock.json`, and the README version badge.

The lockfile change is limited to the two version lines (no dependency changes).

Intended to ship alongside:
- #146 — filter sibling-app (lastGLANCE chore) events out of the activity log
- #145 — Chinese (Simplified & Traditional) translations

## Verification
- `npm install` regenerated the lockfile; diff is the version lines only.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_