### PR TITLE
Timeline-strip widget: TODAY tag + pinned-style caption

### DIFF
--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -163,6 +163,15 @@ struct TimelineStripView: View {
                     Circle().fill(Palette.amber)
                         .frame(width: 6, height: 6)
                         .position(x: px(m.todayX), y: axisY)
+                    // "TODAY" tag above the marker. A bg-colored pad keeps it legible
+                    // where it sits over the line, and the x is clamped off the edges.
+                    Text("TODAY")
+                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                        .foregroundColor(Palette.amber)
+                        .fixedSize()
+                        .padding(.horizontal, 3)
+                        .background(Palette.bg)
+                        .position(x: min(max(px(m.todayX), 20), w - 20), y: 7)
                 }
             }
         }

--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -193,11 +193,12 @@ struct TimelineStripView: View {
     private func captionItem(_ m: WidgetMilestone, align: HorizontalAlignment) -> some View {
         VStack(alignment: align, spacing: 1) {
             Text(m.title)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: 14, weight: .semibold, design: .monospaced))
                 .foregroundColor(Palette.text)
                 .lineLimit(1)
+                .minimumScaleFactor(0.8)
             Text(WidgetDate.relativeLabel(m.date))
-                .font(.system(size: 9, design: .monospaced))
+                .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(Palette.muted)
         }
     }

--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -190,16 +190,24 @@ struct TimelineStripView: View {
         }
     }
 
+    // Mirrors the pinned-countdown layout: time-to/from biggest, then the
+    // milestone name, then the absolute date smallest.
     private func captionItem(_ m: WidgetMilestone, align: HorizontalAlignment) -> some View {
         VStack(alignment: align, spacing: 1) {
+            Text(WidgetDate.relativeLabel(m.date))
+                .font(.system(size: 16, weight: .bold, design: .monospaced))
+                .foregroundColor(Palette.text)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
             Text(m.title)
-                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(Palette.text)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
-            Text(WidgetDate.relativeLabel(m.date))
-                .font(.system(size: 12, design: .monospaced))
+            Text(WidgetDate.formatDate(m.date, precision: m.datePrecision ?? "day"))
+                .font(.system(size: 10, design: .monospaced))
                 .foregroundColor(Palette.muted)
+                .lineLimit(1)
         }
     }
 }


### PR DESCRIPTION
Polish on the iOS timeline-strip widget.

- **TODAY tag** above the today marker — small bold amber monospaced text with a bg-colored pad so it stays legible over the line, x clamped off the edges so it won't clip when today sits near the start/end of the window.
- **Caption reordered to match the pinned-countdown widget**: time-to/from biggest (bold), then milestone name, then the absolute date smallest/muted. Labels shrink-to-fit instead of truncating.

iOS-only / SwiftUI; not compiled in this environment — build locally and report anything Xcode flags. Android strip remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_