### PR TITLE
Blob thumbnail/poster generation (Phase 7, client step 3)

### DIFF
--- a/src/blobs/thumbnail.test.js
+++ b/src/blobs/thumbnail.test.js
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateThumbnail,
+  fitWithin,
+  sourceKind,
+  ThumbnailGenerationError,
+  MAX_THUMBNAIL_EDGE,
+  DEFAULT_OUTPUT_MIME,
+  POSTER_FRAME_TIME_SECONDS,
+} from './thumbnail.ts'
+
+// =============================================================================
+// TEST ENVIRONMENT NOTE
+//
+// The REAL image-processing primitive (browserImageProcessor) uses webview canvas
+// APIs — createImageBitmap, OffscreenCanvas, a <video> element + frame grab. Those
+// do NOT exist in the vitest 'node' environment (no canvas, no DOM video), so they
+// are exercised IN-APP, not here. Per the module's injectable design, these tests
+// supply a FAKE ImageProcessor that records its calls and produces deterministic
+// bytes, letting us assert the generation logic (kind routing, downscale bounds,
+// poster-frame path, clean typed failure, plaintext output) without any canvas.
+// =============================================================================
+
+// A fake source "blob": 4-byte big-endian width/height header + a marker.
+function fakeSource(width, height, marker = 'ok') {
+  const head = new Uint8Array([
+    (width >> 8) & 0xff, width & 0xff,
+    (height >> 8) & 0xff, height & 0xff,
+  ])
+  const tail = new TextEncoder().encode(marker)
+  const out = new Uint8Array(head.length + tail.length)
+  out.set(head, 0)
+  out.set(tail, head.length)
+  return out
+}
+
+function readDims(bytes) {
+  if (bytes.length < 4) throw new Error('fake decode: too short')
+  const width = (bytes[0] << 8) | bytes[1]
+  const height = (bytes[2] << 8) | bytes[3]
+  if (width === 0 || height === 0) throw new Error('fake decode: corrupt (zero dims)')
+  return { width, height }
+}
+
+// Fake-encoded output: a 4-byte target-dims header + an ASCII tag for the mime.
+// This lets a test read the encoded thumbnail's dimensions straight out of the
+// returned bytes (proving the size bound from the real output, not just a spy).
+function fakeEncodedBytes(targetWidth, targetHeight, mimeType) {
+  const head = new Uint8Array([
+    (targetWidth >> 8) & 0xff, targetWidth & 0xff,
+    (targetHeight >> 8) & 0xff, targetHeight & 0xff,
+  ])
+  const tag = new TextEncoder().encode(`ENC:${mimeType}`)
+  const out = new Uint8Array(head.length + tag.length)
+  out.set(head, 0)
+  out.set(tag, head.length)
+  return out
+}
+
+function readEncodedDims(bytes) {
+  return { width: (bytes[0] << 8) | bytes[1], height: (bytes[2] << 8) | bytes[3] }
+}
+
+// A recording fake ImageProcessor. `behavior` lets a test force decode/encode
+// failures to exercise the clean-failure path.
+function makeFakeProcessor(behavior = {}) {
+  const calls = {
+    decodeImage: 0,
+    decodeVideoFrame: 0,
+    encode: 0,
+    lastEncode: null,
+    lastPosterTime: null,
+  }
+  const processor = {
+    async decodeImage(bytes) {
+      calls.decodeImage++
+      if (behavior.decodeThrows) throw new Error('fake decode failure')
+      return { ...readDims(bytes), source: { kind: 'image-bitmap' } }
+    },
+    async decodeVideoFrame(bytes, _mime, atSeconds) {
+      calls.decodeVideoFrame++
+      calls.lastPosterTime = atSeconds
+      if (behavior.decodeThrows) throw new Error('fake video decode failure')
+      return { ...readDims(bytes), source: { kind: 'video-frame' } }
+    },
+    async encode(image, targetWidth, targetHeight, mimeType, quality) {
+      calls.encode++
+      calls.lastEncode = { targetWidth, targetHeight, mimeType, quality, source: image.source }
+      if (behavior.encodeThrows) throw new Error('fake encode failure')
+      if (behavior.encodeEmpty) return new Uint8Array(0)
+      return fakeEncodedBytes(targetWidth, targetHeight, mimeType)
+    },
+  }
+  return { processor, calls }
+}
+
+describe('thumbnail — sourceKind', () => {
+  it('classifies image and video mime types, rejects the rest', () => {
+    expect(sourceKind('image/jpeg')).toBe('image')
+    expect(sourceKind('image/png')).toBe('image')
+    expect(sourceKind('video/mp4')).toBe('video')
+    expect(sourceKind('VIDEO/QUICKTIME')).toBe('video')
+    expect(sourceKind('application/pdf')).toBeNull()
+    expect(sourceKind('')).toBeNull()
+    expect(sourceKind(undefined)).toBeNull()
+  })
+})
+
+describe('thumbnail — fitWithin (pure downscale math)', () => {
+  it('downscales the longest edge to the bound, preserving aspect ratio', () => {
+    expect(fitWithin(2000, 1000, 512)).toEqual({ width: 512, height: 256 })
+    expect(fitWithin(1000, 2000, 512)).toEqual({ width: 256, height: 512 })
+    expect(fitWithin(1024, 1024, 512)).toEqual({ width: 512, height: 512 })
+  })
+
+  it('never upscales a source already within the bound', () => {
+    expect(fitWithin(100, 80, 512)).toEqual({ width: 100, height: 80 })
+    expect(fitWithin(512, 300, 512)).toEqual({ width: 512, height: 300 })
+  })
+})
+
+describe('thumbnail — image source', () => {
+  it('produces downscaled bytes within the size bound, aspect preserved', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const src = fakeSource(2000, 1000) // 2:1, larger than the bound
+
+    const out = await generateThumbnail(src, 'image/jpeg', { processor })
+
+    // Routed to the image decoder (not the video path).
+    expect(calls.decodeImage).toBe(1)
+    expect(calls.decodeVideoFrame).toBe(0)
+
+    // Downscaled to the longest-edge bound, aspect preserved.
+    expect(calls.lastEncode.targetWidth).toBe(512)
+    expect(calls.lastEncode.targetHeight).toBe(256)
+    expect(Math.max(calls.lastEncode.targetWidth, calls.lastEncode.targetHeight))
+      .toBeLessThanOrEqual(MAX_THUMBNAIL_EDGE)
+
+    // Output mime + dimensions read back from the ACTUAL returned bytes.
+    expect(out.mimeType).toBe(DEFAULT_OUTPUT_MIME)
+    const dims = readEncodedDims(out.bytes)
+    expect(dims).toEqual({ width: 512, height: 256 })
+    expect(Math.max(dims.width, dims.height)).toBeLessThanOrEqual(MAX_THUMBNAIL_EDGE)
+  })
+
+  it('does not upscale a small image', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(120, 90), 'image/png', { processor })
+    expect(calls.lastEncode.targetWidth).toBe(120)
+    expect(calls.lastEncode.targetHeight).toBe(90)
+    expect(readEncodedDims(out.bytes)).toEqual({ width: 120, height: 90 })
+  })
+
+  it('honors a custom maxEdge and output mime', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(800, 400), 'image/jpeg', {
+      processor,
+      maxEdge: 256,
+      outputMimeType: 'image/webp',
+    })
+    expect(calls.lastEncode.targetWidth).toBe(256)
+    expect(calls.lastEncode.targetHeight).toBe(128)
+    expect(out.mimeType).toBe('image/webp')
+  })
+})
+
+describe('thumbnail — video source (poster frame)', () => {
+  it('grabs a poster frame and downscales it to an image', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const src = fakeSource(1920, 1080) // 16:9 video
+
+    const out = await generateThumbnail(src, 'video/mp4', { processor })
+
+    // Routed to the video poster path, at the default poster timestamp.
+    expect(calls.decodeVideoFrame).toBe(1)
+    expect(calls.decodeImage).toBe(0)
+    expect(calls.lastPosterTime).toBe(POSTER_FRAME_TIME_SECONDS)
+    expect(calls.lastEncode.source).toEqual({ kind: 'video-frame' })
+
+    // Poster frame downscaled to the bound, output is a still image.
+    expect(calls.lastEncode.targetWidth).toBe(512)
+    expect(calls.lastEncode.targetHeight).toBe(288)
+    expect(out.mimeType).toBe(DEFAULT_OUTPUT_MIME) // an image, not a video
+    expect(readEncodedDims(out.bytes)).toEqual({ width: 512, height: 288 })
+  })
+
+  it('honors a custom poster timestamp', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    await generateThumbnail(fakeSource(640, 480), 'video/webm', {
+      processor,
+      posterTimeSeconds: 3.5,
+    })
+    expect(calls.lastPosterTime).toBe(3.5)
+  })
+})
+
+describe('thumbnail — clean failure (ThumbnailGenerationError, no partial output)', () => {
+  it('throws on an unsupported source type WITHOUT invoking the processor', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    await expect(generateThumbnail(fakeSource(10, 10), 'application/pdf', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.decodeImage).toBe(0)
+    expect(calls.decodeVideoFrame).toBe(0)
+    expect(calls.encode).toBe(0)
+  })
+
+  it('throws on empty source bytes', async () => {
+    const { processor } = makeFakeProcessor()
+    await expect(generateThumbnail(new Uint8Array(0), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('throws (and never encodes) when the decoder fails on a corrupt source', async () => {
+    const { processor, calls } = makeFakeProcessor({ decodeThrows: true })
+    await expect(generateThumbnail(fakeSource(100, 100), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.encode).toBe(0) // no partial output — it failed before encoding
+  })
+
+  it('throws when the decoder reports zero/garbage dimensions', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    // A header of 0x0 makes the fake decoder treat the source as corrupt.
+    await expect(generateThumbnail(fakeSource(0, 0), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.encode).toBe(0)
+  })
+
+  it('throws when the encoder fails', async () => {
+    const { processor } = makeFakeProcessor({ encodeThrows: true })
+    await expect(generateThumbnail(fakeSource(800, 600), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('throws when the encoder produces no bytes', async () => {
+    const { processor } = makeFakeProcessor({ encodeEmpty: true })
+    await expect(generateThumbnail(fakeSource(800, 600), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('wraps the underlying failure as the cause', async () => {
+    const { processor } = makeFakeProcessor({ decodeThrows: true })
+    const err = await generateThumbnail(fakeSource(100, 100), 'image/jpeg', { processor })
+      .then(() => null, (e) => e)
+    expect(err).toBeInstanceOf(ThumbnailGenerationError)
+    expect(err.cause).toBeInstanceOf(Error)
+  })
+})
+
+describe('thumbnail — output is plaintext bytes ready for the upload path', () => {
+  it('returns exactly the processor-produced image bytes (not encrypted/transformed)', async () => {
+    const { processor } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(1000, 500), 'image/jpeg', { processor })
+
+    // The returned bytes are precisely what the image processor produced — this
+    // module performs no encryption/addressing. (Encryption + content-addressing
+    // happen later, when these bytes go through blobTransport.uploadBlob.)
+    const expected = fakeEncodedBytes(512, 256, 'image/jpeg')
+    expect([...out.bytes]).toEqual([...expected])
+    expect(out.bytes).toBeInstanceOf(Uint8Array)
+    expect(typeof out.mimeType).toBe('string')
+  })
+})

--- a/src/blobs/thumbnail.ts
+++ b/src/blobs/thumbnail.ts
@@ -1,0 +1,303 @@
+// =============================================================================
+// thumbnail — blob thumbnail / poster generation (Phase 7, client step 3)
+// =============================================================================
+//
+// Produces a thumbnail as its OWN plaintext image bytes, ready to hand to the
+// blob upload path (blobTransport.uploadBlob), which encrypts + content-addresses
+// them like any blob. Per the spec, a thumbnail is CONTENT, not a per-device
+// derivative: the uploading device generates it ONCE at upload time, and it then
+// becomes its own content-addressed, encrypted blob — synced and cached like any
+// other content, never regenerated per device.
+//
+// THIS MODULE GENERATES BYTES ONLY. It does NOT encrypt, address, or upload (that
+// is blobCrypto/blobTransport's job), and it does NOT touch milestones or the
+// upload flow (that is the next wiring step). It has no UI, sync, milestone, or
+// crypto imports, so — like the other blob modules — it can be lifted into a
+// shared `@glance-apps/*` package later. (FUTURE: extract.)
+//
+// ENVIRONMENT: this runs on-device in a webview (browser / Capacitor), NOT in
+// Node. Images are downscaled/re-encoded with createImageBitmap + OffscreenCanvas;
+// video poster frames are grabbed with a <video> element + canvas. Those
+// primitives don't exist in jsdom/node, so the image-processing primitive is an
+// INJECTABLE dependency (`ImageProcessor`) — mirroring how blobCrypto/blobTransport
+// made their root-key/connection/fetch dependencies injectable. The real,
+// browser-backed processor (`browserImageProcessor`) is the default and is
+// exercised IN-APP; tests inject a fake processor (see thumbnail.test.js).
+//
+// FAIL CLEANLY (load-bearing): if the source is corrupt, an unsupported format,
+// or generation otherwise fails, this throws a typed `ThumbnailGenerationError`
+// and returns NOTHING — no partial bytes. The caller (the milestone upload flow,
+// next step) must treat that as a failed upload and NOT publish a milestone that
+// references a thumbnail which was never made. This module only throws the clean
+// typed error; it does not itself touch milestones.
+// =============================================================================
+
+/** Longest-edge bound (px) for a generated thumbnail. Aspect ratio is preserved. */
+export const MAX_THUMBNAIL_EDGE = 512
+
+/** Default output encoding for the thumbnail bytes. */
+export const DEFAULT_OUTPUT_MIME = 'image/jpeg'
+
+/** Default lossy-encode quality (0..1) for the thumbnail. */
+export const DEFAULT_QUALITY = 0.8
+
+/** Default timestamp (seconds) to grab a video poster frame from. */
+export const POSTER_FRAME_TIME_SECONDS = 1
+
+/**
+ * Thrown when a thumbnail cannot be produced (corrupt/unsupported source, or any
+ * decode/encode failure). A clean, typed failure with NO partial output — the
+ * caller treats it as a failed upload and publishes nothing referencing a
+ * thumbnail that was never made.
+ */
+export class ThumbnailGenerationError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'ThumbnailGenerationError'
+  }
+}
+
+/** A decoded raster image: its pixel dimensions plus an opaque drawable source. */
+export interface RasterImage {
+  width: number
+  height: number
+  /** Opaque handle the processor's own `encode` knows how to draw (e.g. ImageBitmap). */
+  source: unknown
+}
+
+/**
+ * The platform image-processing primitive. The real implementation uses browser
+ * canvas APIs; tests inject a fake. Kept tiny and side-effect-explicit so it can
+ * be swapped per platform.
+ */
+export interface ImageProcessor {
+  /** Decode still-image bytes into a drawable raster (with dimensions). */
+  decodeImage(bytes: Uint8Array, mimeType: string): Promise<RasterImage>
+  /** Grab a poster frame from video bytes at ~`atSeconds` into a drawable raster. */
+  decodeVideoFrame(bytes: Uint8Array, mimeType: string, atSeconds: number): Promise<RasterImage>
+  /** Downscale `image` to `targetWidth`×`targetHeight` and encode to `mimeType` bytes. */
+  encode(
+    image: RasterImage,
+    targetWidth: number,
+    targetHeight: number,
+    mimeType: string,
+    quality: number,
+  ): Promise<Uint8Array>
+}
+
+/** Options for {@link generateThumbnail}. All optional; sensible defaults apply. */
+export interface ThumbnailOptions {
+  /** Image-processing primitive. Defaults to the browser-backed processor. */
+  processor?: ImageProcessor
+  /** Longest-edge bound in px. Defaults to {@link MAX_THUMBNAIL_EDGE}. */
+  maxEdge?: number
+  /** Output mime type. Defaults to {@link DEFAULT_OUTPUT_MIME}. */
+  outputMimeType?: string
+  /** Encode quality 0..1. Defaults to {@link DEFAULT_QUALITY}. */
+  quality?: number
+  /** Video poster timestamp (s). Defaults to {@link POSTER_FRAME_TIME_SECONDS}. */
+  posterTimeSeconds?: number
+}
+
+export type SourceKind = 'image' | 'video'
+
+/** Classify a source mime type. Returns null for anything we can't thumbnail. */
+export function sourceKind(mimeType: string | undefined | null): SourceKind | null {
+  if (typeof mimeType !== 'string') return null
+  const m = mimeType.toLowerCase().trim()
+  if (m.startsWith('image/')) return 'image'
+  if (m.startsWith('video/')) return 'video'
+  return null
+}
+
+function isPositiveInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+/**
+ * Fit `(width, height)` within a `maxEdge` longest-edge bound, preserving aspect
+ * ratio. Never upscales: a source already within the bound is returned unchanged.
+ * Pure — no platform dependency — so it's directly testable.
+ */
+export function fitWithin(
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } {
+  const longest = Math.max(width, height)
+  if (longest <= maxEdge) return { width, height }
+  const scale = maxEdge / longest
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+/**
+ * Generate a thumbnail / poster image from a source blob's bytes.
+ *
+ * - IMAGE source: decode → downscale to {@link MAX_THUMBNAIL_EDGE} (longest edge,
+ *   aspect preserved) → re-encode → bytes.
+ * - VIDEO source: grab a poster frame (~`posterTimeSeconds`) → downscale the same
+ *   way → encode → bytes. (A static poster is the required minimum; a short
+ *   preview clip is an optional future addition.)
+ *
+ * Returns the thumbnail's RAW PLAINTEXT image bytes plus their mime type. It does
+ * NOT encrypt, address, or upload — hand the result to blobTransport.uploadBlob,
+ * which encrypts + content-addresses it like any blob.
+ *
+ * @throws {ThumbnailGenerationError} on unsupported/corrupt source or any
+ *         decode/encode failure — cleanly, with no partial output.
+ */
+export async function generateThumbnail(
+  sourceBytes: Uint8Array,
+  mimeType: string,
+  opts: ThumbnailOptions = {},
+): Promise<{ bytes: Uint8Array; mimeType: string }> {
+  const processor = opts.processor ?? browserImageProcessor
+  const maxEdge = opts.maxEdge ?? MAX_THUMBNAIL_EDGE
+  const outputMimeType = opts.outputMimeType ?? DEFAULT_OUTPUT_MIME
+  const quality = opts.quality ?? DEFAULT_QUALITY
+  const posterTime = opts.posterTimeSeconds ?? POSTER_FRAME_TIME_SECONDS
+
+  if (!(sourceBytes instanceof Uint8Array) || sourceBytes.length === 0) {
+    throw new ThumbnailGenerationError('source bytes are empty or not a Uint8Array')
+  }
+
+  const kind = sourceKind(mimeType)
+  if (!kind) {
+    throw new ThumbnailGenerationError(`unsupported source type: ${mimeType || '(none)'}`)
+  }
+
+  // Decode (platform). A corrupt or undecodable source surfaces here.
+  let decoded: RasterImage
+  try {
+    decoded =
+      kind === 'video'
+        ? await processor.decodeVideoFrame(sourceBytes, mimeType, posterTime)
+        : await processor.decodeImage(sourceBytes, mimeType)
+  } catch (err) {
+    throw new ThumbnailGenerationError(`failed to decode ${kind} source`, { cause: err })
+  }
+  if (!decoded || !isPositiveInt(decoded.width) || !isPositiveInt(decoded.height)) {
+    throw new ThumbnailGenerationError('decoder returned invalid dimensions')
+  }
+
+  const target = fitWithin(decoded.width, decoded.height, maxEdge)
+
+  // Downscale + encode (platform).
+  let bytes: Uint8Array
+  try {
+    bytes = await processor.encode(decoded, target.width, target.height, outputMimeType, quality)
+  } catch (err) {
+    throw new ThumbnailGenerationError('failed to encode thumbnail', { cause: err })
+  }
+  if (!(bytes instanceof Uint8Array) || bytes.length === 0) {
+    throw new ThumbnailGenerationError('encoder produced no bytes')
+  }
+
+  return { bytes, mimeType: outputMimeType }
+}
+
+// =============================================================================
+// browserImageProcessor — the real, on-device primitive (NOT run in tests)
+// -----------------------------------------------------------------------------
+// Uses webview canvas APIs. None of these globals are touched at import time
+// (every reference is inside a method), so importing this module under jsdom/node
+// is safe; the methods themselves only run in-app, where tests inject a fake.
+// =============================================================================
+
+function requireGlobal<T>(name: string): T {
+  const g = (globalThis as any)[name]
+  if (g == null) throw new Error(`thumbnail: ${name} is not available in this environment`)
+  return g as T
+}
+
+async function decodeWith(createBitmap: () => Promise<any>): Promise<RasterImage> {
+  const bitmap = await createBitmap()
+  return { width: bitmap.width, height: bitmap.height, source: bitmap }
+}
+
+export const browserImageProcessor: ImageProcessor = {
+  async decodeImage(bytes, mimeType) {
+    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
+    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    return decodeWith(() => createImageBitmap(blob))
+  },
+
+  async decodeVideoFrame(bytes, mimeType, atSeconds) {
+    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
+    const doc = requireGlobal<any>('document')
+    const URLg = requireGlobal<any>('URL')
+    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    const url = URLg.createObjectURL(blob)
+    const video: any = doc.createElement('video')
+    video.muted = true
+    video.preload = 'auto'
+    video.playsInline = true
+    try {
+      video.src = url
+      await onceEvent(video, 'loadedmetadata')
+      const duration = Number.isFinite(video.duration) ? video.duration : atSeconds
+      const seekTo = Math.min(atSeconds, Math.max(0, duration))
+      await seekVideo(video, Number.isFinite(seekTo) ? seekTo : 0)
+      const frame = await createImageBitmap(video)
+      return {
+        width: frame.width || video.videoWidth,
+        height: frame.height || video.videoHeight,
+        source: frame,
+      }
+    } finally {
+      URLg.revokeObjectURL(url)
+    }
+  },
+
+  async encode(image, targetWidth, targetHeight, mimeType, quality) {
+    const OffscreenCanvasG = requireGlobal<any>('OffscreenCanvas')
+    const canvas = new OffscreenCanvasG(targetWidth, targetHeight)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('thumbnail: could not get a 2d canvas context')
+    ctx.drawImage(image.source as any, 0, 0, targetWidth, targetHeight)
+    const blob = await canvas.convertToBlob({ type: mimeType, quality })
+    return new Uint8Array(await blob.arrayBuffer())
+  },
+}
+
+function onceEvent(target: any, name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onOk = () => {
+      cleanup()
+      resolve()
+    }
+    const onErr = () => {
+      cleanup()
+      reject(new Error(`thumbnail: <video> emitted "error" waiting for "${name}"`))
+    }
+    const cleanup = () => {
+      target.removeEventListener(name, onOk)
+      target.removeEventListener('error', onErr)
+    }
+    target.addEventListener(name, onOk, { once: true })
+    target.addEventListener('error', onErr, { once: true })
+  })
+}
+
+function seekVideo(video: any, seconds: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onSeeked = () => {
+      cleanup()
+      resolve()
+    }
+    const onErr = () => {
+      cleanup()
+      reject(new Error('thumbnail: <video> errored while seeking'))
+    }
+    const cleanup = () => {
+      video.removeEventListener('seeked', onSeeked)
+      video.removeEventListener('error', onErr)
+    }
+    video.addEventListener('seeked', onSeeked, { once: true })
+    video.addEventListener('error', onErr, { once: true })
+    video.currentTime = seconds
+  })
+}


### PR DESCRIPTION
## Summary

Third of three stacked PRs for the Phase 7 blob pipeline. **Targets the transport branch** (`claude/blob-transport-client-53f0id`) so its diff is scoped to just thumbnail generation — review/merge steps 1 and 2 first.

Produces a thumbnail as its own **raw plaintext image bytes**, ready to hand to `blobTransport.uploadBlob` (which encrypts + content-addresses them like any blob). Per spec, a thumbnail is **content, not a per-device derivative**: generated once at upload time, then synced/cached as its own content-addressed blob. No milestone wiring, no upload flow (next step); no encryption/addressing here.

### What it does
- **`generateThumbnail(sourceBytes, mimeType, opts?) → { bytes, mimeType }`**:
  - **Image**: decode → downscale to `MAX_THUMBNAIL_EDGE` (512px longest edge, aspect preserved, never upscaled) → re-encode.
  - **Video**: grab a poster frame (~`POSTER_FRAME_TIME_SECONDS`) → downscale the same way → encode a still image. A static poster is the implemented minimum; a preview clip is noted as an optional future addition.
- **Fails cleanly**: unsupported/corrupt source or any decode/encode failure throws a typed **`ThumbnailGenerationError`** with **no partial output**, so the caller never publishes a milestone referencing a thumbnail that was never made.
- **Webview-native, injectable**: runs on-device (browser/Capacitor), not Node. The image-processing primitive is an injectable `ImageProcessor`; the default `browserImageProcessor` uses `createImageBitmap` + `OffscreenCanvas` for images and a `<video>` + canvas frame-grab for video posters, and touches no DOM globals at import time. No sharp / Node image lib.
- Self-contained (no milestone/UI/sync/crypto imports), ready for shared-package extraction. The pure `fitWithin()` downscale math is exported and directly tested.

## Tests
The real canvas/video primitives are exercised **in-app, not in the test env** (vitest `node` has no canvas), so the tests inject a recording fake `ImageProcessor`. 16 tests cover: a valid image downscaled within the size bound with aspect preserved (dims read back from the actual returned bytes); the video poster-frame path; small images not upscaled; custom maxEdge/mime/poster-time; clean typed failure with no partial output across unsupported type (processor never invoked), empty source, decoder failure, garbage dims, and encoder failure/empty output (cause preserved); and that the output is exactly the processor-produced plaintext bytes (not encrypted/transformed).

## Files
- `src/blobs/thumbnail.ts`
- `src/blobs/thumbnail.test.js` (16 tests)

Full suite and `npm run build` pass. (The two pre-existing `dates.test.js` timezone failures are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_