### PR TITLE
Watch mode: ignore passive mouse movement, hide cursor, request fullscreen

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -29,6 +29,7 @@ import { dbPutMedia, dbPutPhoto, dbDeletePhoto, dbGetPhoto, dbPut } from '../../
 import { parseIcs }      from '../../utils/icsParser'
 import * as audio from '../../utils/audio'
 import { useIdleMode } from '../../hooks/useIdleMode.js'
+import { enterFullscreen, exitFullscreen, isFullscreen } from '../../utils/fullscreen.js'
 import { relativeLabel, ageAtDate } from '../../utils/dates'
 import { useIntentPoller } from '../../hooks/useIntentPoller.js'
 import { emitCreateForMilestone, emitRescheduledNotify, emitStateNotify, isIntegrationEnabled } from '../../lib/intentsTransport.js'
@@ -1315,10 +1316,17 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     return opts
   }, [filteredMilestones, chapters, t])
 
+  // True only while watch mode owns the fullscreen it requested, so we exit the
+  // user's own fullscreen alone.
+  const enteredFsRef = useRef(false)
+
   function startWatchTheme(key) {
     setWatchTheme(key)
     setWatchMenuOpen(false)
     setWatchStartToken(n => n + 1)   // fires the start effect even if the theme is unchanged
+    // Request fullscreen here, inside the click gesture, so the browser grants it
+    // (it won't from the deferred start effect or an idle auto-start).
+    enterFullscreen().then(ok => { enteredFsRef.current = ok })
   }
   const anyModalOpen =
     addOpen || !!detail || settingsOpen || helpOpen || kbdOpen || searchOpen ||
@@ -1379,6 +1387,27 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     if (watchStartToken === 0) return
     idle.start(true)
   }, [watchStartToken]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When the tour ends, drop the fullscreen it requested.
+  useEffect(() => {
+    if (!idle.active && enteredFsRef.current) {
+      exitFullscreen()
+      enteredFsRef.current = false
+    }
+  }, [idle.active])
+
+  // If the user leaves fullscreen during the tour (e.g. Esc), end the tour too.
+  useEffect(() => {
+    const onFsChange = () => {
+      if (!isFullscreen() && enteredFsRef.current && idle.active) idle.stop()
+    }
+    document.addEventListener('fullscreenchange', onFsChange)
+    document.addEventListener('webkitfullscreenchange', onFsChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', onFsChange)
+      document.removeEventListener('webkitfullscreenchange', onFsChange)
+    }
+  }, [idle.active, idle.stop])
 
   // Close the watch menu on any outside click.
   useEffect(() => {

--- a/src/hooks/useIdleMode.js
+++ b/src/hooks/useIdleMode.js
@@ -2,11 +2,17 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import * as audio from '../utils/audio'
 import { acquireWakeLock, releaseWakeLock } from '../utils/wakeLock'
 
-// User input that resets the idle timer and (while playing) exits idle mode.
+// User input that resets the idle timer (so watch mode doesn't auto-start while
+// the mouse is in use).
 const ACTIVITY_EVENTS = [
   'mousemove', 'mousedown', 'pointerdown',
   'keydown', 'wheel', 'touchstart', 'touchmove', 'scroll',
 ]
+
+// Deliberate interactions that EXIT watch mode once it's running. Passive
+// mousemove is intentionally excluded — a drifting cursor shouldn't kick you
+// out ("tap anywhere to exit").
+const EXIT_EVENTS = ACTIVITY_EVENTS.filter(e => e !== 'mousemove')
 
 // After idle starts, ignore input briefly so the initiating click/tap (and the
 // natural mouse-away that follows it) doesn't immediately cancel it.
@@ -106,9 +112,10 @@ export function useIdleMode({
         start(false)
       }, timeoutRef.current)
     }
-    function onActivity() {
+    function onActivity(e) {
       if (activeRef.current) {
         if (guardRef.current) return   // ignore the start gesture + mouse-away
+        if (!EXIT_EVENTS.includes(e.type)) return   // passive mousemove: stay in watch mode
         stop()
       }
       scheduleIdle()

--- a/src/index.css
+++ b/src/index.css
@@ -1498,6 +1498,14 @@ button, input, select, textarea {
   opacity: 0;
 }
 
+/* Watch mode is a hands-off ambient display: hide the cursor so it isn't a
+   distraction. Paired with not exiting on mousemove, a drifting cursor now
+   stays fully out of the way. */
+.timeline-view.idle-active,
+.timeline-view.idle-active * {
+  cursor: none;
+}
+
 .idle-overlay {
   position: absolute;
   inset: 0;

--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -1,0 +1,36 @@
+// Best-effort Fullscreen API wrappers for the watch-mode tour.
+//
+// Fullscreen requires transient user activation, so enterFullscreen() must be
+// called from within a user gesture (e.g. the Watch button click). It resolves
+// to true only if THIS call entered fullscreen — false if it's unsupported
+// (e.g. iOS Safari), denied, or we were already fullscreen — so the caller
+// knows whether it's responsible for exiting later.
+
+const fullscreenElement = () =>
+  document.fullscreenElement || document.webkitFullscreenElement || null
+
+export function enterFullscreen(el = document.documentElement) {
+  if (fullscreenElement()) return Promise.resolve(false)
+  const req = el.requestFullscreen || el.webkitRequestFullscreen
+  if (!req) return Promise.resolve(false)
+  try {
+    return Promise.resolve(req.call(el)).then(() => true, () => false)
+  } catch {
+    return Promise.resolve(false)
+  }
+}
+
+export function exitFullscreen() {
+  if (!fullscreenElement()) return Promise.resolve()
+  const exit = document.exitFullscreen || document.webkitExitFullscreen
+  if (!exit) return Promise.resolve()
+  try {
+    return Promise.resolve(exit.call(document)).catch(() => {})
+  } catch {
+    return Promise.resolve()
+  }
+}
+
+export function isFullscreen() {
+  return !!fullscreenElement()
+}


### PR DESCRIPTION
Makes watch mode a proper hands-off ambient display.

## Changes
- **Passive `mousemove` no longer exits.** `useIdleMode` treated every input event the same, so a drifting cursor exited even though the hint says "tap anywhere to exit." Split the lists: `ACTIVITY_EVENTS` (incl. `mousemove`) still resets the idle countdown so watch mode won't auto-start while you're using the mouse, but only `EXIT_EVENTS` — `mousedown`/`pointerdown`/`keydown`/`wheel`/`touchstart`/`touchmove`/`scroll` — exit once it's running.
- **Cursor hidden while active** (`.timeline-view.idle-active { cursor: none }`).
- **Fullscreen on the explicit Watch start.** Starting a tour from the Watch menu is a user gesture, so we request fullscreen there for immersion (`src/utils/fullscreen.js`). Notes:
  - Only the **gesture path** goes fullscreen — fullscreen needs transient activation, so idle **auto-start stays windowed** (cursor's hidden there regardless). This is a browser constraint, not a choice.
  - We only exit the fullscreen **we** requested (tracked via `enteredFsRef`), so a user's pre-existing fullscreen is left alone.
  - Leaving fullscreen (e.g. **Esc**) ends the tour; ending the tour drops the fullscreen. iOS Safari (no element fullscreen) degrades gracefully to windowed.

`npm run build` succeeds; `npm test` — 55 passing.

https://claude.ai/code/session_01Ea54dmyB7v93Wx7bacqZEX