### PR TITLE
Color-slot pinned countdowns + iOS timeline-strip widget

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -107,10 +107,43 @@
                 android:resource="@xml/quick_add_widget_info" />
         </receiver>
 
-        <!-- Home-screen widget: pinned countdown -->
+        <!-- Home-screen widgets: pinned color-slot countdowns (one per slot) -->
         <receiver
-            android:name=".widget.PinnedCountdownReceiver"
-            android:label="@string/widget_pinned_label"
+            android:name=".widget.AmberCountdownReceiver"
+            android:label="@string/widget_pin_amber_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/pinned_countdown_widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.RoseCountdownReceiver"
+            android:label="@string/widget_pin_rose_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/pinned_countdown_widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.TealCountdownReceiver"
+            android:label="@string/widget_pin_teal_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/pinned_countdown_widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.BlueCountdownReceiver"
+            android:label="@string/widget_pin_blue_label"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/android/app/src/main/java/com/lifeglance/app/widget/SlotCountdownWidget.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/SlotCountdownWidget.kt
@@ -3,6 +3,7 @@ package com.lifeglance.app.widget
 import android.content.ComponentName
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,13 +32,15 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.lifeglance.app.MainActivity
 
-private val PINNED_MILESTONE_KEY = ActionParameters.Key<String>(MainActivity.EXTRA_WIDGET_MILESTONE_ID)
+private val SLOT_MILESTONE_KEY = ActionParameters.Key<String>(MainActivity.EXTRA_WIDGET_MILESTONE_ID)
 
 /**
- * "Pinned countdown" widget: a live countdown to the milestone the user pinned in the
- * app (stored as a single id; resolved into the snapshot as `pinned`).
+ * A countdown to the milestone pinned to one color slot. Each slot ("amber", "rose",
+ * "teal", "blue") has its own dedicated widget (the receivers below), so several pinned
+ * countdowns can live on the home screen without per-widget configuration. The slot's
+ * color is the binding — it's the accent and identifies which pin the widget tracks.
  */
-class PinnedCountdownWidget : GlanceAppWidget() {
+class SlotCountdownWidget(private val slot: String, private val accentArgb: Long) : GlanceAppWidget() {
     override val sizeMode = SizeMode.Responsive(
         setOf(
             DpSize(160.dp, 80.dp),
@@ -46,27 +49,27 @@ class PinnedCountdownWidget : GlanceAppWidget() {
     )
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val pinned = WidgetData.readSnapshot(context)?.pinned
+        val milestone = WidgetData.readSnapshot(context)?.pins?.get(slot)
         provideContent {
-            Content(context, pinned)
+            Content(context, milestone)
         }
     }
 
     @Composable
-    private fun Content(context: Context, pinned: WidgetData.Milestone?) {
-        val accent = WidgetTheme.parseColor(pinned?.color)
+    private fun Content(context: Context, milestone: WidgetData.Milestone?) {
+        val accent = Color(accentArgb)
         Column(
             modifier = GlanceModifier
                 .fillMaxSize()
                 .background(ColorProvider(WidgetTheme.BG))
                 .cornerRadius(16.dp)
                 .padding(16.dp)
-                .clickable(openAction(context, pinned?.id)),
+                .clickable(openAction(context, milestone?.id)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (pinned == null) {
+            if (milestone == null) {
                 Text(
-                    text = "Pin a milestone in the app to track it here",
+                    text = "Pin a milestone to the $slot slot in the app",
                     maxLines = 3,
                     style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
                 )
@@ -79,17 +82,17 @@ class PinnedCountdownWidget : GlanceAppWidget() {
             )
             Spacer(GlanceModifier.height(4.dp))
             Text(
-                text = WidgetData.relativeLabel(pinned.date),
+                text = WidgetData.relativeLabel(milestone.date),
                 style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 22.sp, fontWeight = FontWeight.Bold),
             )
             Spacer(GlanceModifier.height(2.dp))
             Text(
-                text = pinned.title,
+                text = milestone.title,
                 maxLines = 2,
                 style = TextStyle(color = ColorProvider(WidgetTheme.TEXT), fontFamily = FontFamily.Monospace, fontSize = 14.sp),
             )
             Text(
-                text = WidgetData.formatDateForPrecision(pinned.date, pinned.datePrecision),
+                text = WidgetData.formatDateForPrecision(milestone.date, milestone.datePrecision),
                 style = TextStyle(color = ColorProvider(WidgetTheme.MUTED), fontFamily = FontFamily.Monospace, fontSize = 11.sp),
             )
         }
@@ -98,11 +101,23 @@ class PinnedCountdownWidget : GlanceAppWidget() {
     private fun openAction(context: Context, milestoneId: String?) =
         actionStartActivity(
             ComponentName(context, MainActivity::class.java),
-            if (milestoneId != null) actionParametersOf(PINNED_MILESTONE_KEY to milestoneId)
+            if (milestoneId != null) actionParametersOf(SLOT_MILESTONE_KEY to milestoneId)
             else actionParametersOf(),
         )
 }
 
-class PinnedCountdownReceiver : GlanceAppWidgetReceiver() {
-    override val glanceAppWidget: GlanceAppWidget = PinnedCountdownWidget()
+class AmberCountdownReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SlotCountdownWidget("amber", 0xFFC8A96E)
+}
+
+class RoseCountdownReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SlotCountdownWidget("rose", 0xFFE85D75)
+}
+
+class TealCountdownReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SlotCountdownWidget("teal", 0xFF38B2AC)
+}
+
+class BlueCountdownReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SlotCountdownWidget("blue", 0xFF4A90D9)
 }

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -56,7 +56,7 @@ object WidgetData {
         val currentChapter: Chapter?,
         val birthday: String?,
         val onThisDay: List<Milestone>,
-        val pinned: Milestone?,
+        val pins: Map<String, Milestone>,
         val pastCount: Int,
         val futureCount: Int,
         val totalCount: Int,
@@ -74,7 +74,7 @@ object WidgetData {
                 currentChapter = parseChapter(obj.optJSONObject("currentChapter")),
                 birthday = obj.stringOrNull("birthday"),
                 onThisDay = parseMilestoneArray(obj.optJSONArray("onThisDay")),
-                pinned = parseMilestone(obj.optJSONObject("pinned")),
+                pins = parsePins(obj.optJSONObject("pins")),
                 pastCount = counts?.optInt("past", 0) ?: 0,
                 futureCount = counts?.optInt("future", 0) ?: 0,
                 totalCount = counts?.optInt("total", 0) ?: 0,
@@ -90,6 +90,18 @@ object WidgetData {
         val out = ArrayList<Milestone>(arr.length())
         for (i in 0 until arr.length()) {
             parseMilestone(arr.optJSONObject(i))?.let { out.add(it) }
+        }
+        return out
+    }
+
+    // { slot -> milestone | null }; only non-null slots are kept.
+    private fun parsePins(obj: JSONObject?): Map<String, Milestone> {
+        if (obj == null) return emptyMap()
+        val out = HashMap<String, Milestone>()
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            parseMilestone(obj.optJSONObject(key))?.let { out[key] = it }
         }
         return out
     }
@@ -244,7 +256,10 @@ object WidgetData {
             CurrentChapterReceiver::class.java,
             OnThisDayReceiver::class.java,
             StatsReceiver::class.java,
-            PinnedCountdownReceiver::class.java,
+            AmberCountdownReceiver::class.java,
+            RoseCountdownReceiver::class.java,
+            TealCountdownReceiver::class.java,
+            BlueCountdownReceiver::class.java,
         )
         val mgr = AppWidgetManager.getInstance(context)
         for (cls in receivers) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="widget_quick_add_label">Add milestone</string>
     <string name="widget_quick_add_description">A one-tap shortcut to add a new milestone.</string>
 
-    <string name="widget_pinned_label">Pinned countdown</string>
-    <string name="widget_pinned_description">A countdown to a milestone you\'ve pinned in the app.</string>
+    <string name="widget_pin_amber_label">Countdown · amber</string>
+    <string name="widget_pin_rose_label">Countdown · rose</string>
+    <string name="widget_pin_teal_label">Countdown · teal</string>
+    <string name="widget_pin_blue_label">Countdown · blue</string>
+    <string name="widget_pinned_description">A countdown to the milestone pinned to this color slot in the app.</string>
 </resources>

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -147,12 +147,17 @@ just a pull + rebuild.
   (all past, non-year milestones); each widget filters it to today's month/day at **render
   time**, so the midnight refresh shows the new day without the app re-pushing.
 
-### ✅ Phase 6 — Pinned countdown + Quick add
+### ✅ Phase 6 — Color-slot countdowns + Quick add
 Both platforms, no new native targets.
-- **Pinned countdown** — a countdown to a milestone the user pins **in the app** (a 📌
-  toggle in the milestone detail stores `lifeglance-pinned-milestone-id`; the snapshot
-  resolves it to `pinned`). This deliberately avoids per-widget configuration (Android
-  config Activity / iOS AppIntent) — a single app-side pin is simpler and cross-platform.
+- **Color-slot countdowns** — four pinnable slots (**amber / rose / teal / blue**), each
+  with its own dedicated countdown widget. A 📌 color-dot picker in the milestone detail
+  assigns a milestone to a slot (`lifeglance-pins` = `{slot: id}`); the snapshot resolves
+  set slots into `pins: {slot: milestone}` (unset slots omitted — never stored as null, so
+  the iOS `[String: Milestone]` decode is safe). Because each slot is a **separate widget
+  type** (its own receiver / `Widget` struct), several different milestones can be pinned
+  on the home screen at once **without** per-widget configuration (config Activity /
+  AppIntent). The slot color is the binding — it's the widget's accent. Implemented as one
+  shared view parameterized by slot + accent.
 - **Quick add** — a launcher widget that opens the app straight into the new-milestone
   sheet. Reuses the launch-target handoff, extended to carry an `action` ("new") alongside
   the existing `milestoneId` (Android intent extra `widget_action`; iOS `lifeglance://new`).

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -12,7 +12,43 @@ struct LifeGlanceWidgetsBundle: WidgetBundle {
         OnThisDayWidget()
         StatsWidget()
         QuickAddWidget()
-        PinnedCountdownWidget()
+        AmberCountdownWidget()
+        RoseCountdownWidget()
+        TealCountdownWidget()
+        BlueCountdownWidget()
+    }
+}
+
+// Each color slot is its own widget (so several pinned countdowns can coexist without
+// per-widget configuration). They share PinnedSlotView, parameterized by slot + accent.
+private func slotConfig(kind: String, slot: String, accentHex: String, name: String) -> some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: SnapshotProvider()) { entry in
+        PinnedSlotView(entry: entry, slot: slot, accent: Color(hex: accentHex, fallback: Palette.amber))
+            .widgetBackground(Palette.bg)
+    }
+    .configurationDisplayName(name)
+    .description("A countdown to the milestone pinned to this color slot in the app.")
+    .supportedFamilies([.systemSmall, .systemMedium])
+}
+
+struct AmberCountdownWidget: Widget {
+    var body: some WidgetConfiguration {
+        slotConfig(kind: "PinnedAmber", slot: "amber", accentHex: "C8A96E", name: "Countdown · amber")
+    }
+}
+struct RoseCountdownWidget: Widget {
+    var body: some WidgetConfiguration {
+        slotConfig(kind: "PinnedRose", slot: "rose", accentHex: "E85D75", name: "Countdown · rose")
+    }
+}
+struct TealCountdownWidget: Widget {
+    var body: some WidgetConfiguration {
+        slotConfig(kind: "PinnedTeal", slot: "teal", accentHex: "38B2AC", name: "Countdown · teal")
+    }
+}
+struct BlueCountdownWidget: Widget {
+    var body: some WidgetConfiguration {
+        slotConfig(kind: "PinnedBlue", slot: "blue", accentHex: "4A90D9", name: "Countdown · blue")
     }
 }
 
@@ -79,16 +115,5 @@ struct QuickAddWidget: Widget {
         .configurationDisplayName("Add milestone")
         .description("A one-tap shortcut to add a new milestone.")
         .supportedFamilies([.systemSmall])
-    }
-}
-
-struct PinnedCountdownWidget: Widget {
-    var body: some WidgetConfiguration {
-        StaticConfiguration(kind: "PinnedCountdownWidget", provider: SnapshotProvider()) { entry in
-            PinnedCountdownView(entry: entry).widgetBackground(Palette.bg)
-        }
-        .configurationDisplayName("Pinned countdown")
-        .description("A countdown to a milestone you've pinned in the app.")
-        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -12,6 +12,7 @@ struct LifeGlanceWidgetsBundle: WidgetBundle {
         OnThisDayWidget()
         StatsWidget()
         QuickAddWidget()
+        TimelineStripWidget()
         AmberCountdownWidget()
         RoseCountdownWidget()
         TealCountdownWidget()
@@ -115,5 +116,16 @@ struct QuickAddWidget: Widget {
         .configurationDisplayName("Add milestone")
         .description("A one-tap shortcut to add a new milestone.")
         .supportedFamilies([.systemSmall])
+    }
+}
+
+struct TimelineStripWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "TimelineStripWidget", provider: SnapshotProvider()) { entry in
+            TimelineStripView(entry: entry).widgetBackground(Palette.bg)
+        }
+        .configurationDisplayName("Timeline")
+        .description("A glance at your timeline around today.")
+        .supportedFamilies([.systemMedium, .systemLarge, .systemExtraLarge])
     }
 }

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -59,6 +59,7 @@ struct WidgetSnapshot: Codable {
     let currentChapter: WidgetChapter?
     let onThisDay: [WidgetMilestone]?
     let pins: [String: WidgetMilestone]?
+    let strip: [WidgetMilestone]?
     let counts: Counts?
 
     struct Counts: Codable {
@@ -211,6 +212,10 @@ enum WidgetDate {
 
     static func weekday() -> String { formatToday("EEEE") }
     static func todayLong() -> String { formatToday("MMMM d, yyyy") }
+
+    // Exposed for the timeline-strip widget, which positions milestones by date.
+    static func calendarDate(_ iso: String) -> Date? { dateOnly(iso) }
+    static func todayDate() -> Date { today() }
 
     private static func formatToday(_ pattern: String) -> String {
         let formatter = DateFormatter()

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -58,7 +58,7 @@ struct WidgetSnapshot: Codable {
     let prev: WidgetMilestone?
     let currentChapter: WidgetChapter?
     let onThisDay: [WidgetMilestone]?
-    let pinned: WidgetMilestone?
+    let pins: [String: WidgetMilestone]?
     let counts: Counts?
 
     struct Counts: Codable {

--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import WidgetKit
+
+// A mini "you are here" slice of the timeline around today. Milestones are positioned
+// by date along a horizontal axis with a bright today marker. Drawn with positioned
+// SwiftUI shapes (no Canvas) so it's widget-safe. Recomputed every render, so the today
+// marker and dot positions stay correct between snapshot pushes.
+
+private struct StripDot: Identifiable {
+    let id: String
+    let x: CGFloat       // 0...1 within the framed window
+    let color: Color
+}
+
+private struct StripTick: Identifiable {
+    let id: Int          // the year
+    let x: CGFloat
+    let label: String
+}
+
+// Auto-fit model: frames the nearest `framePerSide` milestones on each side of today,
+// pads the window, and produces normalized x positions (independent of widget size).
+private struct StripModel {
+    let dots: [StripDot]
+    let ticks: [StripTick]
+    let todayX: CGFloat
+    let nearestPast: WidgetMilestone?
+    let nearestFuture: WidgetMilestone?
+    let isEmpty: Bool
+
+    init(milestones: [WidgetMilestone], framePerSide: Int) {
+        let today = WidgetDate.todayDate()
+
+        let dated = milestones.compactMap { m -> (WidgetMilestone, Date)? in
+            guard let d = WidgetDate.calendarDate(m.date) else { return nil }
+            return (m, d)
+        }
+        guard !dated.isEmpty else {
+            dots = []; ticks = []; todayX = 0.5
+            nearestPast = nil; nearestFuture = nil; isEmpty = true
+            return
+        }
+
+        let past = dated.filter { $0.1 < today }.sorted { $0.1 > $1.1 }    // nearest first
+        let future = dated.filter { $0.1 >= today }.sorted { $0.1 < $1.1 } // nearest first
+
+        // Window = extremes of the nearest framePerSide on each side, plus today.
+        var earliest = today, latest = today
+        for (_, d) in past.prefix(framePerSide) where d < earliest { earliest = d }
+        for (_, d) in future.prefix(framePerSide) where d > latest { latest = d }
+        if earliest == latest {   // only today in frame — show a default ±6mo span
+            earliest = today.addingTimeInterval(-182 * 86_400)
+            latest = today.addingTimeInterval(182 * 86_400)
+        }
+
+        let span = latest.timeIntervalSince(earliest)
+        let pad = span * 0.08
+        let startRef = earliest.timeIntervalSinceReferenceDate - pad
+        let endRef = latest.timeIntervalSinceReferenceDate + pad
+        let total = max(endRef - startRef, 1)
+        func frac(_ d: Date) -> CGFloat {
+            CGFloat((d.timeIntervalSinceReferenceDate - startRef) / total)
+        }
+
+        dots = dated.compactMap { (m, d) in
+            let f = frac(d)
+            guard f >= -0.02, f <= 1.02 else { return nil }
+            return StripDot(id: m.id, x: min(max(f, 0), 1),
+                            color: Color(hex: m.color, fallback: Palette.muted))
+        }
+        todayX = min(max(frac(today), 0), 1)
+
+        // Year ticks (Jan 1 of each year inside the window), unless the span is huge.
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let startYear = cal.component(.year, from: Date(timeIntervalSinceReferenceDate: startRef))
+        let endYear = cal.component(.year, from: Date(timeIntervalSinceReferenceDate: endRef))
+        var t: [StripTick] = []
+        if endYear > startYear && endYear - startYear <= 30 {
+            for y in (startYear + 1)...endYear {
+                if let jan1 = cal.date(from: DateComponents(year: y, month: 1, day: 1)) {
+                    let f = frac(jan1)
+                    if f >= 0, f <= 1 { t.append(StripTick(id: y, x: f, label: String(y))) }
+                }
+            }
+        }
+        ticks = t
+
+        nearestPast = past.first?.0
+        nearestFuture = future.first?.0
+        isEmpty = false
+    }
+}
+
+struct TimelineStripView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    private var framePerSide: Int {
+        switch family {
+        case .systemExtraLarge: return 6
+        case .systemLarge:      return 4
+        default:                return 3   // medium
+        }
+    }
+
+    var body: some View {
+        let model = StripModel(milestones: entry.snapshot?.strip ?? [], framePerSide: framePerSide)
+        VStack(alignment: .leading, spacing: 6) {
+            Text("TIMELINE")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(Palette.amber)
+            chart(model)
+            if family != .systemMedium {
+                caption(model)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(14)
+        .widgetURL(URL(string: "lifeglance://open"))
+    }
+
+    private func chart(_ m: StripModel) -> some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let h = geo.size.height
+            let pad: CGFloat = 4
+            let innerW = max(w - 2 * pad, 1)
+            let axisY = h * 0.5
+            let px: (CGFloat) -> CGFloat = { pad + $0 * innerW }
+
+            ZStack(alignment: .topLeading) {
+                if m.isEmpty {
+                    Text("Not enough milestones to chart yet")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(Palette.muted)
+                        .lineLimit(2)
+                } else {
+                    Rectangle().fill(Palette.muted.opacity(0.35))
+                        .frame(width: innerW, height: 1)
+                        .position(x: w / 2, y: axisY)
+
+                    ForEach(m.ticks) { t in
+                        Rectangle().fill(Palette.muted.opacity(0.25))
+                            .frame(width: 1, height: 5)
+                            .position(x: px(t.x), y: axisY)
+                        Text(t.label)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundColor(Palette.muted)
+                            .fixedSize()
+                            .position(x: px(t.x), y: axisY + 12)
+                    }
+
+                    ForEach(m.dots) { d in
+                        Circle().fill(d.color)
+                            .frame(width: 7, height: 7)
+                            .position(x: px(d.x), y: axisY)
+                    }
+
+                    Rectangle().fill(Palette.amber)
+                        .frame(width: 2, height: max(h - 6, 8))
+                        .position(x: px(m.todayX), y: h / 2)
+                    Circle().fill(Palette.amber)
+                        .frame(width: 6, height: 6)
+                        .position(x: px(m.todayX), y: axisY)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func caption(_ m: StripModel) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            if let p = m.nearestPast {
+                captionItem(p, align: .leading)
+            }
+            Spacer(minLength: 8)
+            if let n = m.nearestFuture {
+                captionItem(n, align: .trailing)
+            }
+        }
+    }
+
+    private func captionItem(_ m: WidgetMilestone, align: HorizontalAlignment) -> some View {
+        VStack(alignment: align, spacing: 1) {
+            Text(m.title)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(Palette.text)
+                .lineLimit(1)
+            Text(WidgetDate.relativeLabel(m.date))
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(Palette.muted)
+        }
+    }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetViews.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetViews.swift
@@ -176,16 +176,17 @@ struct OnThisDayView: View {
     }
 }
 
-// MARK: - Pinned countdown
+// MARK: - Pinned color-slot countdown
 
-struct PinnedCountdownView: View {
+struct PinnedSlotView: View {
     let entry: SnapshotEntry
+    let slot: String
+    let accent: Color
 
     var body: some View {
-        let pinned = entry.snapshot?.pinned
+        let pinned = entry.snapshot?.pins?[slot]
         VStack(alignment: .leading, spacing: 2) {
             if let pinned = pinned {
-                let accent = Color(hex: pinned.color, fallback: Palette.amber)
                 Text("PINNED").font(mono(10, .bold)).foregroundColor(accent)
                 Text(WidgetDate.relativeLabel(pinned.date))
                     .font(mono(22, .bold)).foregroundColor(Palette.text)
@@ -193,7 +194,7 @@ struct PinnedCountdownView: View {
                 Text(WidgetDate.formatDate(pinned.date, precision: pinned.datePrecision ?? "day"))
                     .font(mono(11)).foregroundColor(Palette.muted)
             } else {
-                Text("Pin a milestone in the app to track it here")
+                Text("Pin a milestone to the \(slot) slot in the app")
                     .font(mono(12)).foregroundColor(Palette.muted).lineLimit(3)
             }
         }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -144,9 +144,10 @@ export default function App() {
 
     const flush = () => {
       const birthday = localStorage.getItem('lifeglance-birthday') || null
-      const pinnedId = localStorage.getItem('lifeglance-pinned-milestone-id') || null
+      let pins = {}
+      try { pins = JSON.parse(localStorage.getItem('lifeglance-pins') || '{}') } catch {}
       pushWidgetSnapshot(
-        buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday, new Date(), pinnedId)
+        buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday, new Date(), pins)
       )
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,7 +145,7 @@ export default function App() {
     const flush = () => {
       const birthday = localStorage.getItem('lifeglance-birthday') || null
       let pins = {}
-      try { pins = JSON.parse(localStorage.getItem('lifeglance-pins') || '{}') } catch {}
+      try { pins = JSON.parse(localStorage.getItem('lifeglance-pins') || '{}') } catch { /* ignore malformed pins */ }
       pushWidgetSnapshot(
         buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday, new Date(), pins)
       )

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -4,7 +4,18 @@ import { Capacitor } from '@capacitor/core'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
 
-const PINNED_KEY = 'lifeglance-pinned-milestone-id'
+const PINS_KEY = 'lifeglance-pins'
+// Color pin slots — each maps to its own countdown widget. Keep in sync with PIN_SLOTS
+// in widgetSnapshot.js and the native slot widgets.
+const PIN_SLOTS = [
+  { id: 'amber', color: '#C8A96E' },
+  { id: 'rose',  color: '#E85D75' },
+  { id: 'teal',  color: '#38B2AC' },
+  { id: 'blue',  color: '#4A90D9' },
+]
+const readPins = () => {
+  try { return JSON.parse(localStorage.getItem(PINS_KEY) || '{}') } catch { return {} }
+}
 
 export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelete, onDeleteSeries, birthday, categories = [] }) {
   const { t, i18n } = useTranslation('milestone')
@@ -12,15 +23,17 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
   const [audioUrl,  setAudioUrl]  = useState(null)
   const [photoUrl,  setPhotoUrl]  = useState(null)
   const [confirm,   setConfirm]   = useState(null)
-  const [pinned,    setPinned]    = useState(() => localStorage.getItem(PINNED_KEY) === m.id)
+  const [pins,      setPins]      = useState(readPins)
 
-  // The pinned-countdown widget reads a single pinned milestone id. Toggling here
-  // updates it and nudges the widget snapshot to re-push. Native shells only.
+  // Each color slot maps to its own countdown widget. Tapping a slot pins this milestone
+  // to it (or clears it), then nudges the widget snapshot to re-push. Native shells only.
   const canPin = Capacitor.isNativePlatform()
-  function togglePin() {
-    if (pinned) localStorage.removeItem(PINNED_KEY)
-    else        localStorage.setItem(PINNED_KEY, m.id)
-    setPinned(!pinned)
+  function toggleSlot(slot) {
+    const next = { ...readPins() }
+    if (next[slot] === m.id) delete next[slot]
+    else next[slot] = m.id
+    localStorage.setItem(PINS_KEY, JSON.stringify(next))
+    setPins(next)
     window.dispatchEvent(new Event('lifeglance:widget-refresh'))
   }
 
@@ -184,11 +197,25 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
             </div>
             <div className="sheet-actions-right">
               {canPin && (
-                <button className="btn-ghost" onClick={togglePin}
-                  title={pinned ? 'Unpin from widget' : 'Pin to countdown widget'}
-                  style={{ color: pinned ? 'var(--amber)' : undefined }}>
-                  {pinned ? '📌 Pinned' : '📌 Pin'}
-                </button>
+                <div className="detail-pin-slots" title="Pin to a countdown widget"
+                  style={{ display: 'flex', alignItems: 'center', gap: '4px', marginRight: '6px' }}>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>📌</span>
+                  {PIN_SLOTS.map(s => {
+                    const active = pins[s.id] === m.id
+                    return (
+                      <button key={s.id} type="button" onClick={() => toggleSlot(s.id)}
+                        title={active ? `Unpin from ${s.id} widget` : `Pin to ${s.id} widget`}
+                        aria-label={active ? `Unpin from ${s.id} widget` : `Pin to ${s.id} widget`}
+                        aria-pressed={active}
+                        style={{
+                          width: '18px', height: '18px', borderRadius: '50%', padding: 0,
+                          border: `2px solid ${s.color}`,
+                          background: active ? s.color : 'transparent',
+                          cursor: 'pointer',
+                        }} />
+                    )
+                  })}
+                </div>
               )}
               <button className="btn" onClick={() => { onClose(); onEdit(m) }}
                 style={{ fontSize: '0.8rem', padding: '0.45rem 0.9rem' }}>

--- a/src/utils/widgetSnapshot.js
+++ b/src/utils/widgetSnapshot.js
@@ -124,6 +124,16 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
     if (m) resolvedPins[slot] = projectMilestone(m)
   }
 
+  // Bounded set of the milestones nearest today (≤10 each side, by date) for the
+  // timeline-strip widget. The widget auto-fits a window and positions these against
+  // the render-time "today" so the marker stays correct between pushes.
+  const splitAt = sorted.findIndex(m => new Date(m.date).getTime() >= nowMs)
+  const futureStart = splitAt === -1 ? sorted.length : splitAt
+  const strip = [
+    ...sorted.slice(Math.max(0, futureStart - 10), futureStart),
+    ...sorted.slice(futureStart, futureStart + 10),
+  ].map(projectMilestone)
+
   return {
     version:        WIDGET_SNAPSHOT_VERSION,
     generatedAt:    now.toISOString(),
@@ -133,6 +143,7 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
     currentChapter,
     onThisDay,
     pins:           resolvedPins,
+    strip,
     counts:         { past, future, total: past + future, thisYear: thisYearCount },
   }
 }

--- a/src/utils/widgetSnapshot.js
+++ b/src/utils/widgetSnapshot.js
@@ -20,6 +20,11 @@ import { precomputeEndpoints, getMilestoneVisibility } from './visibility'
 
 export const WIDGET_SNAPSHOT_VERSION = 1
 
+// Color pin slots. Each can hold one milestone (set in the app); each has its own
+// dedicated home-screen widget, so several pinned countdowns can coexist without
+// per-widget configuration. Keep in sync with the native widgets and the pin UI.
+export const PIN_SLOTS = ['amber', 'rose', 'teal', 'blue']
+
 // Pares a milestone down to just what a widget renders.
 function projectMilestone(m) {
   if (!m) return null
@@ -48,7 +53,7 @@ function pickCurrentChapter(chapters, nowMs) {
   return best
 }
 
-export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = null, now = new Date(), pinnedId = null) {
+export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = null, now = new Date(), pins = {}) {
   const nowMs = now.getTime()
 
   // Keep only milestones that are visible on the main timeline.
@@ -108,9 +113,16 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
   const thisYear = now.getFullYear()
   const thisYearCount = visible.filter(m => new Date(m.date).getFullYear() === thisYear).length
 
-  // The milestone the user pinned in the app (by id), for the pinned-countdown widget.
-  // Resolved from all milestones (an explicit pin shows regardless of timeline visibility).
-  const pinned = pinnedId ? (milestones.find(m => m.id === pinnedId) ?? null) : null
+  // Resolve each color pin slot (slot → milestone id, set in the app) to its milestone.
+  // Only set+found slots are included — unset slots are omitted, not stored as null, so
+  // the iOS [String: Milestone] decode never sees a null value. Pinned milestones show
+  // regardless of timeline visibility (the pin is explicit).
+  const resolvedPins = {}
+  for (const slot of PIN_SLOTS) {
+    const id = pins?.[slot]
+    const m = id ? milestones.find(x => x.id === id) : null
+    if (m) resolvedPins[slot] = projectMilestone(m)
+  }
 
   return {
     version:        WIDGET_SNAPSHOT_VERSION,
@@ -120,7 +132,7 @@ export function buildWidgetSnapshot(milestones = [], chapters = [], birthday = n
     prev:           projectMilestone(prev),
     currentChapter,
     onThisDay,
-    pinned:         projectMilestone(pinned),
+    pins:           resolvedPins,
     counts:         { past, future, total: past + future, thisYear: thisYearCount },
   }
 }

--- a/src/utils/widgetSnapshot.test.js
+++ b/src/utils/widgetSnapshot.test.js
@@ -139,6 +139,20 @@ describe('buildWidgetSnapshot', () => {
     expect(buildWidgetSnapshot(milestones, [], null, NOW).pins).toEqual({})
   })
 
+  it('builds the timeline-strip set (nearest milestones, date-sorted, capped per side)', () => {
+    // 12 past + 12 future; strip keeps the nearest 10 of each, ascending by date.
+    const milestones = []
+    for (let i = 1; i <= 12; i++) milestones.push(ms({ id: `p${i}`, date: `${2026 - i}-06-20T12:00:00Z` }))
+    for (let i = 1; i <= 12; i++) milestones.push(ms({ id: `f${i}`, date: `${2026 + i}-06-20T12:00:00Z` }))
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW)
+    expect(snap.strip.length).toBe(20) // 10 past + 10 future
+    const dates = snap.strip.map(m => +new Date(m.date))
+    expect(dates).toEqual([...dates].sort((a, b) => a - b)) // ascending
+    // The very farthest (p12 = 2014, f12 = 2038) are dropped.
+    expect(snap.strip.find(m => m.id === 'p12')).toBeUndefined()
+    expect(snap.strip.find(m => m.id === 'f12')).toBeUndefined()
+  })
+
   it('counts milestones in the current calendar year', () => {
     const milestones = [
       ms({ date: '2026-03-01T12:00:00Z' }),

--- a/src/utils/widgetSnapshot.test.js
+++ b/src/utils/widgetSnapshot.test.js
@@ -125,14 +125,18 @@ describe('buildWidgetSnapshot', () => {
     expect(snap.onThisDay.map(m => m.id)).toEqual(['newer', 'mid', 'older']) // desc by date
   })
 
-  it('resolves the pinned milestone by id (or null)', () => {
+  it('resolves color pin slots by id (or null per slot)', () => {
     const milestones = [
       ms({ id: 'a', title: 'A', date: '2027-01-01T12:00:00Z' }),
       ms({ id: 'b', title: 'B', date: '2028-01-01T12:00:00Z' }),
     ]
-    expect(buildWidgetSnapshot(milestones, [], null, NOW, 'b').pinned?.id).toBe('b')
-    expect(buildWidgetSnapshot(milestones, [], null, NOW, 'missing').pinned).toBeNull()
-    expect(buildWidgetSnapshot(milestones, [], null, NOW).pinned).toBeNull()
+    const snap = buildWidgetSnapshot(milestones, [], null, NOW, { amber: 'a', teal: 'b', rose: 'missing' })
+    expect(snap.pins.amber?.id).toBe('a')
+    expect(snap.pins.teal?.id).toBe('b')
+    // Unset / not-found slots are omitted entirely (no null values stored).
+    expect(snap.pins.rose).toBeUndefined()
+    expect(snap.pins.blue).toBeUndefined()
+    expect(buildWidgetSnapshot(milestones, [], null, NOW).pins).toEqual({})
   })
 
   it('counts milestones in the current calendar year', () => {


### PR DESCRIPTION
Two more widgets on top of the On This Day / Stats / Quick-add set (#185).

## Color-slot pinned countdowns (4 slots)
Replaces the single global app-side pin with **four independent color slots** — amber, rose, teal, blue. Each slot is its own widget *type* (separate receiver/configuration), so several pinned countdowns can coexist on the home screen without per-widget configuration plumbing.

- **App side**: `MilestoneDetail` gets a 4-dot color picker (native only) writing a `lifeglance-pins` slot→id map to localStorage and dispatching a refresh.
- **Snapshot**: `pins` resolves each set slot to its milestone; unset/not-found slots are **omitted** (never stored as null — keeps the iOS `[String: Milestone]` decode happy).
- **Android**: `SlotCountdownWidget(slot, accent)` + Amber/Rose/Teal/Blue receivers.
- **iOS**: `PinnedSlotView` parameterized by slot + accent, four `*CountdownWidget` structs via a shared `slotConfig` helper (small / medium).

## iOS timeline-strip widget (medium / large / extra large)
A "you are here" slice of the timeline around today.

- **Auto-fit window**: frames the nearest **3 / 4 / 6** milestones per side (medium / large / XL), pads the span 8%, positions every dot by date as a normalized fraction.
- **Medium** shows just the chart (axis, year ticks, dots, amber today-marker); **large / XL** add a caption with the nearest past and future milestone.
- Drawn with positioned SwiftUI shapes in a `GeometryReader` (no Canvas — widget-safe).
- **Midnight-correct**: positions and the today-marker are computed at render time against `WidgetDate.todayDate()`. The snapshot's `strip` field just carries the nearest ≤10 milestones per side as raw ISO dates.

## Notes
- Android's timeline strip is **deferred** — Glance has no canvas, so it needs a bitmap-rendering approach.
- Snapshot builder has unit coverage for the strip set and pin slots (13 tests passing).
- Native code (Kotlin/Swift) was **not compiled in this environment** — please build locally and report any errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_