### PR TITLE
Symmetric padding on the timeline-strip TODAY marker

### DIFF
--- a/ios/App/LifeGlanceWidgets/WidgetStripView.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetStripView.swift
@@ -170,9 +170,9 @@ struct TimelineStripView: View {
                         .foregroundColor(Palette.amber)
                         .fixedSize()
                         .padding(.horizontal, 3)
-                        .padding(.bottom, 4)
+                        .padding(.vertical, 4)
                         .background(Palette.bg)
-                        .position(x: min(max(px(m.todayX), 22), w - 22), y: 11)
+                        .position(x: min(max(px(m.todayX), 22), w - 22), y: 13)
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #189: the `TODAY` tag had padding only beneath it. Switched to `.padding(.vertical, 4)` for even top/bottom spacing and nudged the baseline down 2pt so the added top padding doesn't clip at the chart edge.

iOS-only / SwiftUI; not compiled here — build locally to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vf4UsKxdNkGbgtwHxFHnS)_