### PR TITLE
Release v2.3.5 — dark mode, category editing, chapter select-all, and #169 fixes

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.3;
+				MARKETING_VERSION = 2.3.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.3;
+				MARKETING_VERSION = 2.3.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -113,6 +113,9 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
     })
   }
 
+  function selectAll()  { setCheckedIds(new Set(displayMilestones.map(m => m.id))) }
+  function selectNone() { setCheckedIds(new Set()) }
+
   function clearDateError() { setDateError(null) }
 
   function validateDates() {
@@ -382,6 +385,12 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
           ) : displayMilestones.length === 0 ? (
             <div className="chapter-members-empty">{t('membersNoMilestones')}</div>
           ) : (
+            <>
+            <div className="chapter-member-actions">
+              <button type="button" className="chapter-member-action" onClick={selectAll}>{t('selectAll')}</button>
+              <span className="chapter-member-action-sep" aria-hidden="true">·</span>
+              <button type="button" className="chapter-member-action" onClick={selectNone}>{t('selectNone')}</button>
+            </div>
             <div className="chapter-members-list">
               {displayMilestones.map(m => {
                 const mDay        = m.date?.slice(0, 10)
@@ -416,6 +425,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
                 )
               })}
             </div>
+            </>
           )}
         </div>
 

--- a/src/components/help/KeyboardShortcutsModal.jsx
+++ b/src/components/help/KeyboardShortcutsModal.jsx
@@ -16,6 +16,7 @@ export default function KeyboardShortcutsModal({ onClose }) {
     { keys: ['⌘Z', 'Ctrl+Z'],  desc: t('shortcutUndo')               },
     { keys: ['⌘⇧Z', 'Ctrl+Y'], desc: t('shortcutRedo')               },
     { keys: ['M'],              desc: t('shortcutMute')               },
+    { keys: ['D'],              desc: t('shortcutTheme')              },
     { keys: ['n'],              desc: t('shortcutNewMilestone')       },
     { keys: ['⇧N'],            desc: t('shortcutNewChapter')         },
     { keys: ['E'],              desc: t('shortcutExport')             },

--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -1,13 +1,27 @@
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import Step1Welcome   from './Step1Welcome'
 import Step2Past      from './Step2Past'
 import Step3Future    from './Step3Future'
 import Step4Reveal    from './Step4Reveal'
 import TimelinePreview from './TimelinePreview'
+import ThemeToggle    from '../ui/ThemeToggle'
 import { addMilestone } from '../../data/milestones'
 import { init as audioInit, startAmbient, stopAmbient } from '../../utils/audio'
 
+// Forward chevron, matching the line-icon style of the theme toggle.
+function SkipIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="m6 17 5-5-5-5" />
+      <path d="m13 17 5-5-5-5" />
+    </svg>
+  )
+}
+
 export default function Onboarding({ onComplete }) {
+  const { t: tc } = useTranslation('common')
   const [step, setStep]               = useState(1)
   const [pastMilestone, setPast]      = useState(null)
   const [futureMilestone, setFuture]  = useState(null)
@@ -39,13 +53,25 @@ export default function Onboarding({ onComplete }) {
 
   return (
     <div className={`onboarding${step === 1 ? ' onboarding-welcome' : ''}`}>
-      {step === 1 && <Step1Welcome onBegin={handleBegin} onSkip={finish} />}
-      {step === 2 && <Step2Past    onSubmit={handlePast}    onSkip={finish} />}
-      {step === 3 && <Step3Future  onSubmit={handleFuture}  onSkip={finish} pastMilestone={pastMilestone} />}
+      {step === 1 && <Step1Welcome onBegin={handleBegin} />}
+      {step === 2 && <Step2Past    onSubmit={handlePast} />}
+      {step === 3 && <Step3Future  onSubmit={handleFuture} pastMilestone={pastMilestone} />}
       {step === 4 && <Step4Reveal  onComplete={finish} pastMilestone={pastMilestone} futureMilestone={futureMilestone} />}
 
       {/* Timeline preview strip appears from step 2 onwards */}
       {step >= 2 && <TimelinePreview milestones={previewMilestones} />}
+
+      {/* Theme toggle + skip, fixed in the corner while there's still a step to skip */}
+      {step <= 3 && (
+        <div className="onboarding-corner">
+          <ThemeToggle />
+          <span className="onboarding-sep" aria-hidden="true" />
+          <button className="onboarding-link" onClick={finish}>
+            <SkipIcon />
+            {tc('skip')}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/onboarding/Step1Welcome.jsx
+++ b/src/components/onboarding/Step1Welcome.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTypewriter } from '../../utils/typewriter'
 
-export default function Step1Welcome({ onBegin, onSkip }) {
+export default function Step1Welcome({ onBegin }) {
   const { t } = useTranslation('onboarding')
   const TAGLINE = t('tagline')
 
@@ -66,10 +66,6 @@ export default function Step1Welcome({ onBegin, onSkip }) {
           {t('begin')}
         </button>
       </div>
-
-      <button className="skip-link" onClick={onSkip}>
-        {t('skip', { ns: 'common' })}
-      </button>
     </div>
   )
 }

--- a/src/components/onboarding/Step2Past.jsx
+++ b/src/components/onboarding/Step2Past.jsx
@@ -8,7 +8,7 @@ const MONTHS = [
   'July','August','September','October','November','December',
 ]
 
-export default function Step2Past({ onSubmit, onSkip }) {
+export default function Step2Past({ onSubmit }) {
   const { t } = useTranslation('onboarding')
   const { t: tc } = useTranslation('common')
 
@@ -127,8 +127,6 @@ export default function Step2Past({ onSubmit, onSkip }) {
           </button>
         </div>
       </form>
-
-      <button className="skip-link" onClick={onSkip}>{tc('skip')}</button>
     </div>
   )
 }

--- a/src/components/onboarding/Step3Future.jsx
+++ b/src/components/onboarding/Step3Future.jsx
@@ -8,7 +8,7 @@ const MONTHS = [
   'July','August','September','October','November','December',
 ]
 
-export default function Step3Future({ onSubmit, onSkip, pastMilestone }) {
+export default function Step3Future({ onSubmit, pastMilestone }) {
   const { t } = useTranslation('onboarding')
   const { t: tc } = useTranslation('common')
 
@@ -127,8 +127,6 @@ export default function Step3Future({ onSubmit, onSkip, pastMilestone }) {
           </button>
         </div>
       </form>
-
-      <button className="skip-link" onClick={onSkip}>{tc('skip')}</button>
     </div>
   )
 }

--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -37,6 +37,9 @@ export default function SettingsModal({
   const { t: tc } = useTranslation('common')
   const [newLabel,   setNewLabel]   = useState('')
   const [newColor,   setNewColor]   = useState(COLOR_PALETTE[0])
+  const [editingId,  setEditingId]  = useState(null)
+  const [editLabel,  setEditLabel]  = useState('')
+  const [editColor,  setEditColor]  = useState(COLOR_PALETTE[0])
   const [soundOn,    setSoundOn]    = useState(() => !isMuted())
   const [theme,      setThemeState] = useState(getTheme)
   const [persisted,  setPersisted]  = useState(null)
@@ -77,6 +80,25 @@ export default function SettingsModal({
     const updated = categories.filter(c => c.id !== id)
     saveCategories(updated)
     onCategoriesChange(updated)
+  }
+
+  function startEdit(cat) {
+    setEditingId(cat.id)
+    setEditLabel(cat.label)
+    setEditColor(cat.color)
+  }
+
+  function saveEdit() {
+    const label = editLabel.trim()
+    if (!label) return
+    // Categories are referenced by id, so renaming/recoloring updates every
+    // milestone automatically — no need to re-categorize.
+    const updated = categories.map(c =>
+      c.id === editingId ? { ...c, label: label.toLowerCase(), color: editColor } : c
+    )
+    saveCategories(updated)
+    onCategoriesChange(updated)
+    setEditingId(null)
   }
 
   async function handleFileChange(e) {
@@ -173,11 +195,54 @@ export default function SettingsModal({
           <div className="settings-cat-list">
             {categories.map(cat => {
               const inUse = usedIds.has(cat.id)
+              if (editingId === cat.id) {
+                return (
+                  <div key={cat.id} className="settings-cat-add settings-cat-edit-block">
+                    <div className="settings-cat-add-row">
+                      <input
+                        className="input input-sm"
+                        value={editLabel}
+                        onChange={e => setEditLabel(e.target.value)}
+                        onKeyDown={e => { if (e.key === 'Enter') saveEdit() }}
+                        maxLength={30}
+                        autoFocus
+                        style={{ flex: 1, minWidth: 0 }}
+                      />
+                      <button
+                        className="btn btn-filled"
+                        style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem', flexShrink: 0 }}
+                        disabled={!editLabel.trim()}
+                        onClick={saveEdit}
+                      >{tc('save')}</button>
+                      <button
+                        className="btn"
+                        style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem', flexShrink: 0 }}
+                        onClick={() => setEditingId(null)}
+                      >{tc('cancel')}</button>
+                    </div>
+                    <div className="settings-palette">
+                      {COLOR_PALETTE.map(c => (
+                        <button
+                          key={c}
+                          className={`settings-swatch ${editColor === c ? 'selected' : ''}`}
+                          style={{ background: c }}
+                          onClick={() => setEditColor(c)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )
+              }
               return (
                 <div key={cat.id} className="settings-cat-row">
                   <div className="settings-cat-dot" style={{ background: cat.color }} />
                   <span className="settings-cat-name">{cat.label}</span>
                   {inUse && <span className="settings-cat-inuse">{t('categoryInUse')}</span>}
+                  <button
+                    className="settings-cat-edit"
+                    title={tc('edit')}
+                    onClick={() => startEdit(cat)}
+                  >✎</button>
                   <button
                     className="settings-cat-del"
                     disabled={inUse}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1199,6 +1199,37 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     URL.revokeObjectURL(url)
   }
 
+  // Categories changed in Settings (add / rename / recolor / delete). The list
+  // itself is already persisted by Settings; here we re-sync the colour cached on
+  // each milestone so an in-place recolour shows on the timeline immediately and
+  // survives reload. Milestone colour always tracks its category (no per-milestone
+  // colour), so this is safe.
+  async function handleCategoriesChange(updated) {
+    setCategories(updated)
+    const colorById = Object.fromEntries(updated.map(c => [c.id, c.color]))
+    const now = new Date().toISOString()
+    const changed = []
+    const next = milestones.map(m => {
+      const color = colorById[m.category]
+      if (color && color !== m.color) {
+        const nm = { ...m, color, updated_at: now }
+        changed.push(nm)
+        return nm
+      }
+      return m
+    })
+    if (changed.length === 0) return
+    setMilestones(next)
+    // Keep undo-history snapshots colour-consistent so an undo can't resurrect
+    // the old colour.
+    const h = historyRef.current
+    h.stack = h.stack.map(snap => snap.map(m => {
+      const color = colorById[m.category]
+      return color && color !== m.color ? { ...m, color } : m
+    }))
+    for (const m of changed) await dbPut(m)
+  }
+
   async function handleImportIcsFile(file) {
     try {
       const text = await file.text()
@@ -1944,7 +1975,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         <SettingsModal
           textSize={textSize}       onTextSizeChange={setTextSize}
           ultraCompact={ultraCompact}
-          categories={categories}   onCategoriesChange={setCategories}
+          categories={categories}   onCategoriesChange={handleCategoriesChange}
           clustering={clustering}   onClusteringChange={v => {
             setClustering(v)
             localStorage.setItem('lifeglance-clustering', String(v))

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1890,7 +1890,6 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
                     {chapter.title}
                   </div>
                 )}
-                {ev.note && <div className="idle-caption-note">{ev.note}</div>}
                 <div className="idle-caption-meta">
                   {age != null && (
                     <span>{t(isPastEv ? 'idleAgeWas' : 'idleAgeWillBe', { age })}</span>
@@ -1898,6 +1897,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
                   {age != null && <span className="idle-meta-sep">·</span>}
                   <span>{relativeLabel(ev.date, ev.date_precision)}</span>
                 </div>
+                {ev.note && <div className="idle-caption-note">{ev.note}</div>}
               </div>
             )
           })()}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -15,7 +15,7 @@ import MinimapBar        from '../minimap/MinimapBar'
 import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS, applyRecurFilter } from '../../utils/timeline'
 import { expandAnnualDates } from '../../utils/recurrence'
-import { loadCategories } from '../../utils/colors'
+import { loadCategories, saveCategories } from '../../utils/colors'
 import { getMilestoneVisibility, precomputeEndpoints } from '../../utils/visibility'
 import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones, uid } from '../../data/milestones'
 import { listChapters, restoreChapters, createChapter, updateChapter, deleteChapter } from '../../data/chapters'
@@ -1186,7 +1186,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     }
 
     const chapters = await listChapters()
-    const payload = { milestones, photos, chapters }
+    const payload = { milestones, photos, chapters, categories: loadCategories() }
     const json = JSON.stringify(payload, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url  = URL.createObjectURL(blob)
@@ -1254,9 +1254,12 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       const items    = Array.isArray(parsed) ? parsed : (parsed.milestones ?? parsed)
       const photos   = (!Array.isArray(parsed) && parsed.photos) ? parsed.photos : {}
       const chapters = (!Array.isArray(parsed) && Array.isArray(parsed.chapters)) ? parsed.chapters : []
+      const restoredCategories = (!Array.isArray(parsed) && Array.isArray(parsed.categories) && parsed.categories.length > 0)
+        ? parsed.categories : null
 
       const restored = await restoreMilestones(items)
       await restoreChapters(chapters)
+      if (restoredCategories) saveCategories(restoredCategories)
 
       // Re-import photo blobs into the media store
       for (const m of restored) {
@@ -1282,6 +1285,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
 
       setMilestones([...restored])
       setChapters([...chapters])
+      if (restoredCategories) setCategories(restoredCategories)
       historyRef.current = { stack: [[...restored]], idx: 0 }
       setCanUndo(false)
       setCanRedo(false)

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -30,6 +30,7 @@ import { parseIcs }      from '../../utils/icsParser'
 import * as audio from '../../utils/audio'
 import { useIdleMode } from '../../hooks/useIdleMode.js'
 import { enterFullscreen, exitFullscreen, isFullscreen } from '../../utils/fullscreen.js'
+import { toggleTheme } from '../../utils/theme'
 import { relativeLabel, ageAtDate } from '../../utils/dates'
 import { useIntentPoller } from '../../hooks/useIntentPoller.js'
 import { consumeWidgetLaunchTarget } from '../../native/widgetBridge.js'
@@ -693,6 +694,11 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         case 'm': case 'M': {
           if (anyModal) break
           audio.toggleMuted()
+          break
+        }
+        case 'd': case 'D': {
+          if (anyModal) break
+          toggleTheme()
           break
         }
         case 'z': case 'Z': {

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { getTheme, toggleTheme } from '../../utils/theme'
+
+// Crisp line icons (currentColor) so they sit cleanly inline with the
+// monospace label instead of an emoji glyph that renders high and off-baseline.
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+    </svg>
+  )
+}
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+    </svg>
+  )
+}
+
+// Toggles dark / light theme. Tracks its own state since the theme lives on the
+// document (data-theme), not in React. Shows the icon for the theme you'd switch to.
+export default function ThemeToggle() {
+  const { t } = useTranslation('settings')
+  const [theme, setTheme] = useState(getTheme)
+
+  return (
+    <button
+      type="button"
+      className="onboarding-link theme-toggle"
+      onClick={() => setTheme(toggleTheme())}
+    >
+      {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+      {t('themeLabel')}
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1758,6 +1758,20 @@ button, input, select, textarea {
 .settings-cat-del:hover:not(:disabled) { color: var(--amber); }
 .settings-cat-del:disabled { opacity: 0.2; cursor: default; }
 
+.settings-cat-edit {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  padding: 0.15rem 0.3rem;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.settings-cat-edit:hover { color: var(--amber); }
+
+.settings-cat-edit-block { padding: 0.25rem 0; }
+
 .settings-cat-add { display: flex; flex-direction: column; gap: 0.4rem; }
 
 .settings-cat-add-row {

--- a/src/index.css
+++ b/src/index.css
@@ -1633,9 +1633,11 @@ button, input, select, textarea {
   font-size: 0.9rem;
   line-height: 1.45;
   text-align: center;
-  /* Clamp long notes so they don't dominate the screen. */
+  white-space: pre-wrap;     /* preserve the note's own line breaks and wrap long lines */
+  overflow-wrap: anywhere;   /* break very long unbroken words / URLs */
+  /* Clamp very long notes so they don't dominate the screen. */
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2476,6 +2476,26 @@ button, input, select, textarea {
   letter-spacing: 0.03em;
   padding: 0.4rem 0;
 }
+.chapter-member-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+.chapter-member-action {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.chapter-member-action:hover { color: var(--amber); }
+.chapter-member-action-sep { color: var(--text-muted); opacity: 0.4; font-size: 0.65rem; }
 .chapter-members-list {
   display: flex;
   flex-direction: column;

--- a/src/index.css
+++ b/src/index.css
@@ -417,21 +417,44 @@ button, input, select, textarea {
   gap: 1rem;
 }
 
-.skip-link {
+.onboarding-corner {
   position: fixed;
   bottom: 1.25rem;
   right: 1.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+/* thin vertical divider between the two controls */
+.onboarding-sep {
+  width: 1px;
+  height: 0.85rem;
+  background: var(--border);
+}
+
+/* matched icon/text links in the onboarding corner (theme toggle + skip) */
+.onboarding-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
   background: none;
   border: none;
   color: var(--text-muted);
   font-family: var(--font);
   font-size: 0.72rem;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 3px;
   letter-spacing: 0.04em;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: color 0.15s;
 }
-.skip-link:hover { color: var(--text-dim); }
+.onboarding-link:hover { color: var(--text-dim); }
+.onboarding-link svg {
+  display: block;
+  width: 0.95rem;
+  height: 0.95rem;
+}
 
 /* ─── Timeline Preview Strip (onboarding) ──────────────────────────────────── */
 .timeline-preview {

--- a/src/locales/de/chapter.json
+++ b/src/locales/de/chapter.json
@@ -24,5 +24,7 @@
   "errorEndDayRange": "Der Endtag muss zwischen 1 und {{max}} für den gewählten Monat liegen",
   "errorEndAfterStart": "Das Enddatum muss nach dem Startdatum liegen",
   "endpointTooltip": "Ankerpunkt — immer auf der Hauptzeitleiste angezeigt",
-  "endpointDimTooltip": "entspricht einer Kapitelgrenze — ankreuzen, um es zum Ankerpunkt zu machen"
+  "endpointDimTooltip": "entspricht einer Kapitelgrenze — ankreuzen, um es zum Ankerpunkt zu machen",
+  "selectAll": "alle auswählen",
+  "selectNone": "keine auswählen"
 }

--- a/src/locales/de/help.json
+++ b/src/locales/de/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "rückgängig machen",
   "shortcutRedo": "wiederherstellen",
   "shortcutMute": "Ton aus / ein",
+  "shortcutTheme": "Hell- / Dunkelmodus umschalten",
   "shortcutNewMilestone": "neuer Meilenstein",
   "shortcutNewChapter": "neues Kapitel",
   "shortcutExport": "als Bild exportieren",

--- a/src/locales/en/chapter.json
+++ b/src/locales/en/chapter.json
@@ -24,5 +24,7 @@
   "colorLabel": "color",
   "deleteConfirmTitle": "delete <strong>{{title}}</strong>?",
   "endpointTooltip": "endpoint — always shown on main timeline",
-  "endpointDimTooltip": "matches chapter boundary — add to make it an endpoint"
+  "endpointDimTooltip": "matches chapter boundary — add to make it an endpoint",
+  "selectAll": "select all",
+  "selectNone": "select none"
 }

--- a/src/locales/en/help.json
+++ b/src/locales/en/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "undo",
   "shortcutRedo": "redo",
   "shortcutMute": "mute / unmute sound",
+  "shortcutTheme": "toggle dark / light theme",
   "shortcutNewMilestone": "new milestone",
   "shortcutNewChapter": "new chapter",
   "shortcutExport": "export image",

--- a/src/locales/es/chapter.json
+++ b/src/locales/es/chapter.json
@@ -24,5 +24,7 @@
   "errorEndDayRange": "el día de fin debe estar entre 1 y {{max}} para el mes seleccionado",
   "errorEndAfterStart": "la fecha de fin debe ser posterior a la fecha de inicio",
   "endpointTooltip": "ancla — siempre mostrado en la línea de tiempo principal",
-  "endpointDimTooltip": "corresponde a un límite de capítulo — marcar para convertir en ancla"
+  "endpointDimTooltip": "corresponde a un límite de capítulo — marcar para convertir en ancla",
+  "selectAll": "seleccionar todo",
+  "selectNone": "deseleccionar todo"
 }

--- a/src/locales/es/help.json
+++ b/src/locales/es/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "deshacer",
   "shortcutRedo": "rehacer",
   "shortcutMute": "silenciar / activar sonido",
+  "shortcutTheme": "alternar tema claro / oscuro",
   "shortcutNewMilestone": "nuevo hito",
   "shortcutNewChapter": "nuevo capítulo",
   "shortcutExport": "exportar como imagen",

--- a/src/locales/fr/chapter.json
+++ b/src/locales/fr/chapter.json
@@ -24,5 +24,7 @@
   "errorEndDayRange": "le jour de fin doit être compris entre 1 et {{max}} pour le mois sélectionné",
   "errorEndAfterStart": "la date de fin doit être postérieure à la date de début",
   "endpointTooltip": "ancrage — toujours affiché sur la frise principale",
-  "endpointDimTooltip": "correspond à une limite de chapitre — cocher pour en faire un ancrage"
+  "endpointDimTooltip": "correspond à une limite de chapitre — cocher pour en faire un ancrage",
+  "selectAll": "tout sélectionner",
+  "selectNone": "tout désélectionner"
 }

--- a/src/locales/fr/help.json
+++ b/src/locales/fr/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "annuler",
   "shortcutRedo": "rétablir",
   "shortcutMute": "couper / activer le son",
+  "shortcutTheme": "basculer thème clair / sombre",
   "shortcutNewMilestone": "nouveau jalon",
   "shortcutNewChapter": "nouveau chapitre",
   "shortcutExport": "exporter en image",

--- a/src/locales/it/chapter.json
+++ b/src/locales/it/chapter.json
@@ -24,5 +24,7 @@
   "errorEndDayRange": "il giorno di fine deve essere tra 1 e {{max}} per il mese selezionato",
   "errorEndAfterStart": "la data di fine deve essere successiva alla data di inizio",
   "endpointTooltip": "punto di ancoraggio — sempre mostrato sulla timeline principale",
-  "endpointDimTooltip": "corrisponde a un limite di capitolo — spuntare per renderlo un punto di ancoraggio"
+  "endpointDimTooltip": "corrisponde a un limite di capitolo — spuntare per renderlo un punto di ancoraggio",
+  "selectAll": "seleziona tutto",
+  "selectNone": "deseleziona tutto"
 }

--- a/src/locales/it/help.json
+++ b/src/locales/it/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "annulla",
   "shortcutRedo": "ripristina",
   "shortcutMute": "disattiva / attiva audio",
+  "shortcutTheme": "alterna tema chiaro / scuro",
   "shortcutNewMilestone": "nuovo traguardo",
   "shortcutNewChapter": "nuovo capitolo",
   "shortcutExport": "esporta come immagine",

--- a/src/locales/pt/chapter.json
+++ b/src/locales/pt/chapter.json
@@ -24,5 +24,7 @@
   "errorEndDayRange": "o dia de fim deve estar entre 1 e {{max}} para o mês selecionado",
   "errorEndAfterStart": "a data de fim deve ser posterior à data de início",
   "endpointTooltip": "âncora — sempre exibido na linha do tempo principal",
-  "endpointDimTooltip": "corresponde a um limite de capítulo — marcar para torná-lo uma âncora"
+  "endpointDimTooltip": "corresponde a um limite de capítulo — marcar para torná-lo uma âncora",
+  "selectAll": "selecionar tudo",
+  "selectNone": "desmarcar tudo"
 }

--- a/src/locales/pt/help.json
+++ b/src/locales/pt/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "desfazer",
   "shortcutRedo": "refazer",
   "shortcutMute": "silenciar / ativar som",
+  "shortcutTheme": "alternar tema claro / escuro",
   "shortcutNewMilestone": "novo marco",
   "shortcutNewChapter": "novo capítulo",
   "shortcutExport": "exportar como imagem",

--- a/src/locales/zh_CN/chapter.json
+++ b/src/locales/zh_CN/chapter.json
@@ -24,5 +24,7 @@
   "colorLabel": "颜色",
   "deleteConfirmTitle": "删除<strong>{{title}}</strong>章节?",
   "endpointTooltip": "端点—始终显示于[时间主线]",
-  "endpointDimTooltip": "贴合章节边缘—设为端点"
+  "endpointDimTooltip": "贴合章节边缘—设为端点",
+  "selectAll": "全选",
+  "selectNone": "全不选"
 }

--- a/src/locales/zh_CN/help.json
+++ b/src/locales/zh_CN/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "撤销",
   "shortcutRedo": "重做",
   "shortcutMute": "静音/打开音效",
+  "shortcutTheme": "切换深色/浅色模式",
   "shortcutNewMilestone": "创建里程碑",
   "shortcutNewChapter": "新添章节",
   "shortcutExport": "将展示导出为图片",

--- a/src/locales/zh_HK/chapter.json
+++ b/src/locales/zh_HK/chapter.json
@@ -24,5 +24,7 @@
   "colorLabel": "顏色",
   "deleteConfirmTitle": "刪除<strong>{{title}}</strong>章節?",
   "endpointTooltip": "端點—始終顯示於[時間主線]",
-  "endpointDimTooltip": "貼合章節邊緣—設為端點"
+  "endpointDimTooltip": "貼合章節邊緣—設為端點",
+  "selectAll": "全選",
+  "selectNone": "全不選"
 }

--- a/src/locales/zh_HK/help.json
+++ b/src/locales/zh_HK/help.json
@@ -16,6 +16,7 @@
   "shortcutUndo": "撤銷",
   "shortcutRedo": "重做",
   "shortcutMute": "靜音/打開音效",
+  "shortcutTheme": "切換深色/淺色模式",
   "shortcutNewMilestone": "創建里程碑",
   "shortcutNewChapter": "新添章節",
   "shortcutExport": "將展示導出為圖片",

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -29,3 +29,8 @@ export function setTheme(theme) {
   try { localStorage.setItem(KEY, t) } catch { /* ignore */ }
   return t
 }
+
+// Flip between dark and light, persist, and return the new theme.
+export function toggleTheme() {
+  return setTheme(getTheme() === 'light' ? 'dark' : 'light')
+}


### PR DESCRIPTION
Bundles the dark/light-mode work and the first batch of Issue #169 fixes, versioned as **v2.3.5**.

## Features
- **Dark / light theme toggle** — a labeled toggle next to *skip* in onboarding, plus a `D` keyboard shortcut to flip the theme in-app (listed in the keyboard-shortcuts modal, translated in all locales).
- **Edit category name & color in place** (#169-2) — categories can now be renamed/recolored from Settings instead of rebuilding them; recolors propagate to existing milestones.
- **Select All / Select None** for the chapter member list (#169-3) — default stays all-checked.

## Fixes
- **Category data now included in local backups** and restored (#169-1) — previously custom categories reverted to defaults on restore.
- **WATCH-mode notes wrap and preserve line breaks** (#169-5) — long/multi-line notes no longer run together; timestamp moved above the note for breathing room.

## Release
- Bumps `package.json`, lockfile, and iOS `MARKETING_VERSION` to **2.3.5**.
- All 69 tests pass; `npm run build` clean.

Deferred to a follow-up: locale-aware date ordering (#169-4) and the remaining translation items (#169-7).

To cut the release: merge this, then publish a GitHub Release tagged `v2.3.5` (that triggers the docker build/publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qud8YZk8Ku68LVcRUkNnmE)_