### PR TITLE
Localize WebDAV cloud-sync error messages (client-only)

### DIFF
--- a/src/locales/de/sync.json
+++ b/src/locales/de/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Falsche Synchronisierungs-Passphrase — sie muss exakt mit der auf deinen anderen Geräten verwendeten übereinstimmen.",
   "vaultSkippedToast": "{{count}} Element(e) konnten nicht gelesen werden — siehe Cloud-Sync-Einstellungen.",
   "vaultSkippedNote": "{{count}} Element(e) konnten auf diesem Gerät nicht gelesen werden und wurden übersprungen. Sie werden bei der nächsten Synchronisierung automatisch erneut versucht — meist liegt eine abweichende Sync-Passphrase vor.",
-  "verifierUnsupported": "Dein Sync-Server muss aktualisiert werden, um die Schlüsselverifizierung zu unterstützen."
+  "verifierUnsupported": "Dein Sync-Server muss aktualisiert werden, um die Schlüsselverifizierung zu unterstützen.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/en/sync.json
+++ b/src/locales/en/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Wrong sync passphrase — it must exactly match the passphrase used on your other devices.",
   "vaultSkippedToast": "{{count}} item(s) couldn't be read — check cloud sync settings.",
   "vaultSkippedNote": "{{count}} item(s) couldn't be read on this device and were skipped. They'll be retried automatically on the next sync — this usually means a sync passphrase mismatch.",
-  "verifierUnsupported": "Your sync server needs to be updated to support key verification."
+  "verifierUnsupported": "Your sync server needs to be updated to support key verification.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/es/sync.json
+++ b/src/locales/es/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Frase de contraseña de sincronización incorrecta — debe coincidir exactamente con la usada en tus otros dispositivos.",
   "vaultSkippedToast": "{{count}} elemento(s) no se pudieron leer — revisa los ajustes de sincronización en la nube.",
   "vaultSkippedNote": "{{count}} elemento(s) no se pudieron leer en este dispositivo y se omitieron. Se reintentarán automáticamente en la próxima sincronización — esto suele indicar una frase de contraseña de sincronización distinta.",
-  "verifierUnsupported": "Tu servidor de sincronización debe actualizarse para admitir la verificación de clave."
+  "verifierUnsupported": "Tu servidor de sincronización debe actualizarse para admitir la verificación de clave.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/fr/sync.json
+++ b/src/locales/fr/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Phrase secrète de synchronisation incorrecte — elle doit correspondre exactement à celle utilisée sur vos autres appareils.",
   "vaultSkippedToast": "{{count}} élément(s) illisible(s) — vérifiez les réglages de synchronisation cloud.",
   "vaultSkippedNote": "{{count}} élément(s) n'ont pas pu être lus sur cet appareil et ont été ignorés. Ils seront réessayés automatiquement lors de la prochaine synchronisation — cela indique généralement une phrase secrète de synchronisation différente.",
-  "verifierUnsupported": "Votre serveur de synchronisation doit être mis à jour pour prendre en charge la vérification de clé."
+  "verifierUnsupported": "Votre serveur de synchronisation doit être mis à jour pour prendre en charge la vérification de clé.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/it/sync.json
+++ b/src/locales/it/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Passphrase di sincronizzazione errata — deve corrispondere esattamente a quella usata sugli altri dispositivi.",
   "vaultSkippedToast": "{{count}} elemento/i non leggibili — controlla le impostazioni di sincronizzazione cloud.",
   "vaultSkippedNote": "{{count}} elemento/i non sono stati letti su questo dispositivo e sono stati ignorati. Verranno ritentati automaticamente alla prossima sincronizzazione — di solito indica una passphrase di sincronizzazione diversa.",
-  "verifierUnsupported": "Il tuo server di sincronizzazione deve essere aggiornato per supportare la verifica della chiave."
+  "verifierUnsupported": "Il tuo server di sincronizzazione deve essere aggiornato per supportare la verifica della chiave.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/pt/sync.json
+++ b/src/locales/pt/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "Frase-passe de sincronização incorreta — deve corresponder exatamente à usada nos seus outros dispositivos.",
   "vaultSkippedToast": "{{count}} item(ns) não puderam ser lidos — verifique as definições de sincronização na nuvem.",
   "vaultSkippedNote": "{{count}} item(ns) não puderam ser lidos neste dispositivo e foram ignorados. Serão repetidos automaticamente na próxima sincronização — normalmente indica uma frase-passe de sincronização diferente.",
-  "verifierUnsupported": "O seu servidor de sincronização precisa de ser atualizado para suportar a verificação de chave."
+  "verifierUnsupported": "O seu servidor de sincronização precisa de ser atualizado para suportar a verificação de chave.",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/zh_CN/sync.json
+++ b/src/locales/zh_CN/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "密码短语错误。请确认与其他设备一致。",
   "vaultSkippedToast": "有{{count}}个条目无法读取。请检查云端同步设置。",
   "vaultSkippedNote": "本设备上有{{count}}个条目无法读取并已跳过。下次同步时将自动重试，这通常表示密码短语不一致。",
-  "verifierUnsupported": "请更新您的同步服务器以支持密钥验证。"
+  "verifierUnsupported": "请更新您的同步服务器以支持密钥验证。",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/locales/zh_HK/sync.json
+++ b/src/locales/zh_HK/sync.json
@@ -53,5 +53,13 @@
   "wrongPassphrase": "密碼短語錯誤。請確認與其他裝置一致。",
   "vaultSkippedToast": "有{{count}}個項目無法讀取。請檢查雲端同步設定。",
   "vaultSkippedNote": "本裝置上有{{count}}個項目無法讀取並已略過。下次同步時將自動重試，這通常表示密碼短語不一致。",
-  "verifierUnsupported": "請更新您的同步伺服器以支援金鑰驗證。"
+  "verifierUnsupported": "請更新您的同步伺服器以支援金鑰驗證。",
+  "authFailed": "Authentication failed — check your username and password in sync settings.",
+  "forbidden": "Sync blocked (403) — your server may be blocking the request.",
+  "locked": "Sync is locked by another device — try again in a moment.",
+  "networkError": "Network error — check your connection and try again.",
+  "preconditionFailed": "Another device updated first — retrying.",
+  "passphraseRequired": "Enter your sync passphrase to continue.",
+  "appIdMismatch": "This sync data belongs to a different app.",
+  "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app."
 }

--- a/src/sync/status.js
+++ b/src/sync/status.js
@@ -6,14 +6,42 @@ export const isSyncing = (status) =>
 
 // Maps typed engine error codes (the 2nd arg of onError) to user-facing i18n
 // keys in the 'sync' namespace. Codes absent from this map fall back to the raw
-// engine message. These codes only fire on the GLANCEvault database transport;
-// the file-tier engine lifeGLANCE currently uses never emits them, so the
-// mapping is inert until the cutover but keeps the presentation layer ready.
+// engine message (which the engine already renders in English). The package
+// emits the code alongside the message, so localising is a client-only concern:
+// look the code up here, otherwise show the engine's message.
+//
+// WebDAV file-tier codes (emitted today, see classifyError in @glance-apps/sync):
+//   AUTH_FAILURE                — 401: bad username / password.
+//   FORBIDDEN                   — 403: the server refused the request.
+//   LOCKED                      — 423: another device holds the lock.
+//   NETWORK_ERROR               — connection failed / unclassified transport error.
+//   PRECONDITION_FAILED         — 412: another device wrote first; retried.
+//   PASSPHRASE_REQUIRED         — encryption is on but no passphrase is in session.
+//   APP_ID_MISMATCH             — the remote file belongs to a different app.
+//   SCHEMA_FORWARD_INCOMPATIBLE — the remote file is from a newer app version.
+//
+// GLANCEvault database-transport codes (inert until that cutover; lifeGLANCE is
+// WebDAV-only today, but the mapping keeps the presentation layer ready):
 //   KEY_MISMATCH         — wrong sync passphrase for this account's existing data.
 //   VERIFIER_UNSUPPORTED — the sync server is too old to host the key verifier.
+//
 // ACCOUNT_ID_REQUIRED is intentionally absent: it's a benign, retryable startup
 // race handled (suppressed) in the engine's onError, not surfaced as an error.
+//
+// Note: the "Test Connection" path is deliberately NOT covered here. The engine's
+// test()/connection-test returns { success, error } with no code, so its result
+// string can't be keyed; CloudSyncModal renders that raw English error as-is.
 export const SYNC_ERROR_I18N_KEYS = {
+  // WebDAV file-tier transport
+  AUTH_FAILURE: 'authFailed',
+  FORBIDDEN: 'forbidden',
+  LOCKED: 'locked',
+  NETWORK_ERROR: 'networkError',
+  PRECONDITION_FAILED: 'preconditionFailed',
+  PASSPHRASE_REQUIRED: 'passphraseRequired',
+  APP_ID_MISMATCH: 'appIdMismatch',
+  SCHEMA_FORWARD_INCOMPATIBLE: 'schemaForwardIncompatible',
+  // GLANCEvault database transport (inert until cutover)
   KEY_MISMATCH: 'wrongPassphrase',
   VERIFIER_UNSUPPORTED: 'verifierUnsupported',
 }

--- a/src/sync/status.test.js
+++ b/src/sync/status.test.js
@@ -41,9 +41,25 @@ describe('syncErrorText', () => {
       .toBe('t:verifierUnsupported')
   })
 
+  it('maps the WebDAV file-tier codes to their friendly keys', () => {
+    const cases = {
+      AUTH_FAILURE: 'authFailed',
+      FORBIDDEN: 'forbidden',
+      LOCKED: 'locked',
+      NETWORK_ERROR: 'networkError',
+      PRECONDITION_FAILED: 'preconditionFailed',
+      PASSPHRASE_REQUIRED: 'passphraseRequired',
+      APP_ID_MISMATCH: 'appIdMismatch',
+      SCHEMA_FORWARD_INCOMPATIBLE: 'schemaForwardIncompatible',
+    }
+    for (const [code, key] of Object.entries(cases)) {
+      expect(syncErrorText({ message: 'raw engine text', code }, t)).toBe(`t:${key}`)
+    }
+  })
+
   it('falls back to the raw engine message for unmapped codes', () => {
-    expect(syncErrorText({ message: 'Network down', code: 'NETWORK_ERROR' }, t))
-      .toBe('Network down')
+    expect(syncErrorText({ message: 'Something unexpected', code: 'SOME_UNKNOWN_CODE' }, t))
+      .toBe('Something unexpected')
     expect(syncErrorText({ message: 'Just a message', code: null }, t))
       .toBe('Just a message')
   })


### PR DESCRIPTION
**The package already emits the codes — this is client-only. No change to `@glance-apps/sync`.**

Mirrors the sibling-app change in dayGLANCE PR #1052, scoped down to lifeGLANCE's WebDAV-only sync (no iCloud, no GLANCEvault).

## Why it's client-only
I verified against the installed `@glance-apps/sync@1.5.2`. Its file-tier `classifyError` already passes a typed `code` to `onError` alongside the (English) message for every WebDAV failure:

| HTTP / cause | code | hard-stop |
|---|---|---|
| 401 | `AUTH_FAILURE` | no |
| 403 | `FORBIDDEN` | yes |
| 423 | `LOCKED` | no |
| 412 | `PRECONDITION_FAILED` | no |
| no passphrase in session | `PASSPHRASE_REQUIRED` | no |
| remote file is another app's | `APP_ID_MISMATCH` | yes |
| remote file is a newer schema | `SCHEMA_FORWARD_INCOMPATIBLE` | yes |
| anything else | `NETWORK_ERROR` | no |

`engine.js`'s `onError` already forwards `code` into `syncError`. The only gap was that `SYNC_ERROR_I18N_KEYS` didn't map these codes, so they fell back to the engine's raw English string. This PR fills that gap.

## Changes
- **`src/sync/status.js`** — map the eight WebDAV codes to friendly keys in the `sync` namespace. The existing `KEY_MISMATCH` / `VERIFIER_UNSUPPORTED` (GLANCEvault) mappings are retained. `syncErrorText()` is unchanged; all three consumers — the `CloudSyncModal` error banner, the `TimelineView` sync-dot tooltip, and the save-error path — already read this map, so they pick up localized text with no extra wiring.
- **Locales** — added the eight keys to every `sync.json`. Real English wording (reused verbatim from dayGLANCE PR #1052) in `en`; **English stubs in the secondary locales (fr/de/es/it/pt/zh_CN/zh_HK) awaiting native translation**, kept present so the locale files stay complete (this repo keeps full key parity per locale; `fallbackLng: 'en'` would cover them regardless).
- **Tests** — `status.test.js` now covers all eight code→key mappings, plus unmapped-code and null fallbacks (the old test asserted `NETWORK_ERROR` fell through to raw text; that's now a mapped code, so it was updated).

## Known exception (left in English by design)
The **Test Connection** path (`engine.test()`) returns `{ success, error }` with **no code**, so its result string can't be keyed. It stays as the raw English error rendered in `CloudSyncModal`. Documented in the helper's doc comment.

## Verification
- Full test suite: **95/95 pass**.
- `npm run lint`: **0 errors** (31 pre-existing advisory warnings, none from these files).
- `npm run build`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7tTJVJCX1B8gfZwCRrwJJ)_