### PR TITLE
Bump @glance-apps/sync to 1.3.2; release 2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.3.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.3.3-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lifeglance",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.1.3",
+        "@glance-apps/sync": "^1.3.2",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1647,9 +1647,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.3.tgz",
-      "integrity": "sha512-tvtaGlRFILVwX+6LG29omq2e1SCuegLQsfo3kpZwCSgwivE7TNZLE6Hnh88CZdcnUerdKHFQn0LsWbz/8uqoJA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.2.tgz",
+      "integrity": "sha512-49Wh24nMQaiGOvgmm6dVXCqCeuXhxx/zjNGGy+VnMnyqUyFEUYy6KYr53E3gTluFMvRxjsoY/ofFIh3OP36kVw==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "type": "module",
   "engines": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.1.3",
+    "@glance-apps/sync": "^1.3.2",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
Dependency maintenance: upgrade the shared cloud-sync engine to its latest release.

## Changes
- `@glance-apps/sync`: `^1.1.3` → `^1.3.2` (published ~17h ago)
- Regenerated `package-lock.json` via `npm install` (resolves to `1.3.2`)
- App version: `2.3.2` → `2.3.3` (patch bump — dependency maintenance, no app feature/behavior changes)
- README version badge: `2.3.2` → `2.3.3`

## Verification
- `npm test` → 7 files, 55 tests passing
- Lockfile resolves `@glance-apps/sync@1.3.2` from the public npm registry

https://claude.ai/code/session_01KLcqHihNZUPxngJgWgZkT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLcqHihNZUPxngJgWgZkT9)_