### PR TITLE
Fix Glance API usage in Next Milestone widget

### DIFF
--- a/android/app/src/main/java/com/lifeglance/app/widget/NextMilestoneWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/NextMilestoneWidget.kt
@@ -1,7 +1,7 @@
 package com.lifeglance.app.widget
 
+import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpSize
@@ -9,6 +9,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
@@ -36,6 +38,10 @@ private val TEXT = Color(0xFFE8E0D0)
 private val AMBER = Color(0xFFC8A96E)
 private val MUTED = Color(0xFF8A8270)
 
+// Glance delivers ActionParameters to the launched activity as Intent extras keyed
+// by the parameter key's name, so MainActivity reads it as EXTRA_WIDGET_MILESTONE_ID.
+private val MILESTONE_KEY = ActionParameters.Key<String>(MainActivity.EXTRA_WIDGET_MILESTONE_ID)
+
 class NextMilestoneWidget : GlanceAppWidget() {
     // Two breakpoints: compact (countdown + title) and a taller layout that also
     // surfaces the most recently passed milestone.
@@ -62,7 +68,7 @@ class NextMilestoneWidget : GlanceAppWidget() {
                 .background(ColorProvider(BG))
                 .cornerRadius(16.dp)
                 .padding(16.dp)
-                .clickable(actionStartActivity(launchIntent(context, next?.id))),
+                .clickable(openAppAction(context, next?.id)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (next == null) {
@@ -106,12 +112,15 @@ class NextMilestoneWidget : GlanceAppWidget() {
         }
     }
 
-    // Opens the app, carrying the tapped milestone id so the web layer can focus it.
-    private fun launchIntent(context: Context, milestoneId: String?): Intent =
-        Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            if (milestoneId != null) putExtra(MainActivity.EXTRA_WIDGET_MILESTONE_ID, milestoneId)
-        }
+    // Opens the app, carrying the tapped milestone id (when present) so the web
+    // layer can focus it. The id rides along as an ActionParameter, which Glance
+    // surfaces to MainActivity as an Intent extra.
+    private fun openAppAction(context: Context, milestoneId: String?) =
+        actionStartActivity(
+            ComponentName(context, MainActivity::class.java),
+            if (milestoneId != null) actionParametersOf(MILESTONE_KEY to milestoneId)
+            else actionParametersOf(),
+        )
 }
 
 class NextMilestoneReceiver : GlanceAppWidgetReceiver() {

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
@@ -1,6 +1,9 @@
 package com.lifeglance.app.widget
 
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -18,13 +21,26 @@ class WidgetRefreshWorker(context: Context, params: WorkerParameters) :
     CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
-        NextMilestoneWidget().updateAll(applicationContext)
+        refreshWidgets(applicationContext)
         schedule(applicationContext)
         return Result.success()
     }
 
     companion object {
         private const val WORK_NAME = "lifeglance_widget_daily_refresh"
+
+        // Broadcast an update to all placed widgets, which makes GlanceAppWidgetReceiver
+        // recompose and re-read the snapshot (recomputing relative labels for the new day).
+        private fun refreshWidgets(context: Context) {
+            val mgr = AppWidgetManager.getInstance(context)
+            val ids = mgr.getAppWidgetIds(ComponentName(context, NextMilestoneReceiver::class.java))
+            if (ids.isEmpty()) return
+            val intent = Intent(context, NextMilestoneReceiver::class.java).apply {
+                action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+            }
+            context.sendBroadcast(intent)
+        }
 
         // Enqueues a one-shot refresh for the next local midnight. KEEP avoids
         // piling up duplicates when called repeatedly (e.g. on every app start).


### PR DESCRIPTION
Follow-up to #166 (already merged). Fixes two Jetpack Glance compile errors that the CI sandbox couldn't catch, because it can't reach Maven/Google repos to actually compile the native module. Both were surfaced by a local `./gradlew :app:compileDebugKotlin`.

## Fixes

- **`actionStartActivity` Intent → ComponentName.** Glance 1.1.1 has no single-`Intent` overload, so the compiler bound to the `ComponentName` overload (`Argument type mismatch: actual type is Intent, but ComponentName was expected`). Now uses the `ComponentName` overload and passes the tapped milestone id as an **ActionParameter**, which Glance delivers to `MainActivity` as an Intent extra keyed by the parameter name (`widget_milestone_id`) — exactly what `MainActivity` already reads, so the deep-link path is unchanged.

- **`GlanceAppWidget.updateAll` unresolved.** The daily-midnight refresh worker no longer depends on that API; it now broadcasts `ACTION_APPWIDGET_UPDATE` — the same mechanism `WidgetBridgePlugin` already uses to make the receiver recompose and re-read the snapshot. One consistent refresh path for both immediate and scheduled updates.

## Verification

- ✅ Confirmed against the local build output that produced these two errors; both references are corrected.
- ⚠️ Full Gradle/Kotlin compile still can't run in this environment (Maven/Google repos blocked). Please re-run the local Android build to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_