### PR TITLE
chore(release): v2.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.3.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.3.7-green.svg)](../../releases)
 
 ---
 

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.6;
+				MARKETING_VERSION = 2.3.7;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.6;
+				MARKETING_VERSION = 2.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.6",
+      "version": "2.3.7",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release bump to **v2.3.7**.

## Version bumps
- `package.json` and `package-lock.json` (both entries): 2.3.6 → 2.3.7
- iOS `MARKETING_VERSION` (both build configs): 2.3.6 → 2.3.7
- README version badge: 2.3.4 → 2.3.7 (had drifted across recent releases)

## What's included since v2.3.6

### Internationalization
- Fixed duration and relative-time strings that were hardcoded in English and rendered in English regardless of the selected language (affected every non-English build).
- Added a shared `formatDuration()` helper so Timeline chapter-span and summary-stats durations are built from localized parts.
- Localized the "N years ago" label in the On This Day view.
- Moved visibility-cascade wording out of code and into localized labels.
- New strings translated across all nine locales (en, fr, de, es, it, pt, zh_CN, zh_HK).

### Tooling and CI
- Added an ESLint 9 flat config with `npm run lint` and a dedicated CI lint job. Rules-of-hooks is a hard error; React Compiler advisory rules run as warnings.
- Fixed the genuine issues surfaced on first lint run (missing i18n keys, intentional empty catch blocks).

### Dependencies
- Updated `@glance-apps/intents` to 1.4.0 and pinned both `@glance-apps/intents` and `@glance-apps/sync` to exact versions.

### Documentation
- Added the glance-intents transport reference and CONTRIBUTING notes for the lint workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKzjshVqe976qBZcUiTiTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKzjshVqe976qBZcUiTiTh)_