### PR TITLE
On This Day midnight freshness + pinned countdown + quick-add widgets

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -93,6 +93,32 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/stats_widget_info" />
         </receiver>
+
+        <!-- Home-screen widget: quick add (launcher) -->
+        <receiver
+            android:name=".widget.QuickAddReceiver"
+            android:label="@string/widget_quick_add_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/quick_add_widget_info" />
+        </receiver>
+
+        <!-- Home-screen widget: pinned countdown -->
+        <receiver
+            android:name=".widget.PinnedCountdownReceiver"
+            android:label="@string/widget_pinned_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/pinned_countdown_widget_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -14,6 +14,8 @@ public class MainActivity extends BridgeActivity {
 
     // Extra carrying the milestone id a widget tap wants the app to focus.
     public static final String EXTRA_WIDGET_MILESTONE_ID = "widget_milestone_id";
+    // Extra carrying a widget action (e.g. "new" from the quick-add widget).
+    public static final String EXTRA_WIDGET_ACTION = "widget_action";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -35,12 +37,14 @@ public class MainActivity extends BridgeActivity {
     private void handleWidgetIntent(Intent intent) {
         if (intent == null) return;
         String milestoneId = intent.getStringExtra(EXTRA_WIDGET_MILESTONE_ID);
-        if (milestoneId == null) return;
-        getSharedPreferences(WidgetData.PREFS, MODE_PRIVATE)
-            .edit()
-            .putString(WidgetData.KEY_PENDING_TARGET, milestoneId)
-            .apply();
+        String action      = intent.getStringExtra(EXTRA_WIDGET_ACTION);
+        if (milestoneId == null && action == null) return;
+        var editor = getSharedPreferences(WidgetData.PREFS, MODE_PRIVATE).edit();
+        if (milestoneId != null) editor.putString(WidgetData.KEY_PENDING_TARGET, milestoneId);
+        if (action != null)      editor.putString(WidgetData.KEY_PENDING_ACTION, action);
+        editor.apply();
         intent.removeExtra(EXTRA_WIDGET_MILESTONE_ID);
+        intent.removeExtra(EXTRA_WIDGET_ACTION);
     }
 
     @Override

--- a/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
@@ -48,11 +48,16 @@ public class WidgetBridgePlugin extends Plugin {
         Context ctx = getContext();
         SharedPreferences prefs = ctx.getSharedPreferences(WidgetData.PREFS, Context.MODE_PRIVATE);
         String target = prefs.getString(WidgetData.KEY_PENDING_TARGET, null);
-        if (target != null) {
-            prefs.edit().remove(WidgetData.KEY_PENDING_TARGET).apply();
+        String action = prefs.getString(WidgetData.KEY_PENDING_ACTION, null);
+        if (target != null || action != null) {
+            prefs.edit()
+                .remove(WidgetData.KEY_PENDING_TARGET)
+                .remove(WidgetData.KEY_PENDING_ACTION)
+                .apply();
         }
         JSObject ret = new JSObject();
         ret.put("milestoneId", target); // null when nothing is pending
+        ret.put("action", action);
         call.resolve(ret);
     }
 }

--- a/android/app/src/main/java/com/lifeglance/app/widget/OnThisDayWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/OnThisDayWidget.kt
@@ -44,8 +44,12 @@ class OnThisDayWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val snapshot = WidgetData.readSnapshot(context)
+        // Filter the candidate pool to today's date here (render time), so the midnight
+        // refresh shows the correct day even if the app hasn't pushed a new snapshot.
+        val items = (snapshot?.onThisDay ?: emptyList())
+            .filter { WidgetData.isOnThisDay(it.date, it.datePrecision) }
         provideContent {
-            Content(context, snapshot?.onThisDay ?: emptyList())
+            Content(context, items)
         }
     }
 

--- a/android/app/src/main/java/com/lifeglance/app/widget/PinnedCountdownWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/PinnedCountdownWidget.kt
@@ -1,0 +1,108 @@
+package com.lifeglance.app.widget
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lifeglance.app.MainActivity
+
+private val PINNED_MILESTONE_KEY = ActionParameters.Key<String>(MainActivity.EXTRA_WIDGET_MILESTONE_ID)
+
+/**
+ * "Pinned countdown" widget: a live countdown to the milestone the user pinned in the
+ * app (stored as a single id; resolved into the snapshot as `pinned`).
+ */
+class PinnedCountdownWidget : GlanceAppWidget() {
+    override val sizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(160.dp, 80.dp),
+            DpSize(220.dp, 120.dp),
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val pinned = WidgetData.readSnapshot(context)?.pinned
+        provideContent {
+            Content(context, pinned)
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, pinned: WidgetData.Milestone?) {
+        val accent = WidgetTheme.parseColor(pinned?.color)
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(ColorProvider(WidgetTheme.BG))
+                .cornerRadius(16.dp)
+                .padding(16.dp)
+                .clickable(openAction(context, pinned?.id)),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (pinned == null) {
+                Text(
+                    text = "Pin a milestone in the app to track it here",
+                    maxLines = 3,
+                    style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
+                )
+                return@Column
+            }
+
+            Text(
+                text = "PINNED",
+                style = TextStyle(color = ColorProvider(accent), fontFamily = FontFamily.Monospace, fontSize = 10.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(4.dp))
+            Text(
+                text = WidgetData.relativeLabel(pinned.date),
+                style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 22.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.height(2.dp))
+            Text(
+                text = pinned.title,
+                maxLines = 2,
+                style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 14.sp),
+            )
+            Text(
+                text = WidgetData.formatDateForPrecision(pinned.date, pinned.datePrecision),
+                style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+            )
+        }
+    }
+
+    private fun openAction(context: Context, milestoneId: String?) =
+        actionStartActivity(
+            ComponentName(context, MainActivity::class.java),
+            if (milestoneId != null) actionParametersOf(PINNED_MILESTONE_KEY to milestoneId)
+            else actionParametersOf(),
+        )
+}
+
+class PinnedCountdownReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = PinnedCountdownWidget()
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/QuickAddWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/QuickAddWidget.kt
@@ -1,0 +1,71 @@
+package com.lifeglance.app.widget
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lifeglance.app.MainActivity
+
+// Glance delivers this ActionParameter to MainActivity as the EXTRA_WIDGET_ACTION extra.
+private val ACTION_KEY = ActionParameters.Key<String>(MainActivity.EXTRA_WIDGET_ACTION)
+
+/** A launcher widget that opens the app straight into the new-milestone sheet. */
+class QuickAddWidget : GlanceAppWidget() {
+    override val sizeMode = SizeMode.Single
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            Column(
+                modifier = GlanceModifier
+                    .fillMaxSize()
+                    .background(ColorProvider(WidgetTheme.BG))
+                    .cornerRadius(16.dp)
+                    .padding(8.dp)
+                    .clickable(
+                        actionStartActivity(
+                            ComponentName(context, MainActivity::class.java),
+                            actionParametersOf(ACTION_KEY to "new"),
+                        )
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "+",
+                    style = TextStyle(color = ColorProvider(WidgetTheme.AMBER), fontFamily = FontFamily.Monospace, fontSize = 34.sp, fontWeight = FontWeight.Bold),
+                )
+                Text(
+                    text = "new milestone",
+                    maxLines = 1,
+                    style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
+                )
+            }
+        }
+    }
+}
+
+class QuickAddReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = QuickAddWidget()
+}

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -22,6 +22,7 @@ object WidgetData {
     const val PREFS = "lifeglance_widget"
     const val KEY_SNAPSHOT = "snapshot"
     const val KEY_PENDING_TARGET = "pending_target"
+    const val KEY_PENDING_ACTION = "pending_action"
 
     fun prefs(context: Context) =
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -55,6 +56,7 @@ object WidgetData {
         val currentChapter: Chapter?,
         val birthday: String?,
         val onThisDay: List<Milestone>,
+        val pinned: Milestone?,
         val pastCount: Int,
         val futureCount: Int,
         val totalCount: Int,
@@ -72,6 +74,7 @@ object WidgetData {
                 currentChapter = parseChapter(obj.optJSONObject("currentChapter")),
                 birthday = obj.stringOrNull("birthday"),
                 onThisDay = parseMilestoneArray(obj.optJSONArray("onThisDay")),
+                pinned = parseMilestone(obj.optJSONObject("pinned")),
                 pastCount = counts?.optInt("past", 0) ?: 0,
                 futureCount = counts?.optInt("future", 0) ?: 0,
                 totalCount = counts?.optInt("total", 0) ?: 0,
@@ -134,6 +137,17 @@ object WidgetData {
     fun yearsAgo(iso: String, today: LocalDate = LocalDate.now()): Int {
         val date = localDateOf(iso) ?: return 0
         return (today.year - date.year).coerceAtLeast(0)
+    }
+
+    /**
+     * True when a milestone shares today's month (and day, for day-precision). The On
+     * This Day widget applies this at render time so the midnight refresh shows the new
+     * day's matches without the app re-pushing the snapshot.
+     */
+    fun isOnThisDay(iso: String, precision: String, today: LocalDate = LocalDate.now()): Boolean {
+        val date = localDateOf(iso) ?: return false
+        if (date.monthValue != today.monthValue) return false
+        return precision == "month" || date.dayOfMonth == today.dayOfMonth
     }
 
     /** Mirrors the web app's relativeLabel(): "in 3 days", "2 yrs, 1 mo ago", "today". */
@@ -230,6 +244,7 @@ object WidgetData {
             CurrentChapterReceiver::class.java,
             OnThisDayReceiver::class.java,
             StatsReceiver::class.java,
+            PinnedCountdownReceiver::class.java,
         )
         val mgr = AppWidgetManager.getInstance(context)
         for (cls in receivers) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -19,4 +19,10 @@
 
     <string name="widget_stats_label">Milestones</string>
     <string name="widget_stats_description">Your milestone totals: past, ahead, this year, and your age.</string>
+
+    <string name="widget_quick_add_label">Add milestone</string>
+    <string name="widget_quick_add_description">A one-tap shortcut to add a new milestone.</string>
+
+    <string name="widget_pinned_label">Pinned countdown</string>
+    <string name="widget_pinned_description">A countdown to a milestone you\'ve pinned in the app.</string>
 </resources>

--- a/android/app/src/main/res/xml/pinned_countdown_widget_info.xml
+++ b/android/app/src/main/res/xml/pinned_countdown_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="160dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_pinned_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewLayout="@layout/glance_default_loading_layout" />

--- a/android/app/src/main/res/xml/quick_add_widget_info.xml
+++ b/android/app/src/main/res/xml/quick_add_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="80dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="1"
+    android:targetCellHeight="1"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_quick_add_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewLayout="@layout/glance_default_loading_layout" />

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -143,9 +143,19 @@ just a pull + rebuild.
   with "N years ago · date". Shows more rows as the widget grows.
 - **Milestones (stats)** — total with a past/ahead split, plus this-year count and age
   at the larger size.
-- Snapshot gained `onThisDay: Milestone[]` and `counts.thisYear`. `onThisDay` is computed
-  at build time, so it's as fresh as the last snapshot push (fine for a timeline app
-  opened regularly; a follow-up could move the filter to render time for staleness-proofing).
+- Snapshot gained `onThisDay` and `counts.thisYear`. `onThisDay` is the **candidate pool**
+  (all past, non-year milestones); each widget filters it to today's month/day at **render
+  time**, so the midnight refresh shows the new day without the app re-pushing.
+
+### ✅ Phase 6 — Pinned countdown + Quick add
+Both platforms, no new native targets.
+- **Pinned countdown** — a countdown to a milestone the user pins **in the app** (a 📌
+  toggle in the milestone detail stores `lifeglance-pinned-milestone-id`; the snapshot
+  resolves it to `pinned`). This deliberately avoids per-widget configuration (Android
+  config Activity / iOS AppIntent) — a single app-side pin is simpler and cross-platform.
+- **Quick add** — a launcher widget that opens the app straight into the new-milestone
+  sheet. Reuses the launch-target handoff, extended to carry an `action` ("new") alongside
+  the existing `milestoneId` (Android intent extra `widget_action`; iOS `lifeglance://new`).
 
 ---
 
@@ -155,10 +165,9 @@ just a pull + rebuild.
 - **Mini-timeline strip** — a rendered slice of the timeline around today. Highest
   "wow," hardest (native canvas or a cached bitmap from the web app). Deferred by
   decision.
-- **Pinned countdown** — user picks one milestone via a config Activity (Android) /
-  AppIntent configuration (iOS).
-- **Quick-add button** — launcher deep-linking into "New milestone" (`N`); needs a small
-  app-side action handler beyond the current milestone-id launch target.
+- **Per-widget configurable pin** — if a single global pin proves limiting, add real
+  configurable widgets (Android config Activity / iOS AppIntent) so each placed widget
+  can target a different milestone.
 
 ---
 

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -44,11 +44,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func handleWidgetDeepLink(_ url: URL) {
-        guard url.scheme == "lifeglance", url.host == "milestone",
-              let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let id = comps.queryItems?.first(where: { $0.name == "id" })?.value
-        else { return }
-        UserDefaults(suiteName: "group.com.lifeglance")?.set(id, forKey: "pending_target")
+        guard url.scheme == "lifeglance" else { return }
+        let defaults = UserDefaults(suiteName: "group.com.lifeglance")
+        switch url.host {
+        case "milestone":
+            if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let id = comps.queryItems?.first(where: { $0.name == "id" })?.value {
+                defaults?.set(id, forKey: "pending_target")
+            }
+        case "new":
+            defaults?.set("new", forKey: "pending_action")
+        default:
+            break
+        }
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/ios/App/App/WidgetBridgePlugin.swift
+++ b/ios/App/App/WidgetBridgePlugin.swift
@@ -28,11 +28,14 @@ public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve()
     }
 
-    // Returns and clears a pending deep-link target left by a widget tap.
+    // Returns and clears a pending deep-link target / action left by a widget tap.
     @objc func consumeLaunchTarget(_ call: CAPPluginCall) {
         var result = JSObject()
         if let target = WidgetStore.consumePendingTarget() {
             result["milestoneId"] = target
+        }
+        if let action = WidgetStore.consumePendingAction() {
+            result["action"] = action
         }
         call.resolve(result)
     }

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -11,6 +11,8 @@ struct LifeGlanceWidgetsBundle: WidgetBundle {
         CurrentChapterWidget()
         OnThisDayWidget()
         StatsWidget()
+        QuickAddWidget()
+        PinnedCountdownWidget()
     }
 }
 
@@ -66,5 +68,27 @@ struct StatsWidget: Widget {
         .configurationDisplayName("Milestones")
         .description("Your milestone totals: past, ahead, this year, and your age.")
         .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}
+
+struct QuickAddWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "QuickAddWidget", provider: SnapshotProvider()) { _ in
+            QuickAddView().widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Add milestone")
+        .description("A one-tap shortcut to add a new milestone.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+struct PinnedCountdownWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "PinnedCountdownWidget", provider: SnapshotProvider()) { entry in
+            PinnedCountdownView(entry: entry).widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Pinned countdown")
+        .description("A countdown to a milestone you've pinned in the app.")
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -16,6 +16,7 @@ enum WidgetStore {
     static let appGroupId = "group.com.lifeglance"
     static let keySnapshot = "snapshot"
     static let keyPendingTarget = "pending_target"
+    static let keyPendingAction = "pending_action"
 
     private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroupId) }
 
@@ -39,6 +40,13 @@ enum WidgetStore {
         defaults?.removeObject(forKey: keyPendingTarget)
         return target
     }
+
+    // Returns and clears a pending widget action (e.g. "new" from quick-add).
+    static func consumePendingAction() -> String? {
+        guard let action = defaults?.string(forKey: keyPendingAction) else { return nil }
+        defaults?.removeObject(forKey: keyPendingAction)
+        return action
+    }
 }
 
 // MARK: - Snapshot model (decodes the JSON the web app pushes)
@@ -50,6 +58,7 @@ struct WidgetSnapshot: Codable {
     let prev: WidgetMilestone?
     let currentChapter: WidgetChapter?
     let onThisDay: [WidgetMilestone]?
+    let pinned: WidgetMilestone?
     let counts: Counts?
 
     struct Counts: Codable {
@@ -167,6 +176,15 @@ enum WidgetDate {
         let then = utcCalendar.component(.year, from: date)
         let nowYear = utcCalendar.component(.year, from: today())
         return max(nowYear - then, 0)
+    }
+
+    /// True when a milestone shares today's month (and day, for day-precision). Applied
+    /// at render time so the midnight timeline refresh shows the new day's matches.
+    static func isOnThisDay(_ iso: String, precision: String) -> Bool {
+        guard let date = dateOnly(iso) else { return false }
+        let t = today()
+        if utcCalendar.component(.month, from: date) != utcCalendar.component(.month, from: t) { return false }
+        return precision == "month" || utcCalendar.component(.day, from: date) == utcCalendar.component(.day, from: t)
     }
 
     /// Time-elapsed progress through a bounded chapter as 0...1, or nil if ongoing.

--- a/ios/App/LifeGlanceWidgets/WidgetViews.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetViews.swift
@@ -148,7 +148,10 @@ struct OnThisDayView: View {
     }
 
     var body: some View {
-        let items = entry.snapshot?.onThisDay ?? []
+        // Filter the candidate pool to today's date here (render time) so the midnight
+        // timeline refresh shows the right day without the app re-pushing.
+        let items = (entry.snapshot?.onThisDay ?? [])
+            .filter { WidgetDate.isOnThisDay($0.date, precision: $0.datePrecision ?? "day") }
         let maxRows = family == .systemLarge ? 5 : 2
         VStack(alignment: .leading, spacing: 4) {
             Text("ON THIS DAY").font(mono(10, .bold)).foregroundColor(Palette.amber)
@@ -170,6 +173,46 @@ struct OnThisDayView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(16)
         .widgetURL(URL(string: "lifeglance://open"))
+    }
+}
+
+// MARK: - Pinned countdown
+
+struct PinnedCountdownView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        let pinned = entry.snapshot?.pinned
+        VStack(alignment: .leading, spacing: 2) {
+            if let pinned = pinned {
+                let accent = Color(hex: pinned.color, fallback: Palette.amber)
+                Text("PINNED").font(mono(10, .bold)).foregroundColor(accent)
+                Text(WidgetDate.relativeLabel(pinned.date))
+                    .font(mono(22, .bold)).foregroundColor(Palette.text)
+                Text(pinned.title).font(mono(14)).foregroundColor(Palette.text).lineLimit(2)
+                Text(WidgetDate.formatDate(pinned.date, precision: pinned.datePrecision ?? "day"))
+                    .font(mono(11)).foregroundColor(Palette.muted)
+            } else {
+                Text("Pin a milestone in the app to track it here")
+                    .font(mono(12)).foregroundColor(Palette.muted).lineLimit(3)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(16)
+        .widgetURL(milestoneURL(pinned?.id))
+    }
+}
+
+// MARK: - Quick add
+
+struct QuickAddView: View {
+    var body: some View {
+        VStack(spacing: 2) {
+            Text("+").font(mono(38, .bold)).foregroundColor(Palette.amber)
+            Text("new milestone").font(mono(11)).foregroundColor(Palette.muted).lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .widgetURL(URL(string: "lifeglance://new"))
     }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -144,8 +144,9 @@ export default function App() {
 
     const flush = () => {
       const birthday = localStorage.getItem('lifeglance-birthday') || null
+      const pinnedId = localStorage.getItem('lifeglance-pinned-milestone-id') || null
       pushWidgetSnapshot(
-        buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday)
+        buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday, new Date(), pinnedId)
       )
     }
 

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Capacitor } from '@capacitor/core'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
+
+const PINNED_KEY = 'lifeglance-pinned-milestone-id'
 
 export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday, categories = [] }) {
   const { t, i18n } = useTranslation('milestone')
@@ -9,6 +12,17 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
   const [audioUrl,  setAudioUrl]  = useState(null)
   const [photoUrl,  setPhotoUrl]  = useState(null)
   const [confirm,   setConfirm]   = useState(null)
+  const [pinned,    setPinned]    = useState(() => localStorage.getItem(PINNED_KEY) === m.id)
+
+  // The pinned-countdown widget reads a single pinned milestone id. Toggling here
+  // updates it and nudges the widget snapshot to re-push. Native shells only.
+  const canPin = Capacitor.isNativePlatform()
+  function togglePin() {
+    if (pinned) localStorage.removeItem(PINNED_KEY)
+    else        localStorage.setItem(PINNED_KEY, m.id)
+    setPinned(!pinned)
+    window.dispatchEvent(new Event('lifeglance:widget-refresh'))
+  }
 
   useEffect(() => {
     const handler = (e) => { if (e.key === 'Escape') onClose() }
@@ -169,6 +183,13 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
               )}
             </div>
             <div className="sheet-actions-right">
+              {canPin && (
+                <button className="btn-ghost" onClick={togglePin}
+                  title={pinned ? 'Unpin from widget' : 'Pin to countdown widget'}
+                  style={{ color: pinned ? 'var(--amber)' : undefined }}>
+                  {pinned ? '📌 Pinned' : '📌 Pin'}
+                </button>
+              )}
               <button className="btn" onClick={() => { onClose(); onEdit(m) }}
                 style={{ fontSize: '0.8rem', padding: '0.45rem 0.9rem' }}>
                 {tc('edit')}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -481,6 +481,11 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     const handleTarget = async () => {
       const target = await consumeWidgetLaunchTarget()
       if (!target) return
+      if (target.action === 'new') {   // quick-add widget
+        setEditTarget(null)
+        setAddOpen(true)
+        return
+      }
       const m = milestonesRef.current.find(x => x.id === target.milestoneId)
       if (!m) return
       setSelectedId(m.id)

--- a/src/native/widgetBridge.js
+++ b/src/native/widgetBridge.js
@@ -23,12 +23,16 @@ export async function pushWidgetSnapshot(snapshot) {
 }
 
 // Returns a pending deep-link target a widget tap left behind, or null. The native
-// side clears it once read, so this is safe to call on every resume.
+// side clears it once read, so this is safe to call on every resume. A target is
+// either an action (e.g. { action: 'new' } from the quick-add widget) or a milestone
+// to focus ({ milestoneId }).
 export async function consumeWidgetLaunchTarget() {
   if (!isNative()) return null
   try {
     const res = await WidgetBridge.consumeLaunchTarget()
-    return res?.milestoneId ? { milestoneId: res.milestoneId } : null
+    if (res?.action) return { action: res.action }
+    if (res?.milestoneId) return { milestoneId: res.milestoneId }
+    return null
   } catch (err) {
     console.warn('[widgetBridge] consumeLaunchTarget failed:', err)
     return null

--- a/src/utils/widgetSnapshot.js
+++ b/src/utils/widgetSnapshot.js
@@ -48,7 +48,7 @@ function pickCurrentChapter(chapters, nowMs) {
   return best
 }
 
-export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = null, now = new Date()) {
+export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = null, now = new Date(), pinnedId = null) {
   const nowMs = now.getTime()
 
   // Keep only milestones that are visible on the main timeline.
@@ -95,25 +95,22 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
     }
   }
 
-  // "On this day": past milestones sharing today's month (and day, for day-precision),
-  // mirroring the OnThisDayModal filter. Most recent first. Computed at build time, so
-  // it's as fresh as the last snapshot push (the app pushes on foreground/background).
-  const todayMonth = now.getMonth() + 1
-  const todayDay   = now.getDate()
+  // Candidate pool for the "On This Day" widget: every past, dated (non-year-precision)
+  // milestone, most-recent first. The widget filters this down to today's month/day at
+  // RENDER time, so it stays correct across midnight (when the widget re-renders) without
+  // the app having to re-push the snapshot.
   const onThisDay = visible
-    .filter(m => {
-      const d = new Date(m.date)
-      if (d >= now) return false
-      if (m.date_precision === 'year') return false
-      if (d.getMonth() + 1 !== todayMonth) return false
-      return m.date_precision === 'month' || d.getDate() === todayDay
-    })
+    .filter(m => m.date_precision !== 'year' && new Date(m.date) < now)
     .sort((a, b) => new Date(b.date) - new Date(a.date))
     .map(projectMilestone)
 
   // Milestones dated within the current calendar year (for the stats widget).
   const thisYear = now.getFullYear()
   const thisYearCount = visible.filter(m => new Date(m.date).getFullYear() === thisYear).length
+
+  // The milestone the user pinned in the app (by id), for the pinned-countdown widget.
+  // Resolved from all milestones (an explicit pin shows regardless of timeline visibility).
+  const pinned = pinnedId ? (milestones.find(m => m.id === pinnedId) ?? null) : null
 
   return {
     version:        WIDGET_SNAPSHOT_VERSION,
@@ -123,6 +120,7 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
     prev:           projectMilestone(prev),
     currentChapter,
     onThisDay,
+    pinned:         projectMilestone(pinned),
     counts:         { past, future, total: past + future, thisYear: thisYearCount },
   }
 }

--- a/src/utils/widgetSnapshot.test.js
+++ b/src/utils/widgetSnapshot.test.js
@@ -111,17 +111,28 @@ describe('buildWidgetSnapshot', () => {
     expect(buildWidgetSnapshot([], [], '', NOW).birthday).toBeNull()
   })
 
-  it('collects on-this-day milestones (past, same month/day, not year-precision)', () => {
+  it('builds the on-this-day pool: past, dated (non-year) milestones, most recent first', () => {
+    // The pool is NOT filtered to today's date — the widget does that at render time so it
+    // stays fresh across midnight. So all past, non-year milestones are included here.
     const milestones = [
-      ms({ id: 'match-day',   title: 'Wedding', date: '2018-06-20T12:00:00Z' }),                         // same month+day, past → in
-      ms({ id: 'match-month', title: 'Move',    date: '2019-06-05T12:00:00Z', date_precision: 'month' }), // same month, month-precision → in
-      ms({ id: 'diff-day',    title: 'Other',   date: '2018-06-21T12:00:00Z' }),                         // same month, different day → out
-      ms({ id: 'year-prec',   title: 'Born',    date: '2000-06-20T12:00:00Z', date_precision: 'year' }),  // year-precision → out
-      ms({ id: 'future',      title: 'Future',  date: '2030-06-20T12:00:00Z' }),                         // future → out
+      ms({ id: 'older', title: 'Wedding', date: '2018-06-20T12:00:00Z' }),
+      ms({ id: 'newer', title: 'Move',    date: '2019-06-05T12:00:00Z', date_precision: 'month' }),
+      ms({ id: 'mid',   title: 'Other',   date: '2018-12-21T12:00:00Z' }),
+      ms({ id: 'year',  title: 'Born',    date: '2000-06-20T12:00:00Z', date_precision: 'year' }), // year-precision → out
+      ms({ id: 'fut',   title: 'Future',  date: '2030-06-20T12:00:00Z' }),                         // future → out
     ]
     const snap = buildWidgetSnapshot(milestones, [], null, NOW)
-    // Sorted most-recent first: 2019 (match-month) before 2018 (match-day).
-    expect(snap.onThisDay.map(m => m.id)).toEqual(['match-month', 'match-day'])
+    expect(snap.onThisDay.map(m => m.id)).toEqual(['newer', 'mid', 'older']) // desc by date
+  })
+
+  it('resolves the pinned milestone by id (or null)', () => {
+    const milestones = [
+      ms({ id: 'a', title: 'A', date: '2027-01-01T12:00:00Z' }),
+      ms({ id: 'b', title: 'B', date: '2028-01-01T12:00:00Z' }),
+    ]
+    expect(buildWidgetSnapshot(milestones, [], null, NOW, 'b').pinned?.id).toBe('b')
+    expect(buildWidgetSnapshot(milestones, [], null, NOW, 'missing').pinned).toBeNull()
+    expect(buildWidgetSnapshot(milestones, [], null, NOW).pinned).toBeNull()
   })
 
   it('counts milestones in the current calendar year', () => {


### PR DESCRIPTION
On This Day: store the candidate pool (all past, non-year milestones) in the snapshot and filter to today's month/day at RENDER time on both platforms, so the midnight refresh shows the correct day without the app re-pushing.

Pinned countdown widget (both platforms): a countdown to a milestone the user pins in the app. A 📌 toggle in the milestone detail stores a single id; the snapshot resolves it to `pinned`. Avoids per-widget configuration (config Activity / AppIntent) in favour of one app-side pin.

Quick add widget (both platforms): a launcher that opens straight into the new-milestone sheet. The launch-target handoff now carries an `action` ("new") alongside milestoneId — Android via the widget_action intent extra, iOS via a lifeglance://new deep link; TimelineView opens the add sheet on action 'new'.

Snapshot gains `pinned` and a 5th `pinnedId` arg; tests updated. New Glance widgets + receivers + manifest entries + provider XML + strings; new iOS Widget/View structs in the existing extension files (no new targets).


Claude-Session: https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS