### PR TITLE
Add Android widget data bridge and Next Milestone widget

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 // Derive versionName/versionCode from package.json (e.g. 1.8.4 -> 10804).
 // Assumes a clean x.y.z version (no -beta suffix) and minor/patch < 100.
@@ -48,6 +50,21 @@ android {
             signingConfig keystorePropsFile.exists() ? signingConfigs.release : null
         }
     }
+    compileOptions {
+        // Desugaring lets us use java.time (LocalDate/Period) for the widget's
+        // relative-date math down to minSdk 24.
+        coreLibraryDesugaringEnabled true
+        // Java level is forced to 21 by capacitor.build.gradle (applied below);
+        // keep Kotlin's jvmTarget in sync to avoid a JVM-target mismatch.
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+    kotlinOptions {
+        jvmTarget = '21'
+    }
+    buildFeatures {
+        compose true
+    }
 }
 
 repositories {
@@ -62,6 +79,12 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
+
+    // Home-screen widgets (Jetpack Glance, Kotlin/Compose)
+    implementation "androidx.glance:glance-appwidget:$rootProject.ext.glanceVersion"
+    implementation "androidx.work:work-runtime-ktx:2.9.1"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
+
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,18 @@
             android:grantUriPermissions="true">
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Home-screen widget: next milestone / countdown -->
+        <receiver
+            android:name=".widget.NextMilestoneReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/next_milestone_widget_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -1,5 +1,6 @@
 package com.lifeglance.app;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.core.view.WindowCompat;
@@ -7,13 +8,39 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.getcapacitor.BridgeActivity;
+import com.lifeglance.app.widget.WidgetData;
 
 public class MainActivity extends BridgeActivity {
 
+    // Extra carrying the milestone id a widget tap wants the app to focus.
+    public static final String EXTRA_WIDGET_MILESTONE_ID = "widget_milestone_id";
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(WidgetBridgePlugin.class);
         super.onCreate(savedInstanceState);
+        handleWidgetIntent(getIntent());
         enableImmersiveMode();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleWidgetIntent(intent);
+    }
+
+    // Stash a widget tap's milestone id where the web layer can read it via
+    // WidgetBridge.consumeLaunchTarget() once the WebView resumes.
+    private void handleWidgetIntent(Intent intent) {
+        if (intent == null) return;
+        String milestoneId = intent.getStringExtra(EXTRA_WIDGET_MILESTONE_ID);
+        if (milestoneId == null) return;
+        getSharedPreferences(WidgetData.PREFS, MODE_PRIVATE)
+            .edit()
+            .putString(WidgetData.KEY_PENDING_TARGET, milestoneId)
+            .apply();
+        intent.removeExtra(EXTRA_WIDGET_MILESTONE_ID);
     }
 
     @Override

--- a/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
@@ -1,0 +1,72 @@
+package com.lifeglance.app;
+
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.lifeglance.app.widget.NextMilestoneReceiver;
+import com.lifeglance.app.widget.WidgetData;
+import com.lifeglance.app.widget.WidgetRefreshWorker;
+
+/**
+ * Bridge between the web app (IndexedDB, unreachable from the widget process) and
+ * the native home-screen widgets. The web layer pushes a render-ready snapshot which
+ * is persisted to SharedPreferences and read by the widgets.
+ */
+@CapacitorPlugin(name = "WidgetBridge")
+public class WidgetBridgePlugin extends Plugin {
+
+    @Override
+    public void load() {
+        // Make sure the daily midnight refresh is scheduled whenever the app runs.
+        WidgetRefreshWorker.Companion.schedule(getContext());
+    }
+
+    // Persists the snapshot JSON and refreshes any placed widgets immediately.
+    @PluginMethod
+    public void updateSnapshot(PluginCall call) {
+        String json = call.getString("json");
+        if (json == null) {
+            call.reject("Missing 'json'");
+            return;
+        }
+        Context ctx = getContext();
+        ctx.getSharedPreferences(WidgetData.PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putString(WidgetData.KEY_SNAPSHOT, json)
+            .apply();
+        notifyWidgets(ctx);
+        call.resolve();
+    }
+
+    // Returns and clears a pending deep-link target left by a widget tap.
+    @PluginMethod
+    public void consumeLaunchTarget(PluginCall call) {
+        Context ctx = getContext();
+        SharedPreferences prefs = ctx.getSharedPreferences(WidgetData.PREFS, Context.MODE_PRIVATE);
+        String target = prefs.getString(WidgetData.KEY_PENDING_TARGET, null);
+        if (target != null) {
+            prefs.edit().remove(WidgetData.KEY_PENDING_TARGET).apply();
+        }
+        JSObject ret = new JSObject();
+        ret.put("milestoneId", target); // null when nothing is pending
+        call.resolve(ret);
+    }
+
+    private void notifyWidgets(Context ctx) {
+        AppWidgetManager mgr = AppWidgetManager.getInstance(ctx);
+        ComponentName cn = new ComponentName(ctx, NextMilestoneReceiver.class);
+        int[] ids = mgr.getAppWidgetIds(cn);
+        Intent intent = new Intent(ctx, NextMilestoneReceiver.class);
+        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
+        ctx.sendBroadcast(intent);
+    }
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/NextMilestoneWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/NextMilestoneWidget.kt
@@ -1,0 +1,119 @@
+package com.lifeglance.app.widget
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lifeglance.app.MainActivity
+
+// Brand palette (mirrors the web app's dark theme tokens in src/index.css).
+private val BG = Color(0xFF0F1117)
+private val TEXT = Color(0xFFE8E0D0)
+private val AMBER = Color(0xFFC8A96E)
+private val MUTED = Color(0xFF8A8270)
+
+class NextMilestoneWidget : GlanceAppWidget() {
+    // Two breakpoints: compact (countdown + title) and a taller layout that also
+    // surfaces the most recently passed milestone.
+    override val sizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(160.dp, 80.dp),
+            DpSize(220.dp, 140.dp),
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snapshot = WidgetData.readSnapshot(context)
+        provideContent {
+            Content(context, snapshot)
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, snapshot: WidgetData.Snapshot?) {
+        val next = snapshot?.next
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(ColorProvider(BG))
+                .cornerRadius(16.dp)
+                .padding(16.dp)
+                .clickable(actionStartActivity(launchIntent(context, next?.id))),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (next == null) {
+                Text(
+                    text = "No upcoming milestones",
+                    style = TextStyle(color = ColorProvider(MUTED), fontFamily = FontFamily.Monospace, fontSize = 13.sp),
+                )
+                return@Column
+            }
+
+            Text(
+                text = "NEXT",
+                style = TextStyle(color = ColorProvider(AMBER), fontFamily = FontFamily.Monospace, fontSize = 10.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(4.dp))
+            Text(
+                text = WidgetData.relativeLabel(next.date),
+                style = TextStyle(color = ColorProvider(TEXT), fontFamily = FontFamily.Monospace, fontSize = 22.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(2.dp))
+            Text(
+                text = next.title,
+                maxLines = 2,
+                style = TextStyle(color = ColorProvider(TEXT), fontFamily = FontFamily.Monospace, fontSize = 14.sp),
+            )
+            Text(
+                text = WidgetData.formatDateForPrecision(next.date, next.datePrecision),
+                style = TextStyle(color = ColorProvider(MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+            )
+
+            // Taller layout: a faint "last passed" line beneath.
+            val prev = snapshot.prev
+            if (prev != null) {
+                Spacer(GlanceModifier.height(8.dp))
+                Text(
+                    text = "last · ${prev.title} (${WidgetData.relativeLabel(prev.date)})",
+                    maxLines = 1,
+                    style = TextStyle(color = ColorProvider(MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+                )
+            }
+        }
+    }
+
+    // Opens the app, carrying the tapped milestone id so the web layer can focus it.
+    private fun launchIntent(context: Context, milestoneId: String?): Intent =
+        Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            if (milestoneId != null) putExtra(MainActivity.EXTRA_WIDGET_MILESTONE_ID, milestoneId)
+        }
+}
+
+class NextMilestoneReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = NextMilestoneWidget()
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -1,0 +1,123 @@
+package com.lifeglance.app.widget
+
+import android.content.Context
+import org.json.JSONObject
+import java.time.LocalDate
+import java.time.Period
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+/**
+ * Shared storage contract and parsing for the home-screen widgets.
+ *
+ * The web app (via WidgetBridgePlugin) writes a JSON snapshot into SharedPreferences.
+ * The widget process reads it here. Snapshots store raw ISO dates; relative labels
+ * like "in 12 days" are computed at render time so they stay correct between pushes.
+ */
+object WidgetData {
+    const val PREFS = "lifeglance_widget"
+    const val KEY_SNAPSHOT = "snapshot"
+    const val KEY_PENDING_TARGET = "pending_target"
+
+    fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    data class Milestone(
+        val id: String,
+        val title: String,
+        val date: String,          // ISO 8601
+        val datePrecision: String, // year | month | day
+        val color: String?,
+    )
+
+    data class Snapshot(
+        val next: Milestone?,
+        val prev: Milestone?,
+        val currentChapterTitle: String?,
+        val pastCount: Int,
+        val futureCount: Int,
+    )
+
+    fun readSnapshot(context: Context): Snapshot? {
+        val raw = prefs(context).getString(KEY_SNAPSHOT, null) ?: return null
+        return try {
+            val obj = JSONObject(raw)
+            val counts = obj.optJSONObject("counts")
+            Snapshot(
+                next = parseMilestone(obj.optJSONObject("next")),
+                prev = parseMilestone(obj.optJSONObject("prev")),
+                currentChapterTitle = obj.optJSONObject("currentChapter")?.optString("title"),
+                pastCount = counts?.optInt("past", 0) ?: 0,
+                futureCount = counts?.optInt("future", 0) ?: 0,
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun parseMilestone(obj: JSONObject?): Milestone? {
+        if (obj == null) return null
+        val id = obj.optString("id", "")
+        val date = obj.optString("date", "")
+        if (id.isEmpty() || date.isEmpty()) return null
+        return Milestone(
+            id = id,
+            title = obj.optString("title", ""),
+            date = date,
+            datePrecision = obj.optString("datePrecision", "day"),
+            color = obj.optString("color").takeIf { it.isNotEmpty() },
+        )
+    }
+
+    // The calendar date the milestone falls on, read from the UTC components of the
+    // ISO string — matching the web app's toLocalNoon convention.
+    private fun localDateOf(iso: String): LocalDate? = try {
+        java.time.Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
+    } catch (e: Exception) {
+        null
+    }
+
+    /** Mirrors the web app's relativeLabel(): "in 3 days", "2 yrs, 1 mo ago", "today". */
+    fun relativeLabel(iso: String, today: LocalDate = LocalDate.now()): String {
+        val date = localDateOf(iso) ?: return ""
+        if (date.isEqual(today)) return "today"
+        val past = date.isBefore(today)
+        val from = if (past) date else today
+        val to = if (past) today else date
+        val period = Period.between(from, to)
+        val totalDays = ChronoUnit.DAYS.between(from, to)
+        val years = period.years
+        val months = period.months
+        val suffix = if (past) " ago" else ""
+        val prefix = if (past) "" else "in "
+        val body = when {
+            years > 0 && months > 0 -> "$years yr${plural(years)}, $months mo"
+            years > 0               -> "$years yr${plural(years)}"
+            totalDays > 30          -> "${totalDays / 30} mo"
+            totalDays > 0           -> "$totalDays day${plural(totalDays)}"
+            else                    -> return "today"
+        }
+        return "$prefix$body$suffix"
+    }
+
+    /** Mirrors formatDateDisplay(): precision-aware date formatting. */
+    fun formatDate(iso: String): String {
+        val date = localDateOf(iso) ?: return ""
+        return date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.getDefault()))
+    }
+
+    fun formatDateForPrecision(iso: String, precision: String): String {
+        val date = localDateOf(iso) ?: return ""
+        val pattern = when (precision) {
+            "year"  -> "yyyy"
+            "month" -> "MMMM yyyy"
+            else    -> "MMMM d, yyyy"
+        }
+        return date.format(DateTimeFormatter.ofPattern(pattern, Locale.getDefault()))
+    }
+
+    private fun plural(n: Long) = if (n != 1L) "s" else ""
+    private fun plural(n: Int) = if (n != 1) "s" else ""
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
@@ -1,0 +1,44 @@
+package com.lifeglance.app.widget
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+/**
+ * Re-renders the widgets once per local midnight so relative countdowns ("in 3 days")
+ * roll over even when the app is never opened. Each run re-schedules the next one.
+ */
+class WidgetRefreshWorker(context: Context, params: WorkerParameters) :
+    CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        NextMilestoneWidget().updateAll(applicationContext)
+        schedule(applicationContext)
+        return Result.success()
+    }
+
+    companion object {
+        private const val WORK_NAME = "lifeglance_widget_daily_refresh"
+
+        // Enqueues a one-shot refresh for the next local midnight. KEEP avoids
+        // piling up duplicates when called repeatedly (e.g. on every app start).
+        fun schedule(context: Context) {
+            val now = ZonedDateTime.now()
+            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(now.zone)
+            val delayMs = Duration.between(now, nextMidnight).toMillis().coerceAtLeast(0)
+
+            val request = OneTimeWorkRequestBuilder<WidgetRefreshWorker>()
+                .setInitialDelay(delayMs, TimeUnit.MILLISECONDS)
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="title_activity_main">lifeGLANCE</string>
     <string name="package_name">com.lifeglance.app</string>
     <string name="custom_url_scheme">com.lifeglance.app</string>
+    <string name="widget_next_milestone_description">Your next upcoming milestone, with a live countdown.</string>
 </resources>

--- a/android/app/src/main/res/xml/next_milestone_widget_info.xml
+++ b/android/app/src/main/res/xml/next_milestone_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="160dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_next_milestone_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewLayout="@layout/glance_default_loading_layout" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+    // Kotlin version for the Glance widgets. Buildscript blocks are evaluated before
+    // `apply from: variables.gradle`, so this can't be read from ext here; keep it in
+    // sync with kotlinVersion in variables.gradle.
+    ext.kotlinVersion = '2.0.21'
+
     repositories {
         google()
         mavenCentral()
@@ -9,6 +13,10 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
+
+        // Kotlin + Compose compiler plugins for the Jetpack Glance home-screen widgets.
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,4 +13,8 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
+
+    // Native home-screen widgets (Jetpack Glance, Kotlin/Compose)
+    kotlinVersion = '2.0.21'
+    glanceVersion = '1.1.1'
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import SyncPassphraseModal from './components/sync/SyncPassphraseModal'
 import { initDB, dbGetAll, dbGetAllChapters } from './data/db'
 import { backfillMediaIds } from './data/milestones'
 import { initSyncEngine, getSyncEngine } from './sync/engine'
+import { buildWidgetSnapshot } from './utils/widgetSnapshot'
+import { pushWidgetSnapshot } from './native/widgetBridge'
 
 export default function App() {
   const { t } = useTranslation('common')
@@ -129,6 +131,33 @@ export default function App() {
       getSyncEngine()?.upload()
     }, 5_000)
     return () => clearTimeout(uploadTimerRef.current)
+  }, [milestones, chapters, screen])
+
+  // Push a render-ready snapshot to the native home-screen widgets. Debounced on
+  // data changes (parallel to the sync upload above), and flushed immediately when
+  // the app backgrounds so the widget reflects the latest state by the time the
+  // user is looking at the home screen. No-op on web. Reading birthday from
+  // localStorage here keeps this independent of TimelineView's local copy.
+  const widgetTimerRef = useRef(null)
+  useEffect(() => {
+    if (screen !== 'timeline') return
+
+    const flush = () => {
+      const birthday = localStorage.getItem('lifeglance-birthday') || null
+      pushWidgetSnapshot(
+        buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday)
+      )
+    }
+
+    if (widgetTimerRef.current) clearTimeout(widgetTimerRef.current)
+    widgetTimerRef.current = setTimeout(flush, 1_000)
+
+    const onHide = () => { if (document.visibilityState === 'hidden') flush() }
+    document.addEventListener('visibilitychange', onHide)
+    return () => {
+      clearTimeout(widgetTimerRef.current)
+      document.removeEventListener('visibilitychange', onHide)
+    }
   }, [milestones, chapters, screen])
 
   function handleOnboardingComplete(initial) {

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -32,6 +32,7 @@ import { useIdleMode } from '../../hooks/useIdleMode.js'
 import { enterFullscreen, exitFullscreen, isFullscreen } from '../../utils/fullscreen.js'
 import { relativeLabel, ageAtDate } from '../../utils/dates'
 import { useIntentPoller } from '../../hooks/useIntentPoller.js'
+import { consumeWidgetLaunchTarget } from '../../native/widgetBridge.js'
 import { emitCreateForMilestone, emitRescheduledNotify, emitStateNotify, isIntegrationEnabled } from '../../lib/intentsTransport.js'
 import { isSyncing, SYNC_ERROR_I18N_KEYS } from '../../sync/status.js'
 import { appendActivityEntry } from '../../lib/intentsActivityLog.js'
@@ -470,6 +471,27 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       if (futureI !== -1) setFutureIdx(futureI)
     }
   }
+
+  // ── Widget deep-link ──────────────────────────────────────────────────────────
+  // A home-screen widget tap launches the app with a pending milestone target.
+  // Consume it on mount and on every resume (the native side clears it once read),
+  // then center and open that milestone's detail. (milestonesRef is declared above.)
+  useEffect(() => {
+    const handleTarget = async () => {
+      const target = await consumeWidgetLaunchTarget()
+      if (!target) return
+      const m = milestonesRef.current.find(x => x.id === target.milestoneId)
+      if (!m) return
+      setSelectedId(m.id)
+      setHighlightsActive(true)
+      timelineRef.current?.panToMs(new Date(m.date).getTime())
+      setDetail(m)
+    }
+    handleTarget()
+    const onShow = () => { if (document.visibilityState === 'visible') handleTarget() }
+    document.addEventListener('visibilitychange', onShow)
+    return () => document.removeEventListener('visibilitychange', onShow)
+  }, [])
 
   // ── View mode ────────────────────────────────────────────────────────────────
   function handleViewMode(mode) {

--- a/src/native/widgetBridge.js
+++ b/src/native/widgetBridge.js
@@ -1,0 +1,36 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native bridge to the home-screen widgets. Implemented natively on Android
+// (WidgetBridgePlugin); a no-op on web and any platform without the plugin.
+//
+//   updateSnapshot({ json })   — persist the widget snapshot and refresh widgets
+//   consumeLaunchTarget()      — read + clear a pending deep-link target { milestoneId }
+const WidgetBridge = registerPlugin('WidgetBridge')
+
+const isNative = () => Capacitor.isNativePlatform()
+
+// Pushes a freshly built snapshot to native storage. Swallows errors: a widget
+// update failing must never disrupt the app. Returns true if the push was attempted.
+export async function pushWidgetSnapshot(snapshot) {
+  if (!isNative()) return false
+  try {
+    await WidgetBridge.updateSnapshot({ json: JSON.stringify(snapshot) })
+    return true
+  } catch (err) {
+    console.warn('[widgetBridge] updateSnapshot failed:', err)
+    return false
+  }
+}
+
+// Returns a pending deep-link target a widget tap left behind, or null. The native
+// side clears it once read, so this is safe to call on every resume.
+export async function consumeWidgetLaunchTarget() {
+  if (!isNative()) return null
+  try {
+    const res = await WidgetBridge.consumeLaunchTarget()
+    return res?.milestoneId ? { milestoneId: res.milestoneId } : null
+  } catch (err) {
+    console.warn('[widgetBridge] consumeLaunchTarget failed:', err)
+    return null
+  }
+}

--- a/src/utils/widgetSnapshot.js
+++ b/src/utils/widgetSnapshot.js
@@ -1,0 +1,107 @@
+import { applyRecurFilter } from './timeline'
+import { precomputeEndpoints, getMilestoneVisibility } from './visibility'
+
+// Builds a compact, render-ready snapshot of timeline state for native home-screen
+// widgets (Android / iOS). The snapshot is pushed into native storage by the
+// WidgetBridge plugin and read by the widget process, which cannot reach IndexedDB.
+//
+// Design notes:
+//   - Dates are stored as raw ISO strings, never as relative labels ("in 12 days").
+//     The widget computes relative labels itself at render time, because the
+//     snapshot may be hours or days stale and those labels roll over at midnight.
+//   - Only milestones visible on the main timeline are considered, so a widget
+//     never surfaces something the user has hidden.
+//   - Recurring series are collapsed to a single instance (nearest upcoming, else
+//     most recent past) via applyRecurFilter('next'), so a yearly birthday doesn't
+//     crowd out everything else.
+//
+// The shape is intentionally broad enough to also feed the planned Today and
+// Current Chapter widgets without a schema change.
+
+export const WIDGET_SNAPSHOT_VERSION = 1
+
+// Pares a milestone down to just what a widget renders.
+function projectMilestone(m) {
+  if (!m) return null
+  return {
+    id:            m.id,
+    title:         m.title,
+    date:          m.date,
+    datePrecision: m.date_precision ?? 'day',
+    category:      m.category ?? null,
+    color:         m.color ?? null,
+  }
+}
+
+// Picks the active chapter for "now": started, and either ongoing (no end) or not
+// yet ended. When several overlap, the one with the latest start wins (the most
+// specific / innermost chapter the user is currently living in).
+function pickCurrentChapter(chapters, nowMs) {
+  let best = null
+  for (const c of chapters) {
+    const startMs = new Date(c.start).getTime()
+    if (Number.isNaN(startMs) || startMs > nowMs) continue
+    const endMs = c.end ? new Date(c.end).getTime() : null
+    if (endMs != null && endMs < nowMs) continue
+    if (!best || startMs > new Date(best.start).getTime()) best = c
+  }
+  return best
+}
+
+export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = null, now = new Date()) {
+  const nowMs = now.getTime()
+
+  // Keep only milestones that are visible on the main timeline.
+  const precomputed = precomputeEndpoints(chapters)
+  const visible = milestones.filter(
+    m => getMilestoneVisibility(m, chapters, precomputed, 'main').visible
+  )
+
+  // Collapse recurring series so a single instance represents each one.
+  const collapsed = applyRecurFilter(visible, 'next')
+
+  const sorted = [...collapsed].sort((a, b) => new Date(a.date) - new Date(b.date))
+
+  let next = null   // nearest upcoming (date >= now)
+  let prev = null   // most recently passed (date < now)
+  let past = 0
+  let future = 0
+  for (const m of sorted) {
+    const ms = new Date(m.date).getTime()
+    if (ms >= nowMs) {
+      future++
+      if (!next) next = m            // sorted ascending → first future is nearest
+    } else {
+      past++
+      prev = m                       // sorted ascending → last past is most recent
+    }
+  }
+
+  const chapter = pickCurrentChapter(chapters, nowMs)
+  let currentChapter = null
+  if (chapter) {
+    const memberDates = chapter.milestoneIds
+      .map(id => milestones.find(m => m.id === id))
+      .filter(Boolean)
+      .map(m => new Date(m.date).getTime())
+    currentChapter = {
+      id:          chapter.id,
+      title:       chapter.title,
+      start:       chapter.start,
+      end:         chapter.end ?? null,
+      color:       chapter.color ?? null,
+      passedCount: memberDates.filter(ms => ms < nowMs).length,
+      totalCount:  memberDates.length,
+    }
+  }
+
+  return {
+    version:        WIDGET_SNAPSHOT_VERSION,
+    generatedAt:    now.toISOString(),
+    birthday:       birthday || null,
+    next:           projectMilestone(next),
+    prev:           projectMilestone(prev),
+    currentChapter,
+    counts:         { past, future, total: past + future },
+  }
+}

--- a/src/utils/widgetSnapshot.test.js
+++ b/src/utils/widgetSnapshot.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { buildWidgetSnapshot, WIDGET_SNAPSHOT_VERSION } from './widgetSnapshot'
+
+const NOW = new Date('2026-06-20T12:00:00Z')
+
+// Minimal milestone factory — only the fields the snapshot builder reads.
+function ms(over = {}) {
+  return {
+    id:                     over.id ?? Math.random().toString(36).slice(2),
+    title:                  'untitled',
+    date:                   '2026-01-01T00:00:00Z',
+    date_precision:         'day',
+    category:               'personal',
+    color:                  '#9370DB',
+    mainTimelineVisibility: 'inherit',
+    recurrence_id:          null,
+    ...over,
+  }
+}
+
+describe('buildWidgetSnapshot', () => {
+  it('stamps version and generatedAt, and an empty timeline yields nulls', () => {
+    const snap = buildWidgetSnapshot([], [], null, NOW)
+    expect(snap.version).toBe(WIDGET_SNAPSHOT_VERSION)
+    expect(snap.generatedAt).toBe(NOW.toISOString())
+    expect(snap.next).toBeNull()
+    expect(snap.prev).toBeNull()
+    expect(snap.currentChapter).toBeNull()
+    expect(snap.counts).toEqual({ past: 0, future: 0, total: 0 })
+  })
+
+  it('picks the nearest upcoming as next and most recent past as prev', () => {
+    const milestones = [
+      ms({ id: 'far-past',   title: 'Far past',   date: '2020-01-01T00:00:00Z' }),
+      ms({ id: 'recent',     title: 'Recent',     date: '2026-06-01T00:00:00Z' }),
+      ms({ id: 'soon',       title: 'Soon',       date: '2026-07-01T00:00:00Z' }),
+      ms({ id: 'far-future', title: 'Far future', date: '2030-01-01T00:00:00Z' }),
+    ]
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW)
+    expect(snap.next.id).toBe('soon')
+    expect(snap.prev.id).toBe('recent')
+    expect(snap.counts).toEqual({ past: 2, future: 2, total: 4 })
+  })
+
+  it('projects a milestone down to widget-relevant fields only', () => {
+    const milestones = [ms({ id: 'a', title: 'Trip', date: '2026-07-01T00:00:00Z', category: 'travel', color: '#C8A96E' })]
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW)
+    expect(snap.next).toEqual({
+      id: 'a', title: 'Trip', date: '2026-07-01T00:00:00Z',
+      datePrecision: 'day', category: 'travel', color: '#C8A96E',
+    })
+  })
+
+  it('excludes milestones hidden from the main timeline', () => {
+    const milestones = [
+      ms({ id: 'hidden', title: 'Hidden', date: '2026-07-01T00:00:00Z', mainTimelineVisibility: 'hidden' }),
+      ms({ id: 'shown',  title: 'Shown',  date: '2026-08-01T00:00:00Z', mainTimelineVisibility: 'shown' }),
+    ]
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW)
+    expect(snap.next.id).toBe('shown')
+    expect(snap.counts.future).toBe(1)
+  })
+
+  it('collapses a recurring series to a single upcoming instance', () => {
+    const milestones = [
+      ms({ id: 'b-2025', title: 'Birthday', date: '2025-09-01T00:00:00Z', recurrence_id: 'bday' }),
+      ms({ id: 'b-2026', title: 'Birthday', date: '2026-09-01T00:00:00Z', recurrence_id: 'bday' }),
+      ms({ id: 'b-2027', title: 'Birthday', date: '2027-09-01T00:00:00Z', recurrence_id: 'bday' }),
+    ]
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW)
+    expect(snap.next.id).toBe('b-2026')
+    expect(snap.counts.future).toBe(1)
+    expect(snap.counts.past).toBe(0)
+  })
+
+  it('resolves the current chapter with passed/total member counts', () => {
+    const milestones = [
+      ms({ id: 'm1', date: '2024-02-01T00:00:00Z' }),  // passed
+      ms({ id: 'm2', date: '2026-03-01T00:00:00Z' }),  // passed
+      ms({ id: 'm3', date: '2027-01-01T00:00:00Z' }),  // upcoming
+    ]
+    const chapters = [{
+      id: 'ch', title: 'University', start: '2024-01-01T00:00:00Z', end: '2028-01-01T00:00:00Z',
+      color: '#4A90D9', milestoneIds: ['m1', 'm2', 'm3'], defaultMemberVisibility: 'shown',
+    }]
+    const snap = buildWidgetSnapshot(milestones, chapters, null, NOW)
+    expect(snap.currentChapter).toMatchObject({ id: 'ch', title: 'University', passedCount: 2, totalCount: 3 })
+  })
+
+  it('treats an ongoing chapter (no end) as current and prefers the innermost', () => {
+    const chapters = [
+      { id: 'outer', title: 'Adulthood', start: '2010-01-01T00:00:00Z', end: null, color: '#fff', milestoneIds: [] },
+      { id: 'inner', title: 'New job',   start: '2026-01-01T00:00:00Z', end: null, color: '#fff', milestoneIds: [] },
+    ]
+    const snap = buildWidgetSnapshot([], chapters, null, NOW)
+    expect(snap.currentChapter.id).toBe('inner')
+  })
+
+  it('ignores chapters that have not started or have already ended', () => {
+    const chapters = [
+      { id: 'over',   title: 'Childhood', start: '1990-01-01T00:00:00Z', end: '2008-01-01T00:00:00Z', color: '#fff', milestoneIds: [] },
+      { id: 'future', title: 'Retirement', start: '2050-01-01T00:00:00Z', end: null, color: '#fff', milestoneIds: [] },
+    ]
+    const snap = buildWidgetSnapshot([], chapters, null, NOW)
+    expect(snap.currentChapter).toBeNull()
+  })
+
+  it('passes through the birthday when set', () => {
+    expect(buildWidgetSnapshot([], [], '1990-05-01', NOW).birthday).toBe('1990-05-01')
+    expect(buildWidgetSnapshot([], [], '', NOW).birthday).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Introduces native Android home-screen widget support, starting with a reusable **data bridge** from the web app to native storage and a first **Next Milestone** countdown widget built with Jetpack Glance.

Because all data lives in IndexedDB inside the Capacitor WebView — unreachable from the widget process — the web app pushes a compact, render-ready snapshot into `SharedPreferences`, which the widget reads.

## Data bridge (reusable foundation)

- **`src/utils/widgetSnapshot.js`** — pure `buildWidgetSnapshot()` producing a compact snapshot (next milestone, most-recently-passed, current chapter with passed/total counts, past/future counts). Reuses existing recurrence-collapse (`applyRecurFilter('next')`) and main-timeline visibility logic, so a hidden or duplicated recurring milestone never surfaces. Stores **raw ISO dates** so relative labels recompute at render time (they roll over at midnight).
- **`WidgetBridgePlugin.java`** — Capacitor plugin: persists the snapshot, refreshes placed widgets immediately, and hands off widget-tap deep links.
- **`src/native/widgetBridge.js`** + **`App.jsx`** hook — pushes the snapshot on data change (debounced) and on backgrounding; no-op on web.

## Next Milestone widget

- **`NextMilestoneWidget.kt`** — Jetpack Glance, styled to the app's dark / amber / monospace identity, with compact and taller responsive layouts (the taller one also shows the most recently passed milestone). Computes the countdown natively, mirroring `relativeLabel()`.
- Tapping opens the app focused on that milestone (`TimelineView` consumes a pending target on resume via a `SharedPreferences` handoff).
- **`WidgetRefreshWorker.kt`** — WorkManager job re-renders at local midnight so countdowns roll over even when the app is closed.

## Forward-looking

The snapshot already carries `prev` and `currentChapter`, so the planned **Today** (largest size = prev + next + chapter) and **Current Chapter** widgets are drop-in additions. The snapshot builder is platform-agnostic for an eventual **iOS** widget.

## Build note

This adds **Kotlin + Compose + Jetpack Glance** to the previously Java-only Android module. Kotlin/Java JVM targets are aligned to 21 (Capacitor forces Java 21).

## Verification

- ✅ Web: `npm test` (69 pass, incl. 9 new snapshot tests) and `npm run build` succeed; `cap sync android` clean.
- ⚠️ The Gradle/Kotlin compile could **not** be run in the CI sandbox (network policy blocks Maven/Google repos), so the native module should be built locally (`npm run android`) to confirm the first compile and to place the widget on a home screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_