### PR TITLE
Mute the unconfigured sync dot further

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1606,7 +1606,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
                     height: '8px',
                     borderRadius: '50%',
                     marginRight: '4px',
-                    background: syncHalted || syncError ? 'var(--rose)' : isSyncing(syncStatus) ? 'var(--amber-bright)' : lastSynced ? 'var(--success)' : 'var(--text-muted)',
+                    background: syncHalted || syncError ? 'var(--rose)' : isSyncing(syncStatus) ? 'var(--amber-bright)' : lastSynced ? 'var(--success)' : 'rgba(var(--text-rgb), 0.2)',
                   }}
                 />
                 {t('syncBtn')}


### PR DESCRIPTION
Follow-up to the sync-dot work: the unconfigured/never-synced dot used `--text-muted` (≈0.4 alpha in dark, 0.55 in light), which still read as a prominent gray dot for a "nothing set up" state.

Drops it to `rgba(var(--text-rgb), 0.2)` — roughly half the opacity — so it's a faint, unobtrusive marker while staying theme-aware. The error/syncing/synced states are unchanged.

One-line CSS-in-JS change; `npm run build` succeeds, 55 tests pass. If `0.2` is still too visible (or now too faint), it's a trivial nudge.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_