### PR TITLE
Enlarge the timeline-strip TODAY marker

### DIFF
--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -166,12 +166,13 @@ struct TimelineStripView: View {
                     // "TODAY" tag above the marker. A bg-colored pad keeps it legible
                     // where it sits over the line, and the x is clamped off the edges.
                     Text("TODAY")
-                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                        .font(.system(size: 11, weight: .heavy, design: .monospaced))
                         .foregroundColor(Palette.amber)
                         .fixedSize()
                         .padding(.horizontal, 3)
+                        .padding(.bottom, 4)
                         .background(Palette.bg)
-                        .position(x: min(max(px(m.todayX), 20), w - 20), y: 7)
+                        .position(x: min(max(px(m.todayX), 22), w - 22), y: 11)
                 }
             }
         }


### PR DESCRIPTION
Small visual fix on the iOS timeline-strip widget: the `TODAY` tag was a bit small and sat awkwardly close to the line.

- Bumped the label 8 → 11pt.
- Added 4pt of padding beneath it (the bg pad extends down, opening a gap between the label and the marker line).
- Nudged its baseline down and widened the edge clamp to match the larger text.

iOS-only / SwiftUI; not compiled here — build locally to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_