### PR TITLE
Fix sync status dot showing error during normal syncs

### DIFF
--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getSyncEngine } from '../../sync/engine'
+import { isSyncing } from '../../sync/status'
 
 const PROXY = '/api/webdav-proxy'
 
@@ -34,7 +35,7 @@ const PROVIDERS = [
 function SyncDot({ syncStatus, syncError, syncHalted }) {
   const color = syncHalted || syncError
     ? 'var(--rose)'
-    : syncStatus === 'syncing'
+    : isSyncing(syncStatus)
       ? 'var(--amber-bright)'
       : 'var(--success)'
   return (

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -32,6 +32,7 @@ import { useIdleMode } from '../../hooks/useIdleMode.js'
 import { relativeLabel, ageAtDate } from '../../utils/dates'
 import { useIntentPoller } from '../../hooks/useIntentPoller.js'
 import { emitCreateForMilestone, emitRescheduledNotify, emitStateNotify, isIntegrationEnabled } from '../../lib/intentsTransport.js'
+import { isSyncing } from '../../sync/status.js'
 import { appendActivityEntry } from '../../lib/intentsActivityLog.js'
 import ActivityLogModal from '../dayglance/ActivityLogModal.jsx'
 import { EVENTS } from '@glance-apps/intents'
@@ -1595,7 +1596,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
               <button
                 className="action-link sync-status-btn"
                 onClick={onOpenCloudSync}
-                title={syncHalted ? t('syncErrorTitle') : syncStatus === 'syncing' ? t('syncingTitle') : syncError ? t('syncErrorSimple') : t('cloudSyncTitle')}
+                title={syncHalted ? t('syncErrorTitle') : isSyncing(syncStatus) ? t('syncingTitle') : syncError ? t('syncErrorSimple') : t('cloudSyncTitle')}
               >
                 <span
                   className="sync-dot"
@@ -1605,7 +1606,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
                     height: '8px',
                     borderRadius: '50%',
                     marginRight: '4px',
-                    background: syncHalted || syncError ? 'var(--rose)' : syncStatus === 'syncing' ? 'var(--amber-bright)' : lastSynced ? 'var(--success)' : 'var(--text-muted)',
+                    background: syncHalted || syncError ? 'var(--rose)' : isSyncing(syncStatus) ? 'var(--amber-bright)' : lastSynced ? 'var(--success)' : 'var(--text-muted)',
                   }}
                 />
                 {t('syncBtn')}

--- a/src/sync/engine.js
+++ b/src/sync/engine.js
@@ -38,10 +38,12 @@ export const initSyncEngine = ({ milestonesRef, chaptersRef, setMilestones, setC
 
     onStatusChange: (status) => {
       setSyncStatus(status)
-      if (status === 'synced' || status === 'idle') setSyncError(null)
+      if (status === 'success' || status === 'idle') setSyncError(null)
     },
     onError: (msg, code, isHardStop) => {
-      setSyncError({ message: msg, code, isHardStop });
+      // The engine calls onError(null, …) to clear a previous error; only treat
+      // a real message as an error so the dot doesn't show rose during a sync.
+      setSyncError(msg ? { message: msg, code, isHardStop } : null);
       if (isHardStop) setSyncHalted(true);
     },
     onLastSyncedChange: setLastSynced,

--- a/src/sync/status.js
+++ b/src/sync/status.js
@@ -1,0 +1,5 @@
+// Status vocabulary reported by the cloud sync engine (@glance-apps/sync).
+// The engine emits: 'uploading', 'downloading', 'success', 'error', 'idle'.
+// 'uploading' / 'downloading' are the in-flight states; the rest are terminal.
+export const isSyncing = (status) =>
+  status === 'uploading' || status === 'downloading'

--- a/src/sync/status.test.js
+++ b/src/sync/status.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { isSyncing } from './status.js'
+
+describe('isSyncing', () => {
+  it('is true for the in-flight statuses', () => {
+    expect(isSyncing('uploading')).toBe(true)
+    expect(isSyncing('downloading')).toBe(true)
+  })
+
+  it('is false for terminal statuses', () => {
+    expect(isSyncing('success')).toBe(false)
+    expect(isSyncing('error')).toBe(false)
+    expect(isSyncing('idle')).toBe(false)
+  })
+
+  it('is false for unknown / legacy values', () => {
+    // The dot historically checked for 'syncing', which the engine never emits.
+    expect(isSyncing('syncing')).toBe(false)
+    expect(isSyncing(undefined)).toBe(false)
+    expect(isSyncing('')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes the long-standing sync indicator behavior @krelltunez spotted: the dot goes green → rose → green on every sync and never shows amber, even though sync is working. This is a logic bug present in **both themes** (not theme-specific).

> **Note on base branch:** targeted at `claude/light-theme` (#149) because it edits the same dot line, avoiding a merge conflict. Once #149 merges, I'll retarget this to `main`.

## Root cause (two bugs)
1. **The "clear error" call was stored as a truthy object.** `@glance-apps/sync` calls `onError(null, null, false)` at the start of every upload/download to *clear* the previous error. The app handler did `setSyncError({ message: msg, code, isHardStop })` unconditionally, turning "no error" into the truthy object `{ message: null }`. The dot (`syncHalted || syncError ? rose`) then read that as an error for the entire sync, clearing only on `idle`.
2. **The amber "syncing" state was unreachable.** The dots checked `syncStatus === 'syncing'`, but the engine only emits `'uploading'` / `'downloading'` / `'success'` / `'error'` / `'idle'` — never `'syncing'`. (The app's error-clear similarly checked `'synced'`, which the engine never emits; it emits `'success'`.)

The 404/405s in the console are unrelated — the engine handles those gracefully and they never reach `onError`.

## Fix
- `src/sync/engine.js`: a `null` message now clears the error (`setSyncError(msg ? {…} : null)`); the error-clear status check uses `'success'` (what the engine actually emits).
- New `src/sync/status.js` with an `isSyncing(status)` helper — a single source of truth for the engine's in-flight statuses — used by both the timeline dot/tooltip and the cloud-sync modal's `SyncDot` (which had the same bug). Unit tested.

**Result:** amber while uploading/downloading, green when synced, rose only on a genuine error. The amber state is now actually reachable.

## Verification
- `npm test` — 55 passing (3 new for `isSyncing`, incl. a guard that the legacy `'syncing'` value is correctly treated as not-in-flight).
- `npm run build` succeeds.

## Accessibility note
You mentioned you're color blind. This PR keeps the indicator color-only (per your "fix the logic bug" choice). The hover tooltip already names the state in words. If you ever want it to not depend on color at all — a distinct glyph/shape or a pulse per state — I'm happy to do that as a follow-up.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_