### PR TITLE
chore(release): v2.3.6

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps package.json, lockfile, and iOS MARKETING_VERSION to 2.3.6.

Includes: locale-aware date ordering and formatting via Intl (input grids, timeline, detail and member dates, timestamps) and translation of the remaining hardcoded English strings (relative-time labels, precision and visibility tabs, text-size and idle-timeout labels, age suffix) across all nine locales.


Claude-Session: https://claude.ai/code/session_01GrZDMqnRQEi4D4nQKJwyHW