### PR TITLE
Go fullscreen on native (hide system bars)

### DIFF
--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -1,5 +1,36 @@
 package com.lifeglance.app;
 
+import android.os.Bundle;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        enableImmersiveMode();
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        // System bars reappear after interaction / regaining focus; re-hide them.
+        if (hasFocus) enableImmersiveMode();
+    }
+
+    // Hide the status and navigation bars for a fullscreen timeline; they slide
+    // back in temporarily on an edge swipe, then auto-hide again.
+    private void enableImmersiveMode() {
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        WindowInsetsControllerCompat controller =
+                WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        controller.hide(WindowInsetsCompat.Type.systemBars());
+        controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+    }
+}

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -44,7 +44,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<key>UIStatusBarHidden</key>
 	<true/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Hides the system bars so the native apps run fullscreen, matching the timeline's edge-to-edge intent (the web manifest's `display: fullscreen` only covers the PWA, not the native shells).

## Changes

- **Android** — immersive sticky mode in `MainActivity` via `WindowInsetsControllerCompat` (androidx.core, already on the classpath — no new dependency):
  - Hides both the status bar and navigation bar.
  - `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` — an edge swipe reveals them transiently, then they auto-hide.
  - Re-applied in `onWindowFocusChanged` so the bars don't linger after dialogs / app-switching.
  - Works back to minSdk 24.
- **iOS** — hide the status bar in `Info.plist`: `UIStatusBarHidden = true` and `UIViewControllerBasedStatusBarAppearance = false` (so the plist value actually applies).

## Not build-verified ⚠️

Developed without an Android SDK or Xcode, so the native build wasn't exercised. `vite build`, `cap sync`, and `npm test` (55 passing) are green. Since `MainActivity.java` changed, a clean rebuild (`./build.sh --clean`) is worth it if immersive mode doesn't show on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT28KhCBTHi811VgaYLBNe)_