### PR TITLE
iOS widget Xcode wiring + follow-up widget fixes

### DIFF
--- a/android/app/src/main/java/com/lifeglance/app/widget/CurrentChapterWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/CurrentChapterWidget.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
+import androidx.glance.LocalSize
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
@@ -71,6 +72,10 @@ class CurrentChapterWidget : GlanceAppWidget() {
                 return@Column
             }
 
+            // The smallest size only has room for the headline; the milestone count and
+            // progress bar are shown once the widget is tall enough so they never clip.
+            val tall = LocalSize.current.height >= 110.dp
+
             val accent = WidgetTheme.parseColor(chapter.color)
             Text(
                 text = "CHAPTER",
@@ -79,7 +84,7 @@ class CurrentChapterWidget : GlanceAppWidget() {
             Spacer(GlanceModifier.height(4.dp))
             Text(
                 text = chapter.title,
-                maxLines = 2,
+                maxLines = if (tall) 2 else 1,
                 style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 18.sp, fontWeight = FontWeight.Bold),
             )
             Spacer(GlanceModifier.height(2.dp))
@@ -88,7 +93,7 @@ class CurrentChapterWidget : GlanceAppWidget() {
                 style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
             )
 
-            if (chapter.totalCount > 0) {
+            if (tall && chapter.totalCount > 0) {
                 Text(
                     text = "${chapter.passedCount}/${chapter.totalCount} milestones",
                     style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
@@ -96,9 +101,9 @@ class CurrentChapterWidget : GlanceAppWidget() {
             }
 
             // Bounded chapters get a time-elapsed progress bar; ongoing ones don't,
-            // since there's no end to measure against.
+            // since there's no end to measure against. Hidden at the smallest size.
             val fraction = WidgetData.progressFraction(chapter.start, chapter.end)
-            if (fraction != null) {
+            if (tall && fraction != null) {
                 Spacer(GlanceModifier.height(8.dp))
                 LinearProgressIndicator(
                     progress = fraction,

--- a/docs/IOS-WIDGETS.md
+++ b/docs/IOS-WIDGETS.md
@@ -41,6 +41,12 @@ App target (`ios/App/App/`):
 
 ## Xcode steps
 
+> **First, from the repo root:** `npm run build:ios`. This builds the web bundle and
+> runs `cap sync ios` to stage it (and Capacitor plugins) into the native project — a
+> prerequisite, not part of the Xcode build below. It does **not** compile the app or
+> touch the widget extension target, and is safe to re-run. Run it again whenever you
+> change **web** code; pure Swift/widget changes only need an Xcode rebuild.
+
 1. **Open** `ios/App/App.xcworkspace`.
 
 2. **App Group on the App target** — select the **App** target → *Signing &
@@ -101,3 +107,22 @@ steps — automatic signing provisions the App Group on the fly.
 - No JS changes: `src/native/widgetBridge.js` already calls the `WidgetBridge` plugin
   (the Swift `jsName` matches), and `src/utils/widgetSnapshot.js` is the single source
   of the snapshot for both platforms.
+
+## Registering the WidgetBridge plugin (required)
+
+Capacitor auto-discovers plugins that ship as packages, but **not** plugins defined
+inside the app — so `WidgetBridge` reports *"plugin is not implemented on ios"* until
+it's registered explicitly. `MainViewController.swift` does this via the documented
+`capacitorDidLoad()` hook:
+
+```swift
+class MainViewController: CAPBridgeViewController {
+    override func capacitorDidLoad() {
+        bridge?.registerPluginInstance(WidgetBridgePlugin())
+    }
+}
+```
+
+Add that file to the **App** target, then in **Main.storyboard** set the bridge view
+controller's **Custom Class** to `MainViewController` (Identity Inspector). Without
+this, snapshots never reach the App Group and every widget shows its empty state.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -3,10 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DA92D522FECBEF700F56B1C /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA92D512FECBEF700F56B1C /* WidgetKit.framework */; };
+		0DA92D542FECBEF700F56B1C /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA92D532FECBEF700F56B1C /* SwiftUI.framework */; };
+		0DA92D612FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0DA92D4F2FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0DA92D722FECC30800F56B1C /* WidgetBridgePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */; };
+		0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D752FECE9F200F56B1C /* MainViewController.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
@@ -17,7 +22,38 @@
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0DA92D5F2FECBEF700F56B1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 504EC2FC1FED79650016851F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0DA92D4E2FECBEF700F56B1C;
+			remoteInfo = LifeGlanceWidgetsExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0DA92D662FECBEF700F56B1C /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0DA92D612FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		0DA92D4A2FECBDC700F56B1C /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		0DA92D4F2FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeGlanceWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DA92D512FECBEF700F56B1C /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		0DA92D532FECBEF700F56B1C /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		0DA92D702FECC21B00F56B1C /* LifeGlanceWidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LifeGlanceWidgetsExtension.entitlements; sourceTree = "<group>"; };
+		0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBridgePlugin.swift; sourceTree = "<group>"; };
+		0DA92D752FECE9F200F56B1C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -30,7 +66,37 @@
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0DA92D622FECBEF700F56B1C /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 0DA92D4E2FECBEF700F56B1C /* LifeGlanceWidgetsExtension */;
+		};
+		0DA92D742FECC3C700F56B1C /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				WidgetModel.swift,
+			);
+			target = 504EC3031FED79650016851F /* App */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0DA92D552FECBEF700F56B1C /* LifeGlanceWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0DA92D742FECC3C700F56B1C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0DA92D622FECBEF700F56B1C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LifeGlanceWidgets; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		0DA92D4C2FECBEF700F56B1C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0DA92D542FECBEF700F56B1C /* SwiftUI.framework in Frameworks */,
+				0DA92D522FECBEF700F56B1C /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		504EC3011FED79650016851F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -42,11 +108,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DA92D502FECBEF700F56B1C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0DA92D512FECBEF700F56B1C /* WidgetKit.framework */,
+				0DA92D532FECBEF700F56B1C /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		504EC2FB1FED79650016851F = {
 			isa = PBXGroup;
 			children = (
+				0DA92D702FECC21B00F56B1C /* LifeGlanceWidgetsExtension.entitlements */,
 				958DCC722DB07C7200EA8C5F /* debug.xcconfig */,
 				504EC3061FED79650016851F /* App */,
+				0DA92D552FECBEF700F56B1C /* LifeGlanceWidgets */,
+				0DA92D502FECBEF700F56B1C /* Frameworks */,
 				504EC3051FED79650016851F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -55,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				504EC3041FED79650016851F /* App.app */,
+				0DA92D4F2FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -62,6 +141,9 @@
 		504EC3061FED79650016851F /* App */ = {
 			isa = PBXGroup;
 			children = (
+				0DA92D752FECE9F200F56B1C /* MainViewController.swift */,
+				0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */,
+				0DA92D4A2FECBDC700F56B1C /* App.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
@@ -77,6 +159,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0DA92D4E2FECBEF700F56B1C /* LifeGlanceWidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0DA92D632FECBEF700F56B1C /* Build configuration list for PBXNativeTarget "LifeGlanceWidgetsExtension" */;
+			buildPhases = (
+				0DA92D4B2FECBEF700F56B1C /* Sources */,
+				0DA92D4C2FECBEF700F56B1C /* Frameworks */,
+				0DA92D4D2FECBEF700F56B1C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0DA92D552FECBEF700F56B1C /* LifeGlanceWidgets */,
+			);
+			name = LifeGlanceWidgetsExtension;
+			packageProductDependencies = (
+			);
+			productName = LifeGlanceWidgetsExtension;
+			productReference = 0DA92D4F2FECBEF700F56B1C /* LifeGlanceWidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		504EC3031FED79650016851F /* App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 504EC3161FED79650016851F /* Build configuration list for PBXNativeTarget "App" */;
@@ -84,10 +188,12 @@
 				504EC3001FED79650016851F /* Sources */,
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
+				0DA92D662FECBEF700F56B1C /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0DA92D602FECBEF700F56B1C /* PBXTargetDependency */,
 			);
 			name = App;
 			packageProductDependencies = (
@@ -103,9 +209,12 @@
 		504EC2FC1FED79650016851F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 920;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 920;
 				TargetAttributes = {
+					0DA92D4E2FECBEF700F56B1C = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
@@ -130,11 +239,19 @@
 			projectRoot = "";
 			targets = (
 				504EC3031FED79650016851F /* App */,
+				0DA92D4E2FECBEF700F56B1C /* LifeGlanceWidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0DA92D4D2FECBEF700F56B1C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		504EC3021FED79650016851F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -151,15 +268,32 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0DA92D4B2FECBEF700F56B1C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		504EC3001FED79650016851F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				0DA92D722FECC30800F56B1C /* WidgetBridgePlugin.swift in Sources */,
+				0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0DA92D602FECBEF700F56B1C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0DA92D4E2FECBEF700F56B1C /* LifeGlanceWidgetsExtension */;
+			targetProxy = 0DA92D5F2FECBEF700F56B1C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		504EC30B1FED79650016851F /* Main.storyboard */ = {
@@ -181,6 +315,92 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0DA92D642FECBEF700F56B1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_ENTITLEMENTS = LifeGlanceWidgetsExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CTZ7352A3G;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LifeGlanceWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LifeGlanceWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0DA92D652FECBEF700F56B1C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_ENTITLEMENTS = LifeGlanceWidgetsExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CTZ7352A3G;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LifeGlanceWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LifeGlanceWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		504EC3141FED79650016851F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
@@ -295,9 +515,10 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CTZ7352A3G;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CTZ7352A3G;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -318,9 +539,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CTZ7352A3G;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = CTZ7352A3G;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -339,6 +561,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0DA92D632FECBEF700F56B1C /* Build configuration list for PBXNativeTarget "LifeGlanceWidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0DA92D642FECBEF700F56B1C /* Debug */,
+				0DA92D652FECBEF700F56B1C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "335a53dd6b0f8c63000f6cbddd5ebe7689b6cb917ef03191a386df2b31c7d9f8",
+  "pins" : [
+    {
+      "identity" : "capacitor-swift-pm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
+      "state" : {
+        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
+        "version" : "8.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14111" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
     </dependencies>
     <scenes>
-        <!--Bridge View Controller-->
+        <!--Main View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="138" y="133"/>
         </scene>
     </scenes>
 </document>

--- a/ios/App/App/MainViewController.swift
+++ b/ios/App/App/MainViewController.swift
@@ -1,0 +1,8 @@
+import UIKit
+import Capacitor
+
+class MainViewController: CAPBridgeViewController {
+    override func capacitorDidLoad() {
+        bridge?.registerPluginInstance(WidgetBridgePlugin())
+    }
+}

--- a/ios/App/LifeGlanceWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/App/LifeGlanceWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/App/LifeGlanceWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/App/LifeGlanceWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/App/LifeGlanceWidgets/Assets.xcassets/Contents.json
+++ b/ios/App/LifeGlanceWidgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/App/LifeGlanceWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ios/App/LifeGlanceWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -19,7 +19,7 @@ struct NextMilestoneWidget: Widget {
         }
         .configurationDisplayName("Next milestone")
         .description("Your next upcoming milestone, with a live countdown.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }
 
@@ -30,7 +30,7 @@ struct TodayWidget: Widget {
         }
         .configurationDisplayName("Today")
         .description("Today's date and your age, with recent and upcoming milestones at larger sizes.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }
 
@@ -41,6 +41,6 @@ struct CurrentChapterWidget: Widget {
         }
         .configurationDisplayName("Current chapter")
         .description("The chapter you're in now: how far along you are and milestones passed.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemMedium, .systemLarge])
     }
 }

--- a/ios/App/LifeGlanceWidgets/WidgetTheme.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetTheme.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WidgetKit
 
 // Brand palette + helpers for the widget views, mirroring the web app's dark theme
 // tokens in src/index.css and the Android WidgetTheme.kt. Extension target only.

--- a/ios/App/LifeGlanceWidgets/WidgetViews.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetViews.swift
@@ -42,7 +42,9 @@ struct NextMilestoneView: View {
                 Text(next.title).font(mono(13)).foregroundColor(Palette.text).lineLimit(2)
                 Text(WidgetDate.formatDate(next.date, precision: next.datePrecision ?? "day"))
                     .font(mono(11)).foregroundColor(Palette.muted)
-                if family != .systemSmall, let prev = entry.snapshot?.prev {
+                // Large is the only family with extra vertical room (medium is the
+                // same height as small, just wider), so the secondary line lives there.
+                if family == .systemLarge, let prev = entry.snapshot?.prev {
                     Spacer().frame(height: 6)
                     Text("last · \(prev.title) (\(WidgetDate.relativeLabel(prev.date)))")
                         .font(mono(11)).foregroundColor(Palette.muted).lineLimit(1)
@@ -51,7 +53,7 @@ struct NextMilestoneView: View {
                 Text("No upcoming milestones").font(mono(13)).foregroundColor(Palette.muted)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(16)
         .widgetURL(milestoneURL(next?.id))
     }
@@ -72,7 +74,9 @@ struct TodayView: View {
                 Text("\(age) year\(age == 1 ? "" : "s") old")
                     .font(mono(12)).foregroundColor(Palette.muted)
             }
-            if family != .systemSmall {
+            // Only large has the vertical room for the context block (medium is the
+            // same height as small, just wider).
+            if family == .systemLarge {
                 Spacer().frame(height: 8)
                 if let next = entry.snapshot?.next {
                     ContextLine(label: "next", value: "\(next.title) · \(WidgetDate.relativeLabel(next.date))")
@@ -85,7 +89,7 @@ struct TodayView: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(16)
         .widgetURL(URL(string: "lifeglance://open"))
     }
@@ -94,23 +98,28 @@ struct TodayView: View {
 // MARK: - Current chapter
 
 struct CurrentChapterView: View {
+    @Environment(\.widgetFamily) private var family
     let entry: SnapshotEntry
 
     var body: some View {
+        // Medium is the same height as small (just wider), so the milestone count and
+        // progress bar only fit on large.
+        let roomy = family == .systemLarge
         VStack(alignment: .leading, spacing: 2) {
             if let chapter = entry.snapshot?.currentChapter {
                 let accent = Color(hex: chapter.color, fallback: Palette.amber)
                 Text("CHAPTER").font(mono(10, .bold)).foregroundColor(accent)
-                Text(chapter.title).font(mono(17, .bold)).foregroundColor(Palette.text).lineLimit(2)
+                Text(chapter.title).font(mono(17, .bold)).foregroundColor(Palette.text)
+                    .lineLimit(roomy ? 2 : 1)
                 Text("\(WidgetDate.durationWords(chapter.start)) in")
                     .font(mono(12)).foregroundColor(Palette.muted)
-                if (chapter.totalCount ?? 0) > 0 {
+                if roomy, (chapter.totalCount ?? 0) > 0 {
                     Text("\(chapter.passedCount ?? 0)/\(chapter.totalCount ?? 0) milestones")
                         .font(mono(11)).foregroundColor(Palette.muted)
                 }
                 // Bounded chapters get a time-elapsed bar; ongoing chapters show elapsed
                 // time only, since there's no end to measure against.
-                if let fraction = WidgetDate.progressFraction(start: chapter.start, end: chapter.end) {
+                if roomy, let fraction = WidgetDate.progressFraction(start: chapter.start, end: chapter.end) {
                     Spacer().frame(height: 8)
                     ProgressView(value: fraction)
                         .progressViewStyle(.linear)
@@ -120,7 +129,7 @@ struct CurrentChapterView: View {
                 Text("No active chapter").font(mono(13)).foregroundColor(Palette.muted)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(16)
         .widgetURL(URL(string: "lifeglance://open"))
     }

--- a/ios/App/LifeGlanceWidgetsExtension.entitlements
+++ b/ios/App/LifeGlanceWidgetsExtension.entitlements
@@ -2,10 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lifeglance</string>
+	</array>
 </dict>
 </plist>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -154,9 +154,14 @@ export default function App() {
 
     const onHide = () => { if (document.visibilityState === 'hidden') flush() }
     document.addEventListener('visibilitychange', onHide)
+    // Settings that aren't part of milestones/chapters (e.g. birthday) dispatch this
+    // event so the widget snapshot re-pushes immediately rather than waiting for the
+    // next data change or app background.
+    window.addEventListener('lifeglance:widget-refresh', flush)
     return () => {
       clearTimeout(widgetTimerRef.current)
       document.removeEventListener('visibilitychange', onHide)
+      window.removeEventListener('lifeglance:widget-refresh', flush)
     }
   }, [milestones, chapters, screen])
 

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -1186,7 +1186,17 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     }
 
     const chapters = await listChapters()
-    const payload = { milestones, photos, chapters, categories: loadCategories() }
+    const payload = {
+      milestones,
+      photos,
+      chapters,
+      categories: loadCategories(),
+      categoriesUpdatedAt: localStorage.getItem('lifeglance-categories-updated-at') || '',
+      // Settings worth preserving across a restore (mirrors the cloud-sync payload
+      // in sync/adapter.js, which already carried these).
+      birthday: localStorage.getItem('lifeglance-birthday') || '',
+      birthdayUpdatedAt: localStorage.getItem('lifeglance-birthday-updated-at') || '',
+    }
     const json = JSON.stringify(payload, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url  = URL.createObjectURL(blob)
@@ -1287,10 +1297,24 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       const chapters = (!Array.isArray(parsed) && Array.isArray(parsed.chapters)) ? parsed.chapters : []
       const restoredCategories = (!Array.isArray(parsed) && Array.isArray(parsed.categories) && parsed.categories.length > 0)
         ? parsed.categories : null
+      const restoredBirthday = (!Array.isArray(parsed) && typeof parsed.birthday === 'string' && parsed.birthday)
+        ? parsed.birthday : null
 
       const restored = await restoreMilestones(items)
       await restoreChapters(chapters)
-      if (restoredCategories) saveCategories(restoredCategories)
+      if (restoredCategories) {
+        saveCategories(restoredCategories)
+        if (!Array.isArray(parsed) && parsed.categoriesUpdatedAt) {
+          localStorage.setItem('lifeglance-categories-updated-at', parsed.categoriesUpdatedAt)
+        }
+      }
+      if (restoredBirthday) {
+        localStorage.setItem('lifeglance-birthday', restoredBirthday)
+        localStorage.setItem('lifeglance-birthday-updated-at',
+          parsed.birthdayUpdatedAt || new Date().toISOString())
+        setBirthday(restoredBirthday)
+        window.dispatchEvent(new Event('lifeglance:widget-refresh'))
+      }
 
       // Re-import photo blobs into the media store
       for (const m of restored) {
@@ -1993,6 +2017,9 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
             setBirthday(v)
             localStorage.setItem('lifeglance-birthday', v)
             localStorage.setItem('lifeglance-birthday-updated-at', new Date().toISOString())
+            // Birthday isn't part of milestones/chapters, so nudge the widget snapshot
+            // to re-push (drives the Today widget's age line).
+            window.dispatchEvent(new Event('lifeglance:widget-refresh'))
           }}
           milestones={milestones}
           onExportImage={handleExportImage}


### PR DESCRIPTION
Consolidates the remaining home-screen widget work that wasn't in #179, in two commits:

## 1. iOS Xcode project wiring (`efed5f1`)
Captures the Xcode setup that previously lived only on the local machine, so the iOS widgets build from a fresh checkout without re-doing the manual steps:
- Widget extension target in `project.pbxproj`
- `MainViewController` set as the bridge view controller in `Main.storyboard` (registers the `WidgetBridge` plugin — without this the plugin reports "not implemented on ios")
- Widget `Info.plist`, entitlements, asset catalog, and `Package.resolved`

## 2. Follow-up code fixes (`a5c4aff`)
- **Current Chapter widget (Android):** hide the milestone count + progress bar at the smallest size so they don't clip; clamp the title to one line there.
- **iOS widgets → medium + large** (dropped small). Medium is the same height as small (just wider), so the rich content (age, context lines, milestone count, progress bar) is gated to large; medium shows a clean headline. Content top-aligned to fill large.
- **File backup parity:** include `birthday` / `birthdayUpdatedAt` and `categoriesUpdatedAt` (the cloud-sync payload already carried these). Fixes the Today widget's age disappearing after restoring from a backup. Restore applies them and refreshes the widget.
- Doc updates in `docs/IOS-WIDGETS.md` (build prerequisite, plugin registration step).

## Notes
- The native side couldn't be compiled in CI here (Maven/Xcode unavailable); verified working on-device during the session (all three iOS widgets live with real data).
- After this merges, the `claude/beautiful-darwin-bfnle3` and `claude/ios-xcode-setup` branches are redundant and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_