### PR TITLE
iOS: require fullscreen to pass iPad orientation validation

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -44,6 +44,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>


### PR DESCRIPTION
Fixes App Store upload validation error **90474**: a landscape-only iPad app is rejected unless it opts out of multitasking.

```
Invalid bundle. The "UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight"
orientations were provided for the UISupportedInterfaceOrientations Info.plist key … but you
need to include all of the "…Portrait,…PortraitUpsideDown,…LandscapeLeft,…LandscapeRight"
orientations to support iPad multitasking.
```

lifeGLANCE is intentionally landscape-only and fullscreen, so the correct fix is to **opt out of iPad multitasking** rather than add portrait orientations back (which would let the iPad rotate to portrait and break the design):

- `Info.plist`: `UIRequiresFullScreen = true`.

This is the standard App-Store-accepted combination for landscape immersive apps and preserves the existing landscape lock + fullscreen behavior. Not build-verified here (no macOS/Xcode); re-archive and re-upload to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT28KhCBTHi811VgaYLBNe)_