### PR TITLE
Add Today + Current Chapter widgets (Android) and the iOS WidgetKit port

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,9 +5,27 @@ apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 // Derive versionName/versionCode from package.json (e.g. 1.8.4 -> 10804).
 // Assumes a clean x.y.z version (no -beta suffix) and minor/patch < 100.
 def pkg = new groovy.json.JsonSlurper().parse(rootProject.file("../package.json"))
-def appVersionName = pkg.version as String
-def versionParts = appVersionName.tokenize('.')
-def appVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+def baseVersionName = pkg.version as String
+def versionParts = baseVersionName.tokenize('.')
+def derivedVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+
+// Interim builds for the Play internal test track need a unique, strictly increasing
+// versionCode without bumping package.json. Override it with -PplayVersionCode=NNNNN or
+// the LIFEGLANCE_VERSION_CODE env var (build.sh --version-code passes the latter).
+// Note: the derived scheme leaves no integer gap between patch releases (2.3.7 -> 20307,
+// 2.3.8 -> 20308), so pick an interim code deliberately — once Play sees a code it can
+// never be reused or undercut.
+def versionCodeOverride = project.findProperty('playVersionCode') ?: System.getenv('LIFEGLANCE_VERSION_CODE')
+def appVersionCode = versionCodeOverride ? versionCodeOverride.toString().trim().toInteger() : derivedVersionCode
+
+// Optionally tag the version name (e.g. "2.3.7-rc1") so testers can identify interim
+// builds. Set with -PversionNameSuffix=rc1 or the LIFEGLANCE_VERSION_SUFFIX env var.
+def versionSuffix = project.findProperty('versionNameSuffix') ?: System.getenv('LIFEGLANCE_VERSION_SUFFIX')
+def appVersionName = versionSuffix ? "${baseVersionName}-${versionSuffix}" : baseVersionName
+
+if (versionCodeOverride || versionSuffix) {
+    println "lifeGLANCE version override → code ${appVersionCode}, name ${appVersionName}"
+}
 
 // Load release signing config from android/key.properties (gitignored) when
 // present. Absent (e.g. CI or a machine without the keystore) -> unsigned release.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,29 +2,35 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
-// Derive versionName/versionCode from package.json (e.g. 1.8.4 -> 10804).
+// Derive versionName/versionCode from package.json. The code packs the x.y.z version
+// into the high digits and reserves the low 3 digits for an interim build number, so
+// codes stay aligned with the marketing version while leaving room for test-track
+// uploads between releases:
+//   2.3.7           -> 20307000
+//   2.3.7 build 1   -> 20307001   (interim, internal test track)
+//   2.3.8           -> 20308000
 // Assumes a clean x.y.z version (no -beta suffix) and minor/patch < 100.
 def pkg = new groovy.json.JsonSlurper().parse(rootProject.file("../package.json"))
 def baseVersionName = pkg.version as String
 def versionParts = baseVersionName.tokenize('.')
-def derivedVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+def baseVersionCode = (versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()) * 1000
 
-// Interim builds for the Play internal test track need a unique, strictly increasing
-// versionCode without bumping package.json. Override it with -PplayVersionCode=NNNNN or
-// the LIFEGLANCE_VERSION_CODE env var (build.sh --version-code passes the latter).
-// Note: the derived scheme leaves no integer gap between patch releases (2.3.7 -> 20307,
-// 2.3.8 -> 20308), so pick an interim code deliberately — once Play sees a code it can
-// never be reused or undercut.
-def versionCodeOverride = project.findProperty('playVersionCode') ?: System.getenv('LIFEGLANCE_VERSION_CODE')
-def appVersionCode = versionCodeOverride ? versionCodeOverride.toString().trim().toInteger() : derivedVersionCode
+// Interim builds for the Play internal test track set a build number (1..999) via
+// -PbuildNumber=N or the LIFEGLANCE_BUILD_NUMBER env var (build.sh --build passes the
+// latter). It occupies the low 3 digits; release builds leave it at 0.
+def buildNumber = (project.findProperty('buildNumber') ?: System.getenv('LIFEGLANCE_BUILD_NUMBER') ?: '0').toString().trim().toInteger()
+if (buildNumber < 0 || buildNumber > 999) {
+    throw new GradleException("buildNumber must be 0..999 (got ${buildNumber}); it occupies the low 3 digits of the versionCode")
+}
+def appVersionCode = baseVersionCode + buildNumber
 
 // Optionally tag the version name (e.g. "2.3.7-rc1") so testers can identify interim
 // builds. Set with -PversionNameSuffix=rc1 or the LIFEGLANCE_VERSION_SUFFIX env var.
 def versionSuffix = project.findProperty('versionNameSuffix') ?: System.getenv('LIFEGLANCE_VERSION_SUFFIX')
 def appVersionName = versionSuffix ? "${baseVersionName}-${versionSuffix}" : baseVersionName
 
-if (versionCodeOverride || versionSuffix) {
-    println "lifeGLANCE version override → code ${appVersionCode}, name ${appVersionName}"
+if (buildNumber != 0 || versionSuffix) {
+    println "lifeGLANCE interim build → code ${appVersionCode}, name ${appVersionName}"
 }
 
 // Load release signing config from android/key.properties (gitignored) when

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         <!-- Home-screen widget: next milestone / countdown -->
         <receiver
             android:name=".widget.NextMilestoneReceiver"
+            android:label="@string/widget_next_milestone_label"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -39,6 +40,32 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/next_milestone_widget_info" />
+        </receiver>
+
+        <!-- Home-screen widget: today (date, age, context) -->
+        <receiver
+            android:name=".widget.TodayWidgetReceiver"
+            android:label="@string/widget_today_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/today_widget_info" />
+        </receiver>
+
+        <!-- Home-screen widget: current chapter -->
+        <receiver
+            android:name=".widget.CurrentChapterReceiver"
+            android:label="@string/widget_current_chapter_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/current_chapter_widget_info" />
         </receiver>
     </application>
 

--- a/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
@@ -1,9 +1,6 @@
 package com.lifeglance.app;
 
-import android.appwidget.AppWidgetManager;
-import android.content.ComponentName;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 
 import com.getcapacitor.JSObject;
@@ -11,7 +8,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import com.lifeglance.app.widget.NextMilestoneReceiver;
 import com.lifeglance.app.widget.WidgetData;
 import com.lifeglance.app.widget.WidgetRefreshWorker;
 
@@ -42,7 +38,7 @@ public class WidgetBridgePlugin extends Plugin {
             .edit()
             .putString(WidgetData.KEY_SNAPSHOT, json)
             .apply();
-        notifyWidgets(ctx);
+        WidgetData.refreshAll(ctx);
         call.resolve();
     }
 
@@ -58,15 +54,5 @@ public class WidgetBridgePlugin extends Plugin {
         JSObject ret = new JSObject();
         ret.put("milestoneId", target); // null when nothing is pending
         call.resolve(ret);
-    }
-
-    private void notifyWidgets(Context ctx) {
-        AppWidgetManager mgr = AppWidgetManager.getInstance(ctx);
-        ComponentName cn = new ComponentName(ctx, NextMilestoneReceiver.class);
-        int[] ids = mgr.getAppWidgetIds(cn);
-        Intent intent = new Intent(ctx, NextMilestoneReceiver.class);
-        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
-        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
-        ctx.sendBroadcast(intent);
     }
 }

--- a/android/app/src/main/java/com/lifeglance/app/widget/CurrentChapterWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/CurrentChapterWidget.kt
@@ -1,0 +1,116 @@
+package com.lifeglance.app.widget
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.LinearProgressIndicator
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lifeglance.app.MainActivity
+
+/**
+ * "Current Chapter" widget: the chapter spanning today — its name, how far into it
+ * you are, and milestones passed / total. Bounded chapters show a time-elapsed
+ * progress bar; ongoing chapters (no end date) show elapsed time only.
+ */
+class CurrentChapterWidget : GlanceAppWidget() {
+    override val sizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(160.dp, 80.dp),
+            DpSize(220.dp, 120.dp),
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snapshot = WidgetData.readSnapshot(context)
+        provideContent {
+            Content(context, snapshot?.currentChapter)
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, chapter: WidgetData.Chapter?) {
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(ColorProvider(WidgetTheme.BG))
+                .cornerRadius(16.dp)
+                .padding(16.dp)
+                .clickable(actionStartActivity(ComponentName(context, MainActivity::class.java), actionParametersOf())),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (chapter == null) {
+                Text(
+                    text = "No active chapter",
+                    style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 13.sp),
+                )
+                return@Column
+            }
+
+            val accent = WidgetTheme.parseColor(chapter.color)
+            Text(
+                text = "CHAPTER",
+                style = TextStyle(color = ColorProvider(accent), fontFamily = FontFamily.Monospace, fontSize = 10.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(4.dp))
+            Text(
+                text = chapter.title,
+                maxLines = 2,
+                style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 18.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(2.dp))
+            Text(
+                text = "${WidgetData.durationWords(chapter.start)} in",
+                style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
+            )
+
+            if (chapter.totalCount > 0) {
+                Text(
+                    text = "${chapter.passedCount}/${chapter.totalCount} milestones",
+                    style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+                )
+            }
+
+            // Bounded chapters get a time-elapsed progress bar; ongoing ones don't,
+            // since there's no end to measure against.
+            val fraction = WidgetData.progressFraction(chapter.start, chapter.end)
+            if (fraction != null) {
+                Spacer(GlanceModifier.height(8.dp))
+                LinearProgressIndicator(
+                    progress = fraction,
+                    modifier = GlanceModifier.fillMaxWidth().height(6.dp),
+                    color = ColorProvider(accent),
+                    backgroundColor = ColorProvider(WidgetTheme.TRACK),
+                )
+            }
+        }
+    }
+}
+
+class CurrentChapterReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = CurrentChapterWidget()
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/TodayWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/TodayWidget.kt
@@ -1,0 +1,112 @@
+package com.lifeglance.app.widget
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.LocalSize
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lifeglance.app.MainActivity
+
+/**
+ * "Today" widget: weekday, date, and age. At its larger size it also surfaces the
+ * most recently passed and next upcoming milestones and the current chapter name.
+ */
+class TodayWidget : GlanceAppWidget() {
+    override val sizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(160.dp, 80.dp),
+            DpSize(220.dp, 180.dp),
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snapshot = WidgetData.readSnapshot(context)
+        provideContent {
+            Content(context, snapshot)
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, snapshot: WidgetData.Snapshot?) {
+        val tall = LocalSize.current.height >= 160.dp
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(ColorProvider(WidgetTheme.BG))
+                .cornerRadius(16.dp)
+                .padding(16.dp)
+                .clickable(actionStartActivity(ComponentName(context, MainActivity::class.java), actionParametersOf())),
+        ) {
+            Text(
+                text = "TODAY",
+                style = TextStyle(color = ColorProvider(WidgetTheme.AMBER), fontFamily = FontFamily.Monospace, fontSize = 10.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(4.dp))
+            Text(
+                text = WidgetData.weekday(),
+                style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 22.sp, fontWeight = FontWeight.Bold),
+            )
+            Text(
+                text = WidgetData.todayLong(),
+                style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
+            )
+
+            val age = WidgetData.age(snapshot?.birthday)
+            if (age != null) {
+                Text(
+                    text = "$age year${if (age != 1) "s" else ""} old",
+                    style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
+                )
+            }
+
+            if (tall) {
+                Spacer(GlanceModifier.height(10.dp))
+                snapshot?.next?.let {
+                    ContextLine("next", "${it.title} · ${WidgetData.relativeLabel(it.date)}")
+                }
+                snapshot?.prev?.let {
+                    ContextLine("last", "${it.title} · ${WidgetData.relativeLabel(it.date)}")
+                }
+                snapshot?.currentChapter?.let {
+                    ContextLine("chapter", it.title)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ContextLine(label: String, value: String) {
+        Text(
+            text = "$label · $value",
+            maxLines = 1,
+            style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+        )
+    }
+}
+
+class TodayWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = TodayWidget()
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -1,6 +1,9 @@
 package com.lifeglance.app.widget
 
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import org.json.JSONObject
 import java.time.LocalDate
 import java.time.Period
@@ -24,6 +27,11 @@ object WidgetData {
     fun prefs(context: Context) =
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
+    // optString yields "" for a missing key and (on Android's org.json) the literal
+    // "null" for a JSON null; treat both as absent.
+    private fun JSONObject.stringOrNull(key: String): String? =
+        optString(key).takeIf { it.isNotEmpty() && it != "null" }
+
     data class Milestone(
         val id: String,
         val title: String,
@@ -32,10 +40,21 @@ object WidgetData {
         val color: String?,
     )
 
+    data class Chapter(
+        val id: String,
+        val title: String,
+        val start: String,         // ISO 8601
+        val end: String?,          // ISO 8601, or null for an ongoing chapter
+        val color: String?,
+        val passedCount: Int,
+        val totalCount: Int,
+    )
+
     data class Snapshot(
         val next: Milestone?,
         val prev: Milestone?,
-        val currentChapterTitle: String?,
+        val currentChapter: Chapter?,
+        val birthday: String?,
         val pastCount: Int,
         val futureCount: Int,
     )
@@ -48,13 +67,30 @@ object WidgetData {
             Snapshot(
                 next = parseMilestone(obj.optJSONObject("next")),
                 prev = parseMilestone(obj.optJSONObject("prev")),
-                currentChapterTitle = obj.optJSONObject("currentChapter")?.optString("title"),
+                currentChapter = parseChapter(obj.optJSONObject("currentChapter")),
+                birthday = obj.stringOrNull("birthday"),
                 pastCount = counts?.optInt("past", 0) ?: 0,
                 futureCount = counts?.optInt("future", 0) ?: 0,
             )
         } catch (e: Exception) {
             null
         }
+    }
+
+    private fun parseChapter(obj: JSONObject?): Chapter? {
+        if (obj == null) return null
+        val id = obj.optString("id", "")
+        val start = obj.optString("start", "")
+        if (id.isEmpty() || start.isEmpty()) return null
+        return Chapter(
+            id = id,
+            title = obj.optString("title", ""),
+            start = start,
+            end = obj.stringOrNull("end"),
+            color = obj.stringOrNull("color"),
+            passedCount = obj.optInt("passedCount", 0),
+            totalCount = obj.optInt("totalCount", 0),
+        )
     }
 
     private fun parseMilestone(obj: JSONObject?): Milestone? {
@@ -67,7 +103,7 @@ object WidgetData {
             title = obj.optString("title", ""),
             date = date,
             datePrecision = obj.optString("datePrecision", "day"),
-            color = obj.optString("color").takeIf { it.isNotEmpty() },
+            color = obj.stringOrNull("color"),
         )
     }
 
@@ -116,6 +152,72 @@ object WidgetData {
             else    -> "MMMM d, yyyy"
         }
         return date.format(DateTimeFormatter.ofPattern(pattern, Locale.getDefault()))
+    }
+
+    /** Whole years between a birthday and today, or null if unset / not yet reached. */
+    fun age(birthdayIso: String?, today: LocalDate = LocalDate.now()): Int? {
+        val born = birthdayIso?.let { localDateOf(it) } ?: return null
+        if (today.isBefore(born)) return null
+        return Period.between(born, today).years
+    }
+
+    /**
+     * Coarse elapsed duration from a past date to today, e.g. "2 yrs, 3 mo",
+     * "4 mo", "9 days". Used for "how far into this chapter" — the caller adds
+     * any framing word like "in". Returns "just started" for today/future starts.
+     */
+    fun durationWords(fromIso: String, to: LocalDate = LocalDate.now()): String {
+        val from = localDateOf(fromIso) ?: return ""
+        if (!from.isBefore(to)) return "just started"
+        val p = Period.between(from, to)
+        val totalDays = ChronoUnit.DAYS.between(from, to)
+        return when {
+            p.years > 0 && p.months > 0 -> "${p.years} yr${plural(p.years)}, ${p.months} mo"
+            p.years > 0                 -> "${p.years} yr${plural(p.years)}"
+            totalDays > 30              -> "${totalDays / 30} mo"
+            else                        -> "$totalDays day${plural(totalDays)}"
+        }
+    }
+
+    /** Time-elapsed progress through a bounded chapter as 0..1, or null if ongoing. */
+    fun progressFraction(startIso: String, endIso: String?, today: LocalDate = LocalDate.now()): Float? {
+        if (endIso == null) return null
+        val start = localDateOf(startIso) ?: return null
+        val end = localDateOf(endIso) ?: return null
+        val total = ChronoUnit.DAYS.between(start, end).toDouble()
+        if (total <= 0) return null
+        val elapsed = ChronoUnit.DAYS.between(start, today).toDouble()
+        return (elapsed / total).coerceIn(0.0, 1.0).toFloat()
+    }
+
+    fun weekday(today: LocalDate = LocalDate.now()): String =
+        today.format(DateTimeFormatter.ofPattern("EEEE", Locale.getDefault()))
+
+    fun todayLong(today: LocalDate = LocalDate.now()): String =
+        today.format(DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.getDefault()))
+
+    /**
+     * Refreshes every placed lifeGLANCE widget by broadcasting an update, which makes
+     * each Glance receiver recompose and re-read the snapshot. Called from the bridge
+     * plugin (on data change) and the midnight worker. @JvmStatic so Java can call it.
+     */
+    @JvmStatic
+    fun refreshAll(context: Context) {
+        val receivers = listOf(
+            NextMilestoneReceiver::class.java,
+            TodayWidgetReceiver::class.java,
+            CurrentChapterReceiver::class.java,
+        )
+        val mgr = AppWidgetManager.getInstance(context)
+        for (cls in receivers) {
+            val ids = mgr.getAppWidgetIds(ComponentName(context, cls))
+            if (ids.isEmpty()) continue
+            val intent = Intent(context, cls).apply {
+                action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+            }
+            context.sendBroadcast(intent)
+        }
     }
 
     private fun plural(n: Long) = if (n != 1L) "s" else ""

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import org.json.JSONObject
 import java.time.LocalDate
 import java.time.Period
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -107,10 +106,11 @@ object WidgetData {
         )
     }
 
-    // The calendar date the milestone falls on, read from the UTC components of the
-    // ISO string — matching the web app's toLocalNoon convention.
+    // The calendar date a value falls on. The leading "yyyy-MM-dd" is the UTC date for
+    // a full ISO instant ("2026-07-01T00:00:00.000Z" — matching the web's toLocalNoon
+    // convention) and is also the whole value for a date-only field like birthday.
     private fun localDateOf(iso: String): LocalDate? = try {
-        java.time.Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
+        if (iso.length >= 10) LocalDate.parse(iso.substring(0, 10)) else null
     } catch (e: Exception) {
         null
     }

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt
@@ -1,9 +1,6 @@
 package com.lifeglance.app.widget
 
-import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -21,7 +18,8 @@ class WidgetRefreshWorker(context: Context, params: WorkerParameters) :
     CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
-        refreshWidgets(applicationContext)
+        // Re-render every placed widget so date-relative labels reflect the new day.
+        WidgetData.refreshAll(applicationContext)
         schedule(applicationContext)
         return Result.success()
     }
@@ -29,21 +27,8 @@ class WidgetRefreshWorker(context: Context, params: WorkerParameters) :
     companion object {
         private const val WORK_NAME = "lifeglance_widget_daily_refresh"
 
-        // Broadcast an update to all placed widgets, which makes GlanceAppWidgetReceiver
-        // recompose and re-read the snapshot (recomputing relative labels for the new day).
-        private fun refreshWidgets(context: Context) {
-            val mgr = AppWidgetManager.getInstance(context)
-            val ids = mgr.getAppWidgetIds(ComponentName(context, NextMilestoneReceiver::class.java))
-            if (ids.isEmpty()) return
-            val intent = Intent(context, NextMilestoneReceiver::class.java).apply {
-                action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
-            }
-            context.sendBroadcast(intent)
-        }
-
-        // Enqueues a one-shot refresh for the next local midnight. KEEP avoids
-        // piling up duplicates when called repeatedly (e.g. on every app start).
+        // Enqueues a one-shot refresh for the next local midnight. REPLACE keeps a
+        // single pending job and re-points it at the next midnight on each app start.
         fun schedule(context: Context) {
             val now = ZonedDateTime.now()
             val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(now.zone)

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetTheme.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetTheme.kt
@@ -1,0 +1,23 @@
+package com.lifeglance.app.widget
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Shared palette for the home-screen widgets, mirroring the web app's dark theme
+ * tokens in src/index.css. (NextMilestoneWidget predates this and keeps its own
+ * copy; new widgets use these.)
+ */
+object WidgetTheme {
+    val BG = Color(0xFF0F1117)
+    val TEXT = Color(0xFFE8E0D0)
+    val AMBER = Color(0xFFC8A96E)
+    val MUTED = Color(0xFF8A8270)
+    val TRACK = Color(0xFF2A2C38)
+
+    // Parses a "#RRGGBB" hex into a Color, falling back to amber on anything invalid.
+    fun parseColor(hex: String?, fallback: Color = AMBER): Color = try {
+        if (hex.isNullOrEmpty()) fallback else Color(android.graphics.Color.parseColor(hex))
+    } catch (e: Exception) {
+        fallback
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,5 +4,13 @@
     <string name="title_activity_main">lifeGLANCE</string>
     <string name="package_name">com.lifeglance.app</string>
     <string name="custom_url_scheme">com.lifeglance.app</string>
+
+    <string name="widget_next_milestone_label">Next milestone</string>
     <string name="widget_next_milestone_description">Your next upcoming milestone, with a live countdown.</string>
+
+    <string name="widget_today_label">Today</string>
+    <string name="widget_today_description">Today\'s date and your age, with recent and upcoming milestones at larger sizes.</string>
+
+    <string name="widget_current_chapter_label">Current chapter</string>
+    <string name="widget_current_chapter_description">The chapter you\'re in now: how far along you are and milestones passed.</string>
 </resources>

--- a/android/app/src/main/res/xml/current_chapter_widget_info.xml
+++ b/android/app/src/main/res/xml/current_chapter_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="160dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_current_chapter_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewLayout="@layout/glance_default_loading_layout" />

--- a/android/app/src/main/res/xml/today_widget_info.xml
+++ b/android/app/src/main/res/xml/today_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="160dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_today_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewLayout="@layout/glance_default_loading_layout" />

--- a/build.sh
+++ b/build.sh
@@ -8,13 +8,35 @@ OUT_DIR="$SCRIPT_DIR/outputs"
 # Flags
 FULL_CLEAN=false
 RELEASE=false
-for arg in "$@"; do
-  case "$arg" in
-    --clean)   FULL_CLEAN=true ;;
-    --release) RELEASE=true ;;
-    *) echo "Unknown flag: $arg (valid flags: --clean, --release)" && exit 1 ;;
+VERSION_CODE=""
+VERSION_SUFFIX=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --clean)             FULL_CLEAN=true ;;
+    --release)           RELEASE=true ;;
+    --version-code)      shift; VERSION_CODE="$1" ;;
+    --version-code=*)    VERSION_CODE="${1#*=}" ;;
+    --version-suffix)    shift; VERSION_SUFFIX="$1" ;;
+    --version-suffix=*)  VERSION_SUFFIX="${1#*=}" ;;
+    *) echo "Unknown flag: $1 (valid flags: --clean, --release, --version-code N, --version-suffix S)" && exit 1 ;;
   esac
+  shift
 done
+
+# Interim builds for Play's internal test track: pass an explicit, strictly increasing
+# versionCode without bumping package.json. Plumbed to Gradle via env vars (see
+# android/app/build.gradle).
+if [ -n "$VERSION_CODE" ]; then
+  if ! [[ "$VERSION_CODE" =~ ^[0-9]+$ ]]; then
+    echo "--version-code must be a positive integer (got: $VERSION_CODE)" && exit 1
+  fi
+  export LIFEGLANCE_VERSION_CODE="$VERSION_CODE"
+  echo "==> Using interim versionCode: $VERSION_CODE"
+fi
+if [ -n "$VERSION_SUFFIX" ]; then
+  export LIFEGLANCE_VERSION_SUFFIX="$VERSION_SUFFIX"
+  echo "==> Using versionName suffix: -$VERSION_SUFFIX"
+fi
 
 # ── Dependencies ────────────────────────────────────────────────────────────
 echo "==> Installing npm dependencies..."

--- a/build.sh
+++ b/build.sh
@@ -8,30 +8,31 @@ OUT_DIR="$SCRIPT_DIR/outputs"
 # Flags
 FULL_CLEAN=false
 RELEASE=false
-VERSION_CODE=""
+BUILD_NUMBER=""
 VERSION_SUFFIX=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --clean)             FULL_CLEAN=true ;;
     --release)           RELEASE=true ;;
-    --version-code)      shift; VERSION_CODE="$1" ;;
-    --version-code=*)    VERSION_CODE="${1#*=}" ;;
+    --build)             shift; BUILD_NUMBER="$1" ;;
+    --build=*)           BUILD_NUMBER="${1#*=}" ;;
     --version-suffix)    shift; VERSION_SUFFIX="$1" ;;
     --version-suffix=*)  VERSION_SUFFIX="${1#*=}" ;;
-    *) echo "Unknown flag: $1 (valid flags: --clean, --release, --version-code N, --version-suffix S)" && exit 1 ;;
+    *) echo "Unknown flag: $1 (valid flags: --clean, --release, --build N, --version-suffix S)" && exit 1 ;;
   esac
   shift
 done
 
-# Interim builds for Play's internal test track: pass an explicit, strictly increasing
-# versionCode without bumping package.json. Plumbed to Gradle via env vars (see
-# android/app/build.gradle).
-if [ -n "$VERSION_CODE" ]; then
-  if ! [[ "$VERSION_CODE" =~ ^[0-9]+$ ]]; then
-    echo "--version-code must be a positive integer (got: $VERSION_CODE)" && exit 1
+# Interim builds for Play's internal test track: a build number (1..999) is packed into
+# the low 3 digits of the package.json-derived versionCode, keeping codes aligned with
+# the marketing version (e.g. 2.3.7 build 1 -> 20307001). Plumbed to Gradle via env vars
+# (see android/app/build.gradle).
+if [ -n "$BUILD_NUMBER" ]; then
+  if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]] || [ "$BUILD_NUMBER" -gt 999 ]; then
+    echo "--build must be an integer 0..999 (got: $BUILD_NUMBER)" && exit 1
   fi
-  export LIFEGLANCE_VERSION_CODE="$VERSION_CODE"
-  echo "==> Using interim versionCode: $VERSION_CODE"
+  export LIFEGLANCE_BUILD_NUMBER="$BUILD_NUMBER"
+  echo "==> Interim build number: $BUILD_NUMBER"
 fi
 if [ -n "$VERSION_SUFFIX" ]; then
   export LIFEGLANCE_VERSION_SUFFIX="$VERSION_SUFFIX"

--- a/docs/IOS-WIDGETS.md
+++ b/docs/IOS-WIDGETS.md
@@ -69,6 +69,31 @@ App target (`ios/App/App/`):
 7. **Build & run**, then long-press the home screen → **＋** → search *lifeGLANCE* →
    add any of the three widgets.
 
+## Signing & distribution — do I need App Store Connect?
+
+**No new App Store Connect setup is required for the widgets.** Two different Apple
+sites are involved, and only the first matters here:
+
+- **Apple Developer portal** (developer.apple.com → *Certificates, Identifiers &
+  Profiles*) — where the extension's **App ID** (`com.lifeglance.LifeGlanceWidgets`) and
+  the **App Group** (`group.com.lifeglance`) are registered, with the App Group enabled
+  on **both** the app's and the extension's App IDs. With Xcode's *Automatically manage
+  signing* (the default), **Xcode does all of this for you** when you add the App Groups
+  capability in steps 2 and 4 — it registers the group, creates the extension App ID,
+  and regenerates provisioning profiles. You only touch the portal by hand if you use
+  **manual signing**, in which case register the App Group there and enable it on both
+  App IDs, then update the distribution profiles.
+
+- **App Store Connect** (appstoreconnect.apple.com) — app records, TestFlight, builds.
+  A widget extension is **embedded inside the existing app's build**, so there is **no
+  separate app or extension record to create** here. Nothing widget-specific to
+  configure. When you're ready to test on real devices beyond your own, upload a build
+  to **TestFlight** exactly as you would any release; the widget ships inside it.
+  (TestFlight is the iOS equivalent of Play's internal test track.)
+
+Local simulator / personal-device testing needs **none** of the above beyond the Xcode
+steps — automatic signing provisions the App Group on the fly.
+
 ## Notes
 
 - Widgets show empty states until the app has run once and pushed a snapshot.

--- a/docs/IOS-WIDGETS.md
+++ b/docs/IOS-WIDGETS.md
@@ -1,0 +1,78 @@
+# iOS Widgets — Setup
+
+The iOS widgets (WidgetKit + SwiftUI) reuse the exact same snapshot the web app
+already produces. All Swift/plist/entitlements are written and committed; what remains
+is the Xcode wiring that genuinely can't be scripted without risking the
+`project.pbxproj` (creating an app-extension target, App Group capability, file target
+membership). Do these once in Xcode.
+
+> Bundle id: `com.lifeglance` · App Group: `group.com.lifeglance` ·
+> Extension bundle id: `com.lifeglance.LifeGlanceWidgets`
+
+## Architecture (how it differs from Android)
+
+The widget runs in a **separate extension process**, so unlike Android (same-process
+SharedPreferences) it cannot read the app's storage directly. The app and the extension
+share data through an **App Group** container (`UserDefaults(suiteName:)`). The
+`WidgetBridge` plugin writes the snapshot there and calls
+`WidgetCenter.reloadAllTimelines()`; the widgets read it via `WidgetStore`.
+
+Everything else mirrors Android: raw ISO dates in the snapshot, relative labels
+computed at render time, a midnight timeline-reload boundary, and a widget-tap deep
+link (`lifeglance://milestone?id=…`) that `AppDelegate` stashes for the web layer's
+existing `consumeLaunchTarget()` flow.
+
+## Files already committed
+
+Extension (`ios/App/LifeGlanceWidgets/`):
+- `WidgetModel.swift` — snapshot model, `WidgetStore` (App Group), date/label helpers
+  **(also add to the App target — the plugin uses `WidgetStore`)**
+- `WidgetTheme.swift` — palette, `Color(hex:)`, `widgetBackground`
+- `WidgetProvider.swift` — `SnapshotProvider` (TimelineProvider) + entry
+- `WidgetViews.swift` — the three SwiftUI views
+- `LifeGlanceWidgetsBundle.swift` — `@main` bundle + the three widget configs
+- `Info.plist`, `LifeGlanceWidgets.entitlements`
+
+App target (`ios/App/App/`):
+- `WidgetBridgePlugin.swift` — the iOS `WidgetBridge` Capacitor plugin
+- `App.entitlements` — App Group for the main app
+- `AppDelegate.swift` — parses the widget deep link (already edited)
+- `Info.plist` — `lifeglance` URL scheme (already added)
+
+## Xcode steps
+
+1. **Open** `ios/App/App.xcworkspace`.
+
+2. **App Group on the App target** — select the **App** target → *Signing &
+   Capabilities* → **＋ Capability → App Groups** → add `group.com.lifeglance`. Point its
+   *Code Signing Entitlements* at the committed `App/App.entitlements` (or let Xcode
+   manage and confirm the group matches).
+
+3. **Create the extension** — *File → New → Target… → Widget Extension*. Name it
+   **`LifeGlanceWidgets`**; **uncheck** "Include Live Activity" and "Include
+   Configuration App Intent" (we use `StaticConfiguration`). Click *Activate*. **Delete
+   the template `.swift` file Xcode generates** (it has its own `@main`, which would
+   collide).
+
+4. **Add the committed files to the extension target** — drag the five
+   `ios/App/LifeGlanceWidgets/*.swift` files in; set target membership to
+   **LifeGlanceWidgets**. Use the committed `Info.plist` and
+   `LifeGlanceWidgets.entitlements` for the target (set *Info.plist File* and *Code
+   Signing Entitlements* build settings). Add the **App Groups** capability to this
+   target too (`group.com.lifeglance`).
+
+5. **Shared + app files** — set `WidgetModel.swift` to be a member of **both**
+   LifeGlanceWidgets **and** App. Add `WidgetBridgePlugin.swift` to the **App** target.
+
+6. **Deployment target** — set the extension to **iOS 16+**.
+
+7. **Build & run**, then long-press the home screen → **＋** → search *lifeGLANCE* →
+   add any of the three widgets.
+
+## Notes
+
+- Widgets show empty states until the app has run once and pushed a snapshot.
+- `npx cap sync ios` is safe to run; it copies web assets and won't remove the target.
+- No JS changes: `src/native/widgetBridge.js` already calls the `WidgetBridge` plugin
+  (the Swift `jsName` matches), and `src/utils/widgetSnapshot.js` is the single source
+  of the snapshot for both platforms.

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -105,22 +105,25 @@ for date math via **core library desugaring** (minSdk 24). Versions in
 
 Shipped in PR #166 (merged). Glance API fixes in PR #167.
 
+### ✅ Phase 3 — Today + Current Chapter widgets
+- `TodayWidget.kt` — weekday, date, age; larger size adds prev/next milestones and the
+  current chapter name. Branches on `LocalSize`.
+- `CurrentChapterWidget.kt` — active chapter name, elapsed time "in" the chapter, and
+  milestones passed/total. **Bounded** chapters show a time-elapsed progress bar;
+  **ongoing** chapters (no end) show elapsed time only.
+- `WidgetData` extended: full `currentChapter` + `birthday` parsing, and helpers
+  (`age`, `durationWords`, `progressFraction`, `weekday`/`todayLong`). New
+  `WidgetData.refreshAll()` broadcasts to **all** widget receivers; the bridge plugin
+  and midnight worker now call it so every widget refreshes together.
+- `WidgetTheme.kt` shared palette; two new manifest receivers + provider XML + strings.
+- No snapshot/bridge schema change — the existing snapshot already carried this data.
+
 > ⚠️ The Gradle/Kotlin compile cannot run in the Claude Code sandbox (Maven/Google
 > repos blocked). The native module must be built locally (`npm run android`).
 
 ---
 
 ## Roadmap
-
-### ⏳ Today widget
-Today's date, day of week, and age (from `lifeglance-birthday` via `ageAtDate`).
-**Largest size** also shows most-recently-passed + next-upcoming milestones and the
-current chapter name. Data already in the snapshot (`prev`, `next`, `currentChapter`,
-`birthday`).
-
-### ⏳ Current Chapter widget
-The chapter spanning today: name, how far into it you are (elapsed vs. total span),
-and milestones passed / total. Data already in the snapshot (`currentChapter`).
 
 ### ⏳ iOS widgets
 WidgetKit + a matching native bridge. The snapshot builder is platform-agnostic and
@@ -147,8 +150,9 @@ reusable; only the native widget layer differs.
 | Web hooks | `src/App.jsx`, `src/components/timeline/TimelineView.jsx` |
 | Capacitor plugin | `android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java` |
 | Activity wiring | `android/app/src/main/java/com/lifeglance/app/MainActivity.java` |
-| Widget | `android/app/src/main/java/com/lifeglance/app/widget/NextMilestoneWidget.kt` |
-| Data/format | `android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt` |
-| Refresh | `android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt` |
-| Manifest / provider | `AndroidManifest.xml`, `res/xml/next_milestone_widget_info.xml` |
+| Widgets | `widget/NextMilestoneWidget.kt`, `widget/TodayWidget.kt`, `widget/CurrentChapterWidget.kt` |
+| Shared theme | `android/app/src/main/java/com/lifeglance/app/widget/WidgetTheme.kt` |
+| Data/format/refresh | `android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt` |
+| Midnight tick | `android/app/src/main/java/com/lifeglance/app/widget/WidgetRefreshWorker.kt` |
+| Manifest / provider | `AndroidManifest.xml`, `res/xml/{next_milestone,today,current_chapter}_widget_info.xml` |
 | Build | `android/variables.gradle`, `android/build.gradle`, `android/app/build.gradle` |

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -121,13 +121,23 @@ Shipped in PR #166 (merged). Glance API fixes in PR #167.
 > ⚠️ The Gradle/Kotlin compile cannot run in the Claude Code sandbox (Maven/Google
 > repos blocked). The native module must be built locally (`npm run android`).
 
+### 🚧 Phase 4 — iOS widgets (code complete; Xcode wiring pending)
+WidgetKit + SwiftUI port of all three widgets, reusing the same `widgetSnapshot.js`
+output. The app↔widget link uses an **App Group** (`group.com.lifeglance`) instead of
+Android's same-process SharedPreferences; everything else mirrors Android.
+- `ios/App/LifeGlanceWidgets/` — model+store (`WidgetModel.swift`), theme, provider,
+  views, `@main` bundle, Info.plist, entitlements.
+- `ios/App/App/` — `WidgetBridgePlugin.swift` (iOS `WidgetBridge`), `App.entitlements`,
+  `AppDelegate` deep-link parse, `Info.plist` `lifeglance` URL scheme.
+- No JS changes — same plugin name and snapshot.
+
+> ⚠️ Creating the Widget Extension target + App Group can't be scripted without risking
+> `project.pbxproj`. **See [`IOS-WIDGETS.md`](IOS-WIDGETS.md) for the one-time Xcode
+> setup.** Swift can't be compiled in the Claude Code sandbox either.
+
 ---
 
 ## Roadmap
-
-### ⏳ iOS widgets
-WidgetKit + a matching native bridge. The snapshot builder is platform-agnostic and
-reusable; only the native widget layer differs.
 
 ### 💡 Deferred / ideas
 - **Mini-timeline strip** — a rendered slice of the timeline around today. Highest

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lifeglance</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -34,9 +34,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        // A widget tap opens lifeglance://milestone?id=<id>. Stash the id where the web
+        // layer reads it via WidgetBridge.consumeLaunchTarget() once it resumes. Kept
+        // self-contained (no shared-file dependency) so this compiles on its own.
+        handleWidgetDeepLink(url)
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
+    }
+
+    private func handleWidgetDeepLink(_ url: URL) {
+        guard url.scheme == "lifeglance", url.host == "milestone",
+              let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let id = comps.queryItems?.first(where: { $0.name == "id" })?.value
+        else { return }
+        UserDefaults(suiteName: "group.com.lifeglance")?.set(id, forKey: "pending_target")
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -24,6 +24,17 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.lifeglance.widget</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lifeglance</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ios/App/App/WidgetBridgePlugin.swift
+++ b/ios/App/App/WidgetBridgePlugin.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Capacitor
+import WidgetKit
+
+// iOS half of the WidgetBridge plugin (the Android side is WidgetBridgePlugin.java).
+// The web app pushes a render-ready snapshot here; it is written to the App Group
+// container that the widget extension reads, and the widgets are reloaded.
+//
+// Capacitor auto-discovers plugins conforming to CAPBridgedPlugin; jsName must match
+// registerPlugin('WidgetBridge') in src/native/widgetBridge.js.
+@objc(WidgetBridgePlugin)
+public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "WidgetBridgePlugin"
+    public let jsName = "WidgetBridge"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "updateSnapshot", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "consumeLaunchTarget", returnType: CAPPluginReturnPromise),
+    ]
+
+    // Persists the snapshot JSON and reloads all widget timelines immediately.
+    @objc func updateSnapshot(_ call: CAPPluginCall) {
+        guard let json = call.getString("json") else {
+            call.reject("Missing 'json'")
+            return
+        }
+        WidgetStore.saveSnapshot(json)
+        WidgetCenter.shared.reloadAllTimelines()
+        call.resolve()
+    }
+
+    // Returns and clears a pending deep-link target left by a widget tap.
+    @objc func consumeLaunchTarget(_ call: CAPPluginCall) {
+        var result = JSObject()
+        if let target = WidgetStore.consumePendingTarget() {
+            result["milestoneId"] = target
+        }
+        call.resolve(result)
+    }
+}

--- a/ios/App/LifeGlanceWidgets/Info.plist
+++ b/ios/App/LifeGlanceWidgets/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>lifeGLANCE</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgets.entitlements
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgets.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lifeglance</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import WidgetKit
+
+// Entry point for the widget extension. Bundles the three lifeGLANCE widgets, all
+// driven by the same App Group snapshot via SnapshotProvider.
+@main
+struct LifeGlanceWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        NextMilestoneWidget()
+        TodayWidget()
+        CurrentChapterWidget()
+    }
+}
+
+struct NextMilestoneWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "NextMilestoneWidget", provider: SnapshotProvider()) { entry in
+            NextMilestoneView(entry: entry).widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Next milestone")
+        .description("Your next upcoming milestone, with a live countdown.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct TodayWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "TodayWidget", provider: SnapshotProvider()) { entry in
+            TodayView(entry: entry).widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Today")
+        .description("Today's date and your age, with recent and upcoming milestones at larger sizes.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct CurrentChapterWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CurrentChapterWidget", provider: SnapshotProvider()) { entry in
+            CurrentChapterView(entry: entry).widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Current chapter")
+        .description("The chapter you're in now: how far along you are and milestones passed.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+// Shared model + storage + date logic for the home-screen widgets, mirroring the
+// Android WidgetData.kt. Added to BOTH the App target (the WidgetBridge plugin writes
+// here) and the widget extension (which reads here). Foundation-only — no SwiftUI — so
+// the app target doesn't pull in UI frameworks it doesn't need.
+//
+// The web app pushes a render-ready JSON snapshot into the App Group container; the
+// widget process reads it. Snapshots store raw ISO dates, so relative labels like
+// "in 12 days" are computed at render time and stay correct between pushes.
+
+// MARK: - Shared storage (App Group)
+
+enum WidgetStore {
+    // Must match the App Group added to both targets and the entitlements files.
+    static let appGroupId = "group.com.lifeglance"
+    static let keySnapshot = "snapshot"
+    static let keyPendingTarget = "pending_target"
+
+    private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroupId) }
+
+    static func saveSnapshot(_ json: String) {
+        defaults?.set(json, forKey: keySnapshot)
+    }
+
+    static func loadSnapshot() -> WidgetSnapshot? {
+        guard let json = defaults?.string(forKey: keySnapshot),
+              let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(WidgetSnapshot.self, from: data)
+    }
+
+    static func setPendingTarget(_ id: String) {
+        defaults?.set(id, forKey: keyPendingTarget)
+    }
+
+    // Returns and clears a pending deep-link target left by a widget tap.
+    static func consumePendingTarget() -> String? {
+        guard let target = defaults?.string(forKey: keyPendingTarget) else { return nil }
+        defaults?.removeObject(forKey: keyPendingTarget)
+        return target
+    }
+}
+
+// MARK: - Snapshot model (decodes the JSON the web app pushes)
+
+struct WidgetSnapshot: Codable {
+    let version: Int?
+    let birthday: String?
+    let next: WidgetMilestone?
+    let prev: WidgetMilestone?
+    let currentChapter: WidgetChapter?
+    let counts: Counts?
+
+    struct Counts: Codable {
+        let past: Int?
+        let future: Int?
+        let total: Int?
+    }
+}
+
+struct WidgetMilestone: Codable {
+    let id: String
+    let title: String
+    let date: String
+    let datePrecision: String?
+    let category: String?
+    let color: String?
+}
+
+struct WidgetChapter: Codable {
+    let id: String
+    let title: String
+    let start: String
+    let end: String?        // nil for an ongoing chapter
+    let color: String?
+    let passedCount: Int?
+    let totalCount: Int?
+}
+
+// MARK: - Date helpers (mirror WidgetData.kt)
+
+enum WidgetDate {
+    private static let utc = TimeZone(identifier: "UTC")!
+
+    private static var utcCalendar: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = utc
+        return c
+    }
+
+    // The calendar date a value falls on, as a UTC-anchored Date so two such values
+    // compare purely by calendar date. The leading "yyyy-MM-dd" is the UTC date for a
+    // full ISO instant ("2026-07-01T00:00:00.000Z" — matching the web's toLocalNoon
+    // convention) and is also the whole value for a date-only field like birthday.
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    private static func dateOnly(_ iso: String) -> Date? {
+        guard iso.count >= 10 else { return nil }
+        return dayFormatter.date(from: String(iso.prefix(10)))
+    }
+
+    // Today's local calendar date, expressed in the same UTC-anchored calendar.
+    private static func today() -> Date {
+        var local = Calendar(identifier: .gregorian)
+        local.timeZone = TimeZone.current
+        let comps = local.dateComponents([.year, .month, .day], from: Date())
+        return utcCalendar.date(from: comps) ?? Date()
+    }
+
+    /// Mirrors relativeLabel(): "in 3 days", "2 yrs, 1 mo ago", "today".
+    static func relativeLabel(_ iso: String) -> String {
+        guard let date = dateOnly(iso) else { return "" }
+        let now = today()
+        if date == now { return "today" }
+        let past = date < now
+        let from = past ? date : now
+        let to = past ? now : date
+        let comps = utcCalendar.dateComponents([.year, .month], from: from, to: to)
+        let totalDays = utcCalendar.dateComponents([.day], from: from, to: to).day ?? 0
+        let years = comps.year ?? 0
+        let months = comps.month ?? 0
+        let body: String
+        if years > 0 && months > 0 { body = "\(years) yr\(plural(years)), \(months) mo" }
+        else if years > 0          { body = "\(years) yr\(plural(years))" }
+        else if totalDays > 30     { body = "\(totalDays / 30) mo" }
+        else if totalDays > 0      { body = "\(totalDays) day\(plural(totalDays))" }
+        else { return "today" }
+        return past ? "\(body) ago" : "in \(body)"
+    }
+
+    /// Coarse elapsed duration from a past date to today, e.g. "2 yrs, 3 mo".
+    /// "just started" for a today/future start.
+    static func durationWords(_ iso: String) -> String {
+        guard let from = dateOnly(iso) else { return "" }
+        let now = today()
+        if from >= now { return "just started" }
+        let comps = utcCalendar.dateComponents([.year, .month], from: from, to: now)
+        let totalDays = utcCalendar.dateComponents([.day], from: from, to: now).day ?? 0
+        let years = comps.year ?? 0
+        let months = comps.month ?? 0
+        if years > 0 && months > 0 { return "\(years) yr\(plural(years)), \(months) mo" }
+        if years > 0               { return "\(years) yr\(plural(years))" }
+        if totalDays > 30          { return "\(totalDays / 30) mo" }
+        return "\(totalDays) day\(plural(totalDays))"
+    }
+
+    /// Whole years between a birthday and today, or nil if unset / not yet reached.
+    static func age(_ iso: String?) -> Int? {
+        guard let iso = iso, let born = dateOnly(iso) else { return nil }
+        let now = today()
+        if now < born { return nil }
+        return utcCalendar.dateComponents([.year], from: born, to: now).year
+    }
+
+    /// Time-elapsed progress through a bounded chapter as 0...1, or nil if ongoing.
+    static func progressFraction(start: String, end: String?) -> Double? {
+        guard let end = end, let s = dateOnly(start), let e = dateOnly(end) else { return nil }
+        let total = Double(utcCalendar.dateComponents([.day], from: s, to: e).day ?? 0)
+        if total <= 0 { return nil }
+        let elapsed = Double(utcCalendar.dateComponents([.day], from: s, to: today()).day ?? 0)
+        return min(max(elapsed / total, 0), 1)
+    }
+
+    static func formatDate(_ iso: String, precision: String) -> String {
+        guard let date = dateOnly(iso) else { return "" }
+        let formatter = DateFormatter()
+        formatter.timeZone = utc
+        formatter.locale = Locale.current
+        switch precision {
+        case "year":  formatter.dateFormat = "yyyy"
+        case "month": formatter.dateFormat = "MMMM yyyy"
+        default:      formatter.dateFormat = "MMMM d, yyyy"
+        }
+        return formatter.string(from: date)
+    }
+
+    static func weekday() -> String { formatToday("EEEE") }
+    static func todayLong() -> String { formatToday("MMMM d, yyyy") }
+
+    private static func formatToday(_ pattern: String) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = utc
+        formatter.locale = Locale.current
+        formatter.dateFormat = pattern
+        return formatter.string(from: today())
+    }
+
+    /// Next local midnight, used as the widget timeline's reload boundary so that
+    /// date-relative labels roll over even without an app-driven refresh.
+    static func nextLocalMidnight() -> Date {
+        let cal = Calendar.current
+        let startOfToday = cal.startOfDay(for: Date())
+        return cal.date(byAdding: .day, value: 1, to: startOfToday) ?? Date().addingTimeInterval(3600)
+    }
+
+    private static func plural(_ n: Int) -> String { n != 1 ? "s" : "" }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetProvider.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetProvider.swift
@@ -1,0 +1,27 @@
+import WidgetKit
+
+// A single timeline provider shared by all three widgets: each reads the same snapshot
+// from the App Group. The timeline holds one entry and reloads at the next local
+// midnight so date-relative labels roll over; the WidgetBridge plugin also calls
+// WidgetCenter.reloadAllTimelines() whenever the underlying data changes.
+
+struct SnapshotEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot?
+}
+
+struct SnapshotProvider: TimelineProvider {
+    func placeholder(in context: Context) -> SnapshotEntry {
+        SnapshotEntry(date: Date(), snapshot: WidgetStore.loadSnapshot())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SnapshotEntry) -> Void) {
+        completion(SnapshotEntry(date: Date(), snapshot: WidgetStore.loadSnapshot()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SnapshotEntry>) -> Void) {
+        let entry = SnapshotEntry(date: Date(), snapshot: WidgetStore.loadSnapshot())
+        let timeline = Timeline(entries: [entry], policy: .after(WidgetDate.nextLocalMidnight()))
+        completion(timeline)
+    }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetTheme.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetTheme.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+// Brand palette + helpers for the widget views, mirroring the web app's dark theme
+// tokens in src/index.css and the Android WidgetTheme.kt. Extension target only.
+
+extension Color {
+    // Parses "#RRGGBB" (or "RRGGBB"), falling back on anything invalid.
+    init(hex: String?, fallback: Color) {
+        guard var s = hex?.trimmingCharacters(in: .whitespaces), !s.isEmpty else {
+            self = fallback
+            return
+        }
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let v = UInt64(s, radix: 16) else {
+            self = fallback
+            return
+        }
+        self = Color(
+            red: Double((v >> 16) & 0xFF) / 255.0,
+            green: Double((v >> 8) & 0xFF) / 255.0,
+            blue: Double(v & 0xFF) / 255.0
+        )
+    }
+}
+
+enum Palette {
+    static let bg = Color(hex: "0F1117", fallback: .black)
+    static let text = Color(hex: "E8E0D0", fallback: .white)
+    static let amber = Color(hex: "C8A96E", fallback: .orange)
+    static let muted = Color(hex: "8A8270", fallback: .gray)
+    static let track = Color(hex: "2A2C38", fallback: .gray)
+}
+
+extension View {
+    // iOS 17 requires widget content to declare its background via containerBackground;
+    // earlier versions fall back to a plain background fill.
+    @ViewBuilder
+    func widgetBackground(_ color: Color) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            containerBackground(color, for: .widget)
+        } else {
+            background(color)
+        }
+    }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetViews.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetViews.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import WidgetKit
+
+// Deep-link URLs a widget tap opens the app with. AppDelegate parses these into a
+// pending target the web layer consumes on resume (mirrors the Android handoff).
+private func milestoneURL(_ id: String?) -> URL? {
+    if let id = id, let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+        return URL(string: "lifeglance://milestone?id=\(encoded)")
+    }
+    return URL(string: "lifeglance://open")
+}
+
+private func mono(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+    .system(size: size, weight: weight, design: .monospaced)
+}
+
+// A faint "label · value" context line used by the Today widget's larger size.
+private struct ContextLine: View {
+    let label: String
+    let value: String
+    var body: some View {
+        Text("\(label) · \(value)")
+            .font(mono(11))
+            .foregroundColor(Palette.muted)
+            .lineLimit(1)
+    }
+}
+
+// MARK: - Next milestone
+
+struct NextMilestoneView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    var body: some View {
+        let next = entry.snapshot?.next
+        VStack(alignment: .leading, spacing: 2) {
+            if let next = next {
+                Text("NEXT").font(mono(10, .bold)).foregroundColor(Palette.amber)
+                Text(WidgetDate.relativeLabel(next.date))
+                    .font(mono(20, .bold)).foregroundColor(Palette.text)
+                Text(next.title).font(mono(13)).foregroundColor(Palette.text).lineLimit(2)
+                Text(WidgetDate.formatDate(next.date, precision: next.datePrecision ?? "day"))
+                    .font(mono(11)).foregroundColor(Palette.muted)
+                if family != .systemSmall, let prev = entry.snapshot?.prev {
+                    Spacer().frame(height: 6)
+                    Text("last · \(prev.title) (\(WidgetDate.relativeLabel(prev.date)))")
+                        .font(mono(11)).foregroundColor(Palette.muted).lineLimit(1)
+                }
+            } else {
+                Text("No upcoming milestones").font(mono(13)).foregroundColor(Palette.muted)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(16)
+        .widgetURL(milestoneURL(next?.id))
+    }
+}
+
+// MARK: - Today
+
+struct TodayView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("TODAY").font(mono(10, .bold)).foregroundColor(Palette.amber)
+            Text(WidgetDate.weekday()).font(mono(20, .bold)).foregroundColor(Palette.text)
+            Text(WidgetDate.todayLong()).font(mono(12)).foregroundColor(Palette.muted)
+            if let age = WidgetDate.age(entry.snapshot?.birthday) {
+                Text("\(age) year\(age == 1 ? "" : "s") old")
+                    .font(mono(12)).foregroundColor(Palette.muted)
+            }
+            if family != .systemSmall {
+                Spacer().frame(height: 8)
+                if let next = entry.snapshot?.next {
+                    ContextLine(label: "next", value: "\(next.title) · \(WidgetDate.relativeLabel(next.date))")
+                }
+                if let prev = entry.snapshot?.prev {
+                    ContextLine(label: "last", value: "\(prev.title) · \(WidgetDate.relativeLabel(prev.date))")
+                }
+                if let chapter = entry.snapshot?.currentChapter {
+                    ContextLine(label: "chapter", value: chapter.title)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(16)
+        .widgetURL(URL(string: "lifeglance://open"))
+    }
+}
+
+// MARK: - Current chapter
+
+struct CurrentChapterView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let chapter = entry.snapshot?.currentChapter {
+                let accent = Color(hex: chapter.color, fallback: Palette.amber)
+                Text("CHAPTER").font(mono(10, .bold)).foregroundColor(accent)
+                Text(chapter.title).font(mono(17, .bold)).foregroundColor(Palette.text).lineLimit(2)
+                Text("\(WidgetDate.durationWords(chapter.start)) in")
+                    .font(mono(12)).foregroundColor(Palette.muted)
+                if (chapter.totalCount ?? 0) > 0 {
+                    Text("\(chapter.passedCount ?? 0)/\(chapter.totalCount ?? 0) milestones")
+                        .font(mono(11)).foregroundColor(Palette.muted)
+                }
+                // Bounded chapters get a time-elapsed bar; ongoing chapters show elapsed
+                // time only, since there's no end to measure against.
+                if let fraction = WidgetDate.progressFraction(start: chapter.start, end: chapter.end) {
+                    Spacer().frame(height: 8)
+                    ProgressView(value: fraction)
+                        .progressViewStyle(.linear)
+                        .tint(accent)
+                }
+            } else {
+                Text("No active chapter").font(mono(13)).foregroundColor(Palette.muted)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(16)
+        .widgetURL(URL(string: "lifeglance://open"))
+    }
+}


### PR DESCRIPTION
Expands the home-screen widget work across two commits on this branch.

## 1. Android — Today + Current Chapter widgets
Two new Jetpack Glance widgets, built on the existing data bridge with no snapshot/bridge schema change.
- **Today** (`TodayWidget.kt`) — weekday, date, age; larger size (branches on `LocalSize`) adds next/most-recent milestones and the current chapter name.
- **Current Chapter** (`CurrentChapterWidget.kt`) — chapter name, elapsed time "in" the chapter, milestones passed/total. **Bounded** chapters show a time-elapsed progress bar; **ongoing** chapters show elapsed time only.
- `WidgetData` extended (full `currentChapter` + `birthday` parsing, helpers, JSON-null hardening); new `refreshAll()` so the bridge plugin and midnight worker refresh **all** widgets together; shared `WidgetTheme.kt`; manifest receivers + provider XML + labels.

## 2. iOS — WidgetKit port of all three widgets
Ports Next Milestone, Today, and Current Chapter to WidgetKit + SwiftUI, reusing the same `widgetSnapshot.js` output (no JS changes). The web↔widget link uses an **App Group** (`group.com.lifeglance`) since the widget runs in a separate process; everything else mirrors Android.
- `ios/App/LifeGlanceWidgets/` — `WidgetModel.swift` (Codable snapshot, App Group `WidgetStore`, date/label helpers), theme, `SnapshotProvider` (midnight reload), three SwiftUI views, `@main` bundle, Info.plist, entitlements.
- `ios/App/App/` — `WidgetBridgePlugin.swift` (iOS `WidgetBridge`), `App.entitlements`, `AppDelegate` deep-link parse, `Info.plist` `lifeglance` URL scheme.
- The Widget Extension target + App Group can't be scripted without risking `project.pbxproj` → one-time Xcode steps in **`docs/IOS-WIDGETS.md`**.

## Bug fix (both platforms)
The `birthday` field is stored date-only (`YYYY-MM-DD`, from `<input type="date">`), which the full-ISO instant parsers rejected — so the Today widget's age line never rendered. Both platforms now parse the leading `yyyy-MM-dd` (the UTC date for a full ISO instant, and the whole value for a date-only field).

## Verification
- ✅ No web changes; `widgetSnapshot` schema and tests unchanged.
- ⚠️ Neither the Android (Maven blocked) nor the iOS (no Xcode) native code can be compiled in the Claude Code sandbox. Build locally: `npm run android`, and follow `docs/IOS-WIDGETS.md` for iOS.

> Note: the iOS port shares this branch with the Android commit, so it's bundled here. Happy to split iOS into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS