### PR TITLE
Blob encryption core (Phase 7, client step 1)

### DIFF
--- a/src/blobs/blobCrypto.test.js
+++ b/src/blobs/blobCrypto.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  encryptBlob,
+  decryptBlob,
+  deriveBlobKey,
+  BlobKeyUnavailableError,
+  NONCE_LENGTH,
+} from './blobCrypto.ts'
+
+// The module reaches the vault root key through an injectable provider
+// (default: the intents key store). In tests we inject a provider that returns
+// a root key shaped EXACTLY like the real one: a non-extractable HKDF base key
+// whose only usage is ["deriveKey"] (see @glance-apps/intents deriveIntentsRootKey).
+// This proves deriveBlobKey works against the genuine key shape, with no mocks.
+
+let rootKey
+let provideKey   // resolves to the (stable) root key
+let provideNull  // resolves to null — simulates "key not available"
+
+beforeEach(async () => {
+  const rootBits = crypto.getRandomValues(new Uint8Array(32))
+  rootKey = await crypto.subtle.importKey('raw', rootBits, 'HKDF', false, ['deriveKey'])
+  provideKey = async () => rootKey
+  provideNull = async () => null
+})
+
+// Fill a buffer with random bytes in <=64KB chunks (getRandomValues' per-call cap).
+function randomBytes(n) {
+  const out = new Uint8Array(n)
+  for (let off = 0; off < n; off += 65536) {
+    crypto.getRandomValues(out.subarray(off, Math.min(off + 65536, n)))
+  }
+  return out
+}
+
+async function sha256Hex(bytes) {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
+  return [...digest].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+const enc = (s) => new TextEncoder().encode(s)
+
+describe('blobCrypto — determinism (a)', () => {
+  it('encrypts the same plaintext to byte-identical ciphertext and hash', async () => {
+    const pt = enc('the same bytes every time')
+    const a = await encryptBlob(pt, provideKey)
+    const b = await encryptBlob(pt, provideKey)
+
+    expect([...a.bytes]).toEqual([...b.bytes]) // byte-identical stored form
+    expect(a.hash).toBe(b.hash) // same content address → dedup / idempotent upload
+  })
+
+  it('is deterministic across distinct Uint8Array instances of equal content', async () => {
+    const a = await encryptBlob(enc('hello'), provideKey)
+    const b = await encryptBlob(new Uint8Array([104, 101, 108, 108, 111]), provideKey) // "hello"
+    expect(a.hash).toBe(b.hash)
+  })
+})
+
+describe('blobCrypto — distinct plaintexts (b)', () => {
+  it('yields different nonces and different hashes (no collision)', async () => {
+    const a = await encryptBlob(enc('hello world'), provideKey)
+    const c = await encryptBlob(enc('goodbye moon'), provideKey)
+
+    const nonceA = a.bytes.slice(0, NONCE_LENGTH)
+    const nonceC = c.bytes.slice(0, NONCE_LENGTH)
+    expect([...nonceA]).not.toEqual([...nonceC])
+    expect(a.hash).not.toBe(c.hash)
+  })
+
+  it('a single-byte difference in plaintext changes the nonce and hash', async () => {
+    const a = await encryptBlob(new Uint8Array([1, 2, 3, 4]), provideKey)
+    const b = await encryptBlob(new Uint8Array([1, 2, 3, 5]), provideKey)
+    expect([...a.bytes.slice(0, NONCE_LENGTH)]).not.toEqual([...b.bytes.slice(0, NONCE_LENGTH)])
+    expect(a.hash).not.toBe(b.hash)
+  })
+})
+
+describe('blobCrypto — round-trip (c)', () => {
+  it('decrypt(encrypt(p)) === p for a small input', async () => {
+    const pt = enc('round trip me 🛰️')
+    const { bytes } = await encryptBlob(pt, provideKey)
+    const out = await decryptBlob(bytes, provideKey)
+    expect([...out]).toEqual([...pt])
+  })
+
+  it('decrypt(encrypt(p)) === p for an empty input', async () => {
+    const pt = new Uint8Array(0)
+    const { bytes } = await encryptBlob(pt, provideKey)
+    const out = await decryptBlob(bytes, provideKey)
+    expect(out.length).toBe(0)
+  })
+
+  it('decrypt(encrypt(p)) === p for a large (multi-MB) input', async () => {
+    const pt = randomBytes(3 * 1024 * 1024) // 3 MB
+    const { bytes } = await encryptBlob(pt, provideKey)
+    const out = await decryptBlob(bytes, provideKey)
+    expect(out.length).toBe(pt.length)
+    // hash a cheap proof of full-buffer equality rather than a 3M-element toEqual
+    expect(await sha256Hex(out)).toBe(await sha256Hex(pt))
+  })
+
+  it('accepts an ArrayBuffer as plaintext', async () => {
+    const pt = enc('from an ArrayBuffer')
+    const { bytes } = await encryptBlob(pt.buffer, provideKey)
+    const out = await decryptBlob(bytes, provideKey)
+    expect([...out]).toEqual([...pt])
+  })
+})
+
+describe('blobCrypto — integrity (d)', () => {
+  it('a tampered ciphertext byte makes decrypt fail (GCM tag)', async () => {
+    const { bytes } = await encryptBlob(enc('authenticate me'), provideKey)
+    const tampered = bytes.slice()
+    tampered[tampered.length - 1] ^= 0x01 // flip a bit in the tag/ciphertext
+    await expect(decryptBlob(tampered, provideKey)).rejects.toThrow()
+  })
+
+  it('a tampered nonce byte makes decrypt fail', async () => {
+    const { bytes } = await encryptBlob(enc('authenticate me'), provideKey)
+    const tampered = bytes.slice()
+    tampered[0] ^= 0x01 // flip a bit in the nonce
+    await expect(decryptBlob(tampered, provideKey)).rejects.toThrow()
+  })
+
+  it('truncated stored bytes are rejected', async () => {
+    await expect(decryptBlob(new Uint8Array(5), provideKey)).rejects.toThrow()
+  })
+})
+
+describe('blobCrypto — content address (e)', () => {
+  it('hash equals SHA-256 of the exact stored bytes (matches server finalize)', async () => {
+    const { bytes, hash } = await encryptBlob(enc('address me'), provideKey)
+    expect(hash).toBe(await sha256Hex(bytes))
+    expect(hash).toMatch(/^[0-9a-f]{64}$/) // 32-byte SHA-256, hex
+  })
+
+  it('stored bytes are [nonce(12) || ciphertext+tag(>=16)]', async () => {
+    const pt = enc('layout')
+    const { bytes } = await encryptBlob(pt, provideKey)
+    // 12-byte nonce + plaintext length + 16-byte GCM tag
+    expect(bytes.length).toBe(NONCE_LENGTH + pt.length + 16)
+  })
+})
+
+describe('blobCrypto — key not available (f)', () => {
+  it('encryptBlob throws BlobKeyUnavailableError, never produces output', async () => {
+    await expect(encryptBlob(enc('secret'), provideNull)).rejects.toThrow(BlobKeyUnavailableError)
+  })
+
+  it('decryptBlob throws BlobKeyUnavailableError when key is absent', async () => {
+    const { bytes } = await encryptBlob(enc('secret'), provideKey)
+    await expect(decryptBlob(bytes, provideNull)).rejects.toThrow(BlobKeyUnavailableError)
+  })
+
+  it('deriveBlobKey returns null (not a throw) when key is absent', async () => {
+    expect(await deriveBlobKey(provideNull)).toBeNull()
+  })
+})
+
+describe('blobCrypto — key separation', () => {
+  it('different root keys produce different ciphertext for the same plaintext', async () => {
+    const otherBits = crypto.getRandomValues(new Uint8Array(32))
+    const otherRoot = await crypto.subtle.importKey('raw', otherBits, 'HKDF', false, ['deriveKey'])
+    const a = await encryptBlob(enc('same plaintext'), provideKey)
+    const b = await encryptBlob(enc('same plaintext'), async () => otherRoot)
+    expect(a.hash).not.toBe(b.hash) // key is secret, not content-derived
+  })
+
+  it('a blob encrypted under one key does not decrypt under another', async () => {
+    const otherBits = crypto.getRandomValues(new Uint8Array(32))
+    const otherRoot = await crypto.subtle.importKey('raw', otherBits, 'HKDF', false, ['deriveKey'])
+    const { bytes } = await encryptBlob(enc('cross-key'), provideKey)
+    await expect(decryptBlob(bytes, async () => otherRoot)).rejects.toThrow()
+  })
+})

--- a/src/blobs/blobCrypto.ts
+++ b/src/blobs/blobCrypto.ts
@@ -1,0 +1,245 @@
+// =============================================================================
+// blobCrypto — client-side blob encryption core (Phase 7, client step 1)
+// =============================================================================
+//
+// A self-contained, crypto-only module: encrypt a blob, decrypt it, and compute
+// its content address. It does NOT do transfer/upload/download, thumbnailing, or
+// milestone wiring — those are later steps. Its only dependency on the rest of
+// the app is the *root key source* (the vault intents root key, reached exactly
+// the way the intents path reaches it), and even that is injectable so this file
+// can be lifted into a shared `@glance-apps/*` package later if dayGLANCE /
+// lastGLANCE ever need media. (FUTURE: extract to a shared package — keep this
+// module free of UI, transport, and emit-site imports so that stays cheap.)
+//
+// -----------------------------------------------------------------------------
+// THE CONSTRUCTION (deterministic, content-addressed, authenticated)
+// -----------------------------------------------------------------------------
+// A blob is addressed by the hash of its CIPHERTEXT, and encryption is
+// DETERMINISTIC: identical plaintext under the same key produces byte-identical
+// ciphertext (hence the same address, hence dedup + idempotent upload).
+//
+//   1. KEY     blobKey = HKDF(rootKey, info="glance-blob-v1")           (§deriveBlobKey)
+//   2. NONCE   nonce   = HMAC-SHA256(blobKey, plaintext)[:12]           (content-derived)
+//   3. ENCRYPT ct      = AES-GCM(blobKey, nonce, plaintext)             (ct includes the tag)
+//   4. STORE   bytes   = nonce(12) || ct                                (the wire/at-rest form)
+//   5. ADDRESS hash    = SHA-256(bytes) hex-encoded                     (the content address)
+//   6. DECRYPT split nonce off `bytes`, AES-GCM-decrypt the rest        (tag verifies integrity)
+//
+// STORED BYTE LAYOUT (exact):
+//   ┌────────────── stored blob bytes ──────────────┐
+//   │ nonce: 12 bytes │ ciphertext+tag: N+16 bytes  │
+//   └─────────────────┴─────────────────────────────┘
+//   - The nonce travels with the blob because decrypt needs it. It is derived
+//     from the plaintext, so it is NOT secret — but it is unpredictable without
+//     the key (it is a keyed hash), and the decryptor still needs it verbatim.
+//   - AES-GCM ciphertext already carries its 16-byte auth tag appended by
+//     WebCrypto; we do not store it separately.
+//   - `hash` is SHA-256 over these EXACT stored bytes (nonce || ciphertext),
+//     so it equals what the server recomputes when it verifies on finalize.
+//
+// -----------------------------------------------------------------------------
+// SAFETY ARGUMENT — READ THIS BEFORE "SIMPLIFYING" ANYTHING HERE
+// -----------------------------------------------------------------------------
+// This is the load-bearing part. A deterministic, content-derived nonce looks
+// like the classic "GCM nonce reuse" footgun. It is NOT, *because of how the
+// nonce is derived*. Do not change the derivation without re-reading this.
+//
+//  • GCM nonce reuse is catastrophic ONLY across DIFFERENT plaintexts under the
+//    same key (it leaks the XOR of the keystreams and forges the auth key).
+//    Here the nonce is a function of (key, plaintext): nonce = HMAC(blobKey, pt).
+//    Two DIFFERENT plaintexts get DIFFERENT nonces (HMAC-SHA256 is
+//    collision-resistant), and a nonce repeats ONLY when the plaintext is
+//    byte-identical — in which case the ENTIRE message is identical and there is
+//    nothing to leak (encrypting the same bytes twice and getting the same
+//    ciphertext is exactly the dedup property we want). Therefore deterministic
+//    content-derived-nonce GCM is SAFE for this use. This is precisely why we do
+//    NOT need AES-GCM-SIV (which WebCrypto lacks anyway).
+//
+//  • The nonce is derived WITH THE KEY (HMAC keyed by blobKey), so a keyless
+//    party (e.g. the storage server) cannot compute the nonce, cannot confirm a
+//    guessed plaintext, and cannot link/learn anything from the stored blob.
+//    Addressing by the SHA-256 of the ciphertext leaks nothing to a keyless
+//    server — it is the hash of pseudorandom bytes.
+//
+//  • We derive the NONCE from content, never the KEY. (Deriving the key from
+//    content would be "convergent encryption" — weak, brute-forceable for
+//    low-entropy plaintext. The key stays secret, derived from the vault root.)
+//
+// -----------------------------------------------------------------------------
+// KEY DERIVATION — on the record, domain-separated (quote for §deriveBlobKey)
+// -----------------------------------------------------------------------------
+//   Root key source: loadIntentsRootKey() — the same per-account vault root key
+//     the sync/intents path uses (PBKDF2(syncPassphrase, /salt/:accountId) →
+//     HKDF base CryptoKey, non-extractable, usages ["deriveKey"]). We reach it
+//     through that existing cached/IDB-backed store; we never re-derive it here.
+//   Blob key:  HKDF-SHA256(ikm = rootKey, salt = "" , info = "glance-blob-v1")
+//     → 32 bytes, imported as both the AES-256-GCM key and the HMAC-SHA256 key.
+//
+//   Domain separation (same root, separate domains — no two can collide):
+//     sync     : HKDF info "glance-sync:entity:<id>"
+//     intents  : HKDF info "glance-intents-envelope-v1"
+//     blobs    : HKDF info "glance-blob-v1"   ← this module
+//
+// =============================================================================
+
+import { loadIntentsRootKey } from '../lib/intentsKeyStore.js'
+
+/** AES-GCM nonce length, in bytes. The stored blob is [nonce || ciphertext]. */
+export const NONCE_LENGTH = 12
+
+/** HKDF `info` string that domain-separates the blob key from sync and intents. */
+export const HKDF_INFO_BLOB = 'glance-blob-v1'
+
+/**
+ * Raised when the vault root key is not available, so a blob cannot be
+ * encrypted or decrypted. This is a CLEAR, TYPED signal — never a silent
+ * no-op and never a plaintext fallback. Callers (in a later step) treat it the
+ * way the intents path treats a missing key: a transient hold/retry condition
+ * that resolves once vault key setup/restore completes.
+ */
+export class BlobKeyUnavailableError extends Error {
+  constructor(message = 'blob key not available (vault root key not set up on this device)') {
+    super(message)
+    this.name = 'BlobKeyUnavailableError'
+  }
+}
+
+/** The derived blob key, materialised as the two WebCrypto keys we need. */
+export interface BlobKey {
+  /** AES-256-GCM key for encrypt/decrypt. */
+  aesKey: CryptoKey
+  /** HMAC-SHA256 key for the content-derived nonce (same key bytes as `aesKey`). */
+  hmacKey: CryptoKey
+}
+
+/** A source of the vault root key: resolves to the key, or null if unavailable. */
+export type RootKeyProvider = () => Promise<CryptoKey | null>
+
+/** Plaintext accepted for encryption (binary blob data). */
+export type Plaintext = Uint8Array | ArrayBuffer
+
+const textEncoder = new TextEncoder()
+
+function toBytes(data: Plaintext): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data)
+}
+
+/**
+ * Derive the blob key from the vault root key via HKDF with info
+ * "glance-blob-v1" (see the KEY DERIVATION block above). The root key is a
+ * non-extractable HKDF base key whose only usage is "deriveKey", so we derive an
+ * extractable 256-bit key, export its raw bytes, and re-import those same bytes
+ * as BOTH the AES-256-GCM key and the HMAC-SHA256 key — i.e. one blob key used
+ * for both encryption and the keyed nonce, exactly as the construction requires.
+ *
+ * @param getRootKey  Source of the root key (default: the vault intents store).
+ *                    Injectable so this module stays decoupled and testable.
+ * @returns the BlobKey, or `null` if the root key is not available.
+ */
+export async function deriveBlobKey(
+  getRootKey: RootKeyProvider = loadIntentsRootKey,
+): Promise<BlobKey | null> {
+  const rootKey = await getRootKey()
+  if (!rootKey) return null
+
+  // HKDF-SHA256 over the root key, domain-separated by info "glance-blob-v1".
+  // Empty salt is intentional: the per-domain info string is the separator, and
+  // the root key is already high-entropy keying material (RFC 5869 §3.1).
+  const derived = await crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0),
+      info: textEncoder.encode(HKDF_INFO_BLOB),
+    },
+    rootKey,
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true, // extractable: we re-import the same bytes as AES-GCM + HMAC
+    ['sign'],
+  )
+
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', derived))
+  const [aesKey, hmacKey] = await Promise.all([
+    crypto.subtle.importKey('raw', raw, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']),
+    crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']),
+  ])
+  return { aesKey, hmacKey }
+}
+
+/** SHA-256 of `bytes`, lowercase hex. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
+  let hex = ''
+  for (const b of digest) hex += b.toString(16).padStart(2, '0')
+  return hex
+}
+
+/**
+ * Encrypt a blob deterministically and compute its content address.
+ *
+ * @param plaintext   The blob bytes.
+ * @param getRootKey  Root key source (default: the vault intents store).
+ * @returns `{ bytes, hash }` where `bytes` is the stored form [nonce || ciphertext]
+ *          and `hash` is SHA-256(bytes) hex — the server-visible content address.
+ * @throws  {BlobKeyUnavailableError} if the root key is unavailable. NEVER falls
+ *          back to plaintext.
+ */
+export async function encryptBlob(
+  plaintext: Plaintext,
+  getRootKey: RootKeyProvider = loadIntentsRootKey,
+): Promise<{ bytes: Uint8Array; hash: string }> {
+  const blobKey = await deriveBlobKey(getRootKey)
+  if (!blobKey) throw new BlobKeyUnavailableError()
+
+  const pt = toBytes(plaintext)
+
+  // Content-derived nonce: HMAC-SHA256(blobKey, plaintext) truncated to 12 bytes.
+  // Deterministic in (key, plaintext); unpredictable without the key.
+  const mac = new Uint8Array(await crypto.subtle.sign('HMAC', blobKey.hmacKey, pt))
+  const nonce = mac.slice(0, NONCE_LENGTH)
+
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, blobKey.aesKey, pt),
+  )
+
+  // Stored form: [nonce || ciphertext+tag].
+  const bytes = new Uint8Array(NONCE_LENGTH + ciphertext.length)
+  bytes.set(nonce, 0)
+  bytes.set(ciphertext, NONCE_LENGTH)
+
+  const hash = await sha256Hex(bytes)
+  return { bytes, hash }
+}
+
+/**
+ * Decrypt a stored blob.
+ *
+ * @param stored      The stored bytes [nonce || ciphertext], as produced by
+ *                    {@link encryptBlob}.
+ * @param getRootKey  Root key source (default: the vault intents store).
+ * @returns the recovered plaintext bytes.
+ * @throws  {BlobKeyUnavailableError} if the root key is unavailable.
+ * @throws  if the blob has been tampered with (AES-GCM tag verification fails)
+ *          or is malformed.
+ */
+export async function decryptBlob(
+  stored: Uint8Array,
+  getRootKey: RootKeyProvider = loadIntentsRootKey,
+): Promise<Uint8Array> {
+  const blobKey = await deriveBlobKey(getRootKey)
+  if (!blobKey) throw new BlobKeyUnavailableError()
+
+  if (stored.length < NONCE_LENGTH) {
+    throw new Error('malformed blob: shorter than the nonce length')
+  }
+  const nonce = stored.slice(0, NONCE_LENGTH)
+  const ciphertext = stored.slice(NONCE_LENGTH)
+
+  // GCM tag verification happens inside decrypt: a tampered blob throws here.
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: nonce },
+    blobKey.aesKey,
+    ciphertext,
+  )
+  return new Uint8Array(plaintext)
+}


### PR DESCRIPTION
## Summary

First of three stacked PRs building the lifeGLANCE client-side blob pipeline (Phase 7). This step adds the **crypto core** only — a self-contained, crypto-only module. No transfer/upload, no thumbnails, no milestone wiring (those are the next PRs).

A blob is addressed by the hash of its **ciphertext**, and encryption is **deterministic**, so identical plaintext under the same key produces identical ciphertext — hence the same address, hence dedup + idempotent upload.

### The construction
- **Key**: `HKDF(vault root key, info "glance-blob-v1")` — domain-separated from sync (`glance-sync:entity:<id>`) and intents (`glance-intents-envelope-v1`). The root key is reached the same way the intents path reaches it (`loadIntentsRootKey`), and encryption **never** falls back to plaintext when the key is absent.
- **Nonce**: `HMAC-SHA256(blobKey, plaintext)` truncated to 12 bytes — content-derived (so encryption is deterministic) and keyed (so a keyless server can't compute or confirm it).
- **Encrypt**: `AES-256-GCM(blobKey, nonce, plaintext)`; stored form is `[nonce(12) || ciphertext+tag]`.
- **Address**: `SHA-256(stored bytes)`, hex.
- **Decrypt**: split the nonce, AES-GCM-decrypt; the GCM tag verifies integrity.

The module carries a **safety-argument comment block** explaining why deterministic content-derived-nonce GCM is safe here (a nonce repeats only when the whole message is byte-identical, so there's nothing to leak) and why AES-GCM-SIV is unnecessary — so a future reader doesn't "simplify" it into a vulnerability. The exact byte layout and the key-derivation (root-key source + HKDF info) are documented on the record.

When the key is unavailable, `encryptBlob`/`decryptBlob` throw a typed `BlobKeyUnavailableError` — a clear hold/retry signal, never a silent no-op or plaintext fallback.

## Files
- `src/blobs/blobCrypto.ts` — `deriveBlobKey`, `encryptBlob(plaintext) → { bytes, hash }`, `decryptBlob(bytes) → plaintext`, `BlobKeyUnavailableError`. The root-key source is injectable so the module stays decoupled and can be lifted into a shared package later.
- `src/blobs/blobCrypto.test.ts` companion → `src/blobs/blobCrypto.test.js` (18 tests).

## Tests
Proven against the genuine root-key shape (a non-extractable HKDF base key with only `deriveKey` usage): (a) determinism — same plaintext → byte-identical ciphertext + same hash; (b) distinct plaintexts → different nonces + hashes; (c) round-trip for small/empty/3 MB/ArrayBuffer inputs; (d) GCM tamper-detection; (e) `hash === SHA-256(stored bytes)`; (f) key-unavailable throws the typed signal and never produces plaintext.

Full suite and `npm run build` pass. (The two pre-existing `dates.test.js` timezone failures are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_