### PR TITLE
Show build date/time in help modal instead of current time

### DIFF
--- a/src/components/help/HelpModal.jsx
+++ b/src/components/help/HelpModal.jsx
@@ -42,9 +42,11 @@ export default function HelpModal({ onClose, onOpenShortcuts }) {
 
   const idbEst = useIndexedDBEstimate()
 
-  const now = new Date()
-  const dateStr = now.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
-  const timeStr = now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+  // Build timestamp injected by Vite (see vite.config.js). Falls back to now if
+  // the constant isn't defined (e.g. outside a Vite build).
+  const built = new Date(typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : Date.now())
+  const dateStr = built.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+  const timeStr = built.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 
   return (
     <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>

--- a/vite.config.js
+++ b/vite.config.js
@@ -39,6 +39,11 @@ function webdavProxyPlugin() {
 }
 
 export default defineConfig({
+  // Captured at build time (and at dev-server start) so the help modal can show
+  // when this bundle was built rather than the current wall-clock time.
+  define: {
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
   plugins: [
     webdavProxyPlugin(),
     react(),


### PR DESCRIPTION
The help (`?`) modal footer (`v{VERSION} · {date}, {time}`) used `new Date()`, so it always showed the **current** wall-clock time instead of when the bundle was built.

## Fix
- `vite.config.js`: inject a `__BUILD_TIME__` constant via `define`, captured at build time (`new Date().toISOString()`).
- `HelpModal.jsx`: render that timestamp instead of `new Date()`, with a fallback to now if the constant isn't defined (e.g. outside a Vite build).

## Verification
- Built and confirmed the placeholder is replaced and the literal ISO timestamp is baked into the bundle (matched the build moment, e.g. `2026-06-13T19:25:23Z`), so it's frozen at build, not evaluated at runtime.
- `npm test` — 55 passing.

Note: under `vite dev` the value is the dev-server start time; on a production `vite build` (Vercel) it's the build moment, which is what the modal is meant to show.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX)_