### PR TITLE
Fix watch-mode wordmark ghost; intensify film grain

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -174,7 +174,7 @@ body::after {
   inset: 0;
   z-index: 9999;
   pointer-events: none;
-  opacity: 0.045;
+  opacity: 0.09;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
   background-size: 200px 200px;
 }
@@ -1490,6 +1490,12 @@ button, input, select, textarea {
   opacity: 0.05;
   pointer-events: none;
   transition: opacity 1s ease;
+}
+
+/* Watch mode redraws the wordmark in .idle-brand; fully hide the header's copy
+   so the faded-chrome original doesn't show through as a ghost behind it. */
+.timeline-view.idle-active .timeline-header .logo {
+  opacity: 0;
 }
 
 .idle-overlay {


### PR DESCRIPTION
Two small visual fixes from review feedback.

## 1. Watch-mode wordmark ghost
In watch mode the chrome (header, bottom bar, minimap, stats) is intentionally faded to `opacity: 0.05` as an ambient backdrop. But the `.idle-brand` overlay **redraws** the `lifeGLANCE` wordmark at its own position (top-left, `0.6rem`/`1.1rem`), while the faded header logo sits at the header's own position. The two don't line up, so the 5%-opacity header copy showed through as a faint "ghost" wordmark below the crisp one. (Present in both themes; just easier to see on light.)

Fix: hide the header's logo copy while `idle-active`, since the overlay already provides the wordmark:
```css
.timeline-view.idle-active .timeline-header .logo { opacity: 0; }
```
The rest of the ambient-faded chrome is unchanged.

## 2. Film grain intensified
The `body::after` grain overlay was at `opacity: 0.045` — nearly invisible, especially on the light theme. Bumped to `0.09` (still subtle, under 10%).

Both are CSS-only. `npm run build` succeeds; `npm test` — 55 passing.

If `0.09` grain feels too strong (or not strong enough) once you see it on a real screen, it's a one-line tweak — happy to dial it.

## Also noted
No auto/System theme option, per your preference — the toggle stays explicit Dark/Light.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_