### PR TITLE
Land blob transport + thumbnail on main (Phase 7, steps 2 & 3)

### DIFF
--- a/src/blobs/blobTransport.test.js
+++ b/src/blobs/blobTransport.test.js
@@ -1,0 +1,458 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { encryptBlob } from './blobCrypto.ts'
+import {
+  uploadBlob,
+  downloadBlob,
+  downloadBlobBytes,
+  blobExists,
+  addBlobRef,
+  releaseBlobRef,
+  readVaultConnection,
+  VaultConnectionUnavailableError,
+  BlobHashMismatchError,
+} from './blobTransport.ts'
+import { BlobKeyUnavailableError } from './blobCrypto.ts'
+
+// =============================================================================
+// END-TO-END / SEAM NOTE
+//
+// The end-to-end test runs against an IN-PROCESS CONTRACT MOCK of the
+// glance-vault blob server (no real server is available in this repo — see
+// src/sync/status.js: the GLANCEvault transport is "inert until cutover"). The
+// mock is high-fidelity to the exact endpoint contract AND — this is the point —
+// its finalize handler hashes the reassembled part bytes the SAME way the crypto
+// core computes a blob's address: SHA-256(nonce || ciphertext), lowercase hex
+// (see `sha256Hex` below, identical to blobCrypto's addressing). So finalize only
+// accepts when the server's hash of the bytes it reassembled equals the hash the
+// client declared — exactly the seam the real server enforces. A round-trip that
+// finalizes + downloads + decrypts back to the original byte-for-byte is therefore
+// real proof that the bytes the client hashes/uploads equal the bytes the server
+// hashes on finalize.
+// =============================================================================
+
+const VAULT_URL = 'https://vault.test'
+const TOKEN = 'device-token-abc'
+const ACCOUNT = 'account-123'
+
+let rootKey
+let provideKey
+let provideNull
+
+beforeEach(async () => {
+  const rootBits = crypto.getRandomValues(new Uint8Array(32))
+  rootKey = await crypto.subtle.importKey('raw', rootBits, 'HKDF', false, ['deriveKey'])
+  provideKey = async () => rootKey
+  provideNull = async () => null
+})
+
+const enc = (s) => new TextEncoder().encode(s)
+
+function randomBytes(n) {
+  const out = new Uint8Array(n)
+  for (let off = 0; off < n; off += 65536) {
+    crypto.getRandomValues(out.subarray(off, Math.min(off + 65536, n)))
+  }
+  return out
+}
+
+// SHA-256(bytes) -> lowercase hex. IDENTICAL to how blobCrypto addresses a blob,
+// and to how the real glance-vault server hashes reassembled bytes on finalize.
+async function sha256Hex(bytes) {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
+  return [...digest].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// ── In-process contract mock of the glance-vault blob server ─────────────────
+
+function makeVaultServer({ token = TOKEN, accountId = ACCOUNT } = {}) {
+  const blobs = new Map() // hash -> { bytes: Uint8Array, refs: number }
+  const sessions = new Map() // uploadId -> { hash, size, partSize, parts: Map<i, Uint8Array> }
+  const hashToUpload = new Map() // hash -> uploadId (initiate idempotency)
+  let nextId = 1
+
+  const calls = { head: 0, initiate: 0, resume: 0, part: 0, finalize: 0, get: 0, refAdd: 0, refRelease: 0 }
+  const partPuts = [] // every part index actually PUT, in order (proves resume skips)
+  let failPartOnce = null // set to an index to make that PUT fail once
+
+  const jsonRes = (status, obj) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => obj,
+    arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(obj)).buffer,
+  })
+  const binRes = (status, bytes) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    arrayBuffer: async () => new Uint8Array(bytes).buffer,
+    json: async () => { throw new Error('not json') },
+  })
+  const emptyRes = (status) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    arrayBuffer: async () => new ArrayBuffer(0),
+    json: async () => ({}),
+  })
+
+  async function handle(url, init) {
+    const u = new URL(url)
+    const path = u.pathname
+    const method = init.method
+    const qAccount = u.searchParams.get('accountId')
+
+    // Auth seam: every request must carry the device Bearer token.
+    if (init.headers.Authorization !== `Bearer ${token}`) return emptyRes(401)
+
+    const jsonBody = typeof init.body === 'string' ? JSON.parse(init.body) : undefined
+    let m
+
+    // HEAD /blobs/:hash  (account-scoped via query)
+    if (method === 'HEAD' && (m = path.match(/^\/blobs\/([^/]+)$/))) {
+      calls.head++
+      if (qAccount !== accountId) return emptyRes(400)
+      return blobs.has(decodeURIComponent(m[1])) ? emptyRes(200) : emptyRes(404)
+    }
+
+    // GET /blobs/:hash  (download, optional Range)
+    if (method === 'GET' && (m = path.match(/^\/blobs\/([^/]+)$/))) {
+      calls.get++
+      if (qAccount !== accountId) return jsonRes(400, { error: 'accountId required' })
+      const rec = blobs.get(decodeURIComponent(m[1]))
+      if (!rec) return jsonRes(404, { error: 'not_found' })
+      const range = init.headers.Range
+      if (range) {
+        const mr = range.match(/^bytes=(\d+)-(\d*)$/)
+        const start = Number(mr[1])
+        const end = mr[2] === '' ? rec.bytes.length - 1 : Number(mr[2])
+        return binRes(206, rec.bytes.subarray(start, end + 1))
+      }
+      return binRes(200, rec.bytes)
+    }
+
+    // POST /blobs/uploads  (initiate, idempotent on hash; accountId in body)
+    if (method === 'POST' && path === '/blobs/uploads') {
+      calls.initiate++
+      if (jsonBody.accountId !== accountId) return jsonRes(400, { error: 'accountId required' })
+      let uploadId = hashToUpload.get(jsonBody.hash)
+      if (!uploadId) {
+        uploadId = `up-${nextId++}`
+        sessions.set(uploadId, {
+          hash: jsonBody.hash,
+          size: jsonBody.size,
+          partSize: jsonBody.partSize,
+          parts: new Map(),
+        })
+        hashToUpload.set(jsonBody.hash, uploadId)
+      }
+      return jsonRes(200, { uploadId })
+    }
+
+    // GET /blobs/uploads/:id  (resume point)
+    if (method === 'GET' && (m = path.match(/^\/blobs\/uploads\/([^/]+)$/))) {
+      calls.resume++
+      const s = sessions.get(decodeURIComponent(m[1]))
+      if (!s) return jsonRes(404, { error: 'no_session' })
+      return jsonRes(200, {
+        received: [...s.parts.keys()].sort((a, b) => a - b),
+        partSize: s.partSize,
+        size: s.size,
+      })
+    }
+
+    // PUT /blobs/uploads/:id/parts/:i  (one part, raw bytes; accountId in query)
+    if (method === 'PUT' && (m = path.match(/^\/blobs\/uploads\/([^/]+)\/parts\/(\d+)$/))) {
+      calls.part++
+      if (qAccount !== accountId) return jsonRes(400, { error: 'accountId required' })
+      const s = sessions.get(decodeURIComponent(m[1]))
+      if (!s) return jsonRes(404, { error: 'no_session' })
+      const i = Number(m[2])
+      if (failPartOnce === i) {
+        failPartOnce = null
+        return emptyRes(500) // transient server hiccup → client throws, session retained
+      }
+      s.parts.set(i, new Uint8Array(init.body)) // store a copy of the part bytes
+      partPuts.push(i)
+      return jsonRes(200, { received: i })
+    }
+
+    // POST /blobs/uploads/:id/finalize  (reassemble + VERIFY hash + store)
+    if (method === 'POST' && (m = path.match(/^\/blobs\/uploads\/([^/]+)\/finalize$/))) {
+      calls.finalize++
+      const s = sessions.get(decodeURIComponent(m[1]))
+      if (!s) return jsonRes(404, { error: 'no_session' })
+      // Reassemble parts in ascending index order.
+      const indices = [...s.parts.keys()].sort((a, b) => a - b)
+      let total = 0
+      for (const i of indices) total += s.parts.get(i).length
+      const reassembled = new Uint8Array(total)
+      let off = 0
+      for (const i of indices) {
+        const p = s.parts.get(i)
+        reassembled.set(p, off)
+        off += p.length
+      }
+      // VERIFY: server's hash of reassembled bytes == client's declared hash.
+      const serverHash = await sha256Hex(reassembled)
+      if (serverHash !== jsonBody.hash) return jsonRes(409, { error: 'hash_mismatch' })
+      blobs.set(serverHash, { bytes: reassembled, refs: 0 })
+      sessions.delete(decodeURIComponent(m[1]))
+      hashToUpload.delete(serverHash)
+      return jsonRes(200, { hash: serverHash, stored: true })
+    }
+
+    // POST /blobs/:hash/ref-add | ref-release
+    if (method === 'POST' && (m = path.match(/^\/blobs\/([^/]+)\/(ref-add|ref-release)$/))) {
+      const hash = decodeURIComponent(m[1])
+      const rec = blobs.get(hash)
+      if (!rec) return jsonRes(404, { error: 'not_found' })
+      if (m[2] === 'ref-add') { calls.refAdd++; rec.refs++ } else { calls.refRelease++; rec.refs-- }
+      return jsonRes(200, { refs: rec.refs })
+    }
+
+    return jsonRes(404, { error: 'unknown_route' })
+  }
+
+  return {
+    fetchImpl: (url, init) => handle(url, init),
+    blobs,
+    sessions,
+    calls,
+    partPuts,
+    setFailPartOnce: (i) => { failPartOnce = i },
+  }
+}
+
+function depsFor(server, extra = {}) {
+  return {
+    connection: { vaultUrl: VAULT_URL, vaultToken: TOKEN, accountId: ACCOUNT },
+    fetchImpl: server.fetchImpl,
+    getRootKey: provideKey,
+    ...extra,
+  }
+}
+
+// ── THE end-to-end test: the client/server hash-agreement seam ───────────────
+
+describe('blobTransport — end-to-end round trip (the hash seam)', () => {
+  it('encrypt → upload (initiate/parts/finalize ACCEPTS) → download → decrypt is byte-identical', async () => {
+    const server = makeVaultServer()
+    const plaintext = enc('a milestone photo, pretend this is JPEG bytes ' + 'x'.repeat(500))
+
+    // Force multipart so reassembly ORDER is genuinely exercised.
+    const deps = depsFor(server, { partSize: 64 })
+
+    const hash = await uploadBlob(plaintext, deps)
+
+    // finalize ACCEPTED (server's hash of reassembled bytes == client's hash) and stored it.
+    expect(server.calls.finalize).toBe(1)
+    expect(server.blobs.has(hash)).toBe(true)
+
+    // Independent cross-check: the address equals SHA-256 of the exact encrypted
+    // stored bytes — i.e. what the client declared and what the server verified.
+    const { bytes, hash: cryptoHash } = await encryptBlob(plaintext, provideKey)
+    expect(hash).toBe(cryptoHash)
+    expect(await sha256Hex(server.blobs.get(hash).bytes)).toBe(hash)
+    expect([...server.blobs.get(hash).bytes]).toEqual([...bytes])
+
+    // Download → decrypt → byte-identical to the original plaintext.
+    const out = await downloadBlob(hash, deps)
+    expect([...out]).toEqual([...plaintext])
+  })
+
+  it('round-trips a larger payload across many parts', async () => {
+    const server = makeVaultServer()
+    const plaintext = randomBytes(200 * 1024) // 200 KiB
+    const deps = depsFor(server, { partSize: 64 * 1024 })
+    const hash = await uploadBlob(plaintext, deps)
+    expect(server.blobs.has(hash)).toBe(true)
+    const out = await downloadBlob(hash, deps)
+    expect(await sha256Hex(out)).toBe(await sha256Hex(plaintext))
+  })
+})
+
+// ── Dedup: existence check skips upload for known content ────────────────────
+
+describe('blobTransport — dedup (existence check skips upload)', () => {
+  it('a second upload of identical content does HEAD only — no initiate/parts/finalize', async () => {
+    const server = makeVaultServer()
+    const plaintext = enc('dedup me')
+    const deps = depsFor(server)
+
+    const hash1 = await uploadBlob(plaintext, deps)
+    const after = { ...server.calls }
+
+    const hash2 = await uploadBlob(plaintext, deps)
+    expect(hash2).toBe(hash1) // same content address
+
+    // The second call hit HEAD (existence) and then short-circuited.
+    expect(server.calls.head).toBe(after.head + 1)
+    expect(server.calls.initiate).toBe(after.initiate) // unchanged
+    expect(server.calls.part).toBe(after.part) // unchanged
+    expect(server.calls.finalize).toBe(after.finalize) // unchanged
+  })
+
+  it('blobExists reflects server state', async () => {
+    const server = makeVaultServer()
+    const { hash } = await encryptBlob(enc('present?'), provideKey)
+    expect(await blobExists(hash, depsFor(server))).toBe(false)
+    await uploadBlob(enc('present?'), depsFor(server))
+    expect(await blobExists(hash, depsFor(server))).toBe(true)
+  })
+})
+
+// ── Interrupted upload resumes from the server's resume point ────────────────
+
+describe('blobTransport — resume after interruption', () => {
+  it('resumes from the resume point and does not re-send already-received parts', async () => {
+    const server = makeVaultServer()
+    const plaintext = randomBytes(300) // > partSize so there are several parts
+    const partSize = 64
+    const deps = depsFor(server, { partSize })
+
+    // The upload chunks the ENCRYPTED bytes ([nonce || ciphertext]), not the
+    // plaintext, so derive the expected part indices from the encrypted length.
+    const { bytes: stored } = await encryptBlob(plaintext, provideKey)
+    const nParts = Math.ceil(stored.length / partSize)
+    const allIndices = [...Array(nParts).keys()]
+    expect(nParts).toBeGreaterThan(2)
+
+    // First attempt: fail part index 1. Parts before it (0) are already stored.
+    server.setFailPartOnce(1)
+    await expect(uploadBlob(plaintext, deps)).rejects.toThrow()
+    expect(server.partPuts).toEqual([0]) // only part 0 made it before the failure
+
+    // Second attempt: initiate is idempotent on hash; resume reports part 0 held;
+    // the client sends only the missing parts and finalizes.
+    const hash = await uploadBlob(plaintext, deps)
+    expect(server.calls.resume).toBeGreaterThanOrEqual(2)
+    // Part 0 was sent exactly once across BOTH attempts (resumed, not restarted).
+    expect(server.partPuts.filter((i) => i === 0)).toHaveLength(1)
+    expect(server.partPuts.sort((a, b) => a - b)).toEqual(allIndices)
+
+    expect(server.blobs.has(hash)).toBe(true)
+    const out = await downloadBlob(hash, deps)
+    expect(await sha256Hex(out)).toBe(await sha256Hex(plaintext))
+  })
+})
+
+// ── Key unavailable: surfaces hold/retry, uploads nothing, never plaintext ───
+
+describe('blobTransport — key unavailable', () => {
+  it('uploadBlob throws BlobKeyUnavailableError and sends NOTHING', async () => {
+    const server = makeVaultServer()
+    const deps = depsFor(server, { getRootKey: provideNull })
+    await expect(uploadBlob(enc('secret'), deps)).rejects.toThrow(BlobKeyUnavailableError)
+    // No request of any kind reached the server — never plaintext, never a probe.
+    expect(server.calls).toEqual({
+      head: 0, initiate: 0, resume: 0, part: 0, finalize: 0, get: 0, refAdd: 0, refRelease: 0,
+    })
+  })
+})
+
+// ── Connection unavailable: clear, transient hold/retry signal ───────────────
+
+describe('blobTransport — connection unavailable', () => {
+  it('throws a transient VaultConnectionUnavailableError when no connection is configured', async () => {
+    // No `connection` in deps and no localStorage config in the node test env.
+    await expect(
+      uploadBlob(enc('x'), { fetchImpl: () => { throw new Error('should not fetch') }, getRootKey: provideKey }),
+    ).rejects.toMatchObject({ name: 'VaultConnectionUnavailableError', transient: true })
+    expect(VaultConnectionUnavailableError).toBeTruthy()
+  })
+
+  it('readVaultConnection returns null when the sync config is absent', () => {
+    expect(readVaultConnection()).toBeNull()
+  })
+})
+
+// ── Download range returns the correct bytes ─────────────────────────────────
+
+describe('blobTransport — range download', () => {
+  it('returns exactly the requested byte slice of the stored blob', async () => {
+    const server = makeVaultServer()
+    const plaintext = randomBytes(1000)
+    const deps = depsFor(server, { partSize: 256 })
+    const hash = await uploadBlob(plaintext, deps)
+
+    // The stored bytes are the encrypted [nonce || ciphertext], known deterministically.
+    const { bytes: stored } = await encryptBlob(plaintext, provideKey)
+
+    const slice = await downloadBlobBytes(hash, { ...deps, range: { start: 10, end: 49 } })
+    expect(slice.length).toBe(40)
+    expect([...slice]).toEqual([...stored.slice(10, 50)])
+
+    // Open-ended range (start..end-of-blob).
+    const tail = await downloadBlobBytes(hash, { ...deps, range: { start: stored.length - 5 } })
+    expect([...tail]).toEqual([...stored.slice(stored.length - 5)])
+  })
+})
+
+// ── Tampered downloaded blob fails decrypt (GCM tag) ─────────────────────────
+
+describe('blobTransport — tamper detection on download', () => {
+  it('a blob corrupted on the server fails to decrypt', async () => {
+    const server = makeVaultServer()
+    const plaintext = enc('integrity matters')
+    const deps = depsFor(server)
+    const hash = await uploadBlob(plaintext, deps)
+
+    // Corrupt the stored bytes server-side (flip a bit in the ciphertext/tag).
+    const rec = server.blobs.get(hash)
+    rec.bytes[rec.bytes.length - 1] ^= 0x01
+
+    await expect(downloadBlob(hash, deps)).rejects.toThrow()
+  })
+})
+
+// ── Finalize hash mismatch surfaces clearly ──────────────────────────────────
+
+describe('blobTransport — finalize hash mismatch', () => {
+  it('throws BlobHashMismatchError when reassembled bytes hash differently', async () => {
+    const server = makeVaultServer()
+    // A fetch wrapper that corrupts one part in flight, so the server reassembles
+    // different bytes than the client hashed → finalize must reject.
+    let corrupted = false
+    const corruptingFetch = (url, init) => {
+      if (init.method === 'PUT' && /\/parts\/0(\?|$)/.test(url) && !corrupted) {
+        corrupted = true
+        const bad = new Uint8Array(init.body)
+        bad[0] ^= 0xff
+        return server.fetchImpl(url, { ...init, body: bad })
+      }
+      return server.fetchImpl(url, init)
+    }
+    const deps = depsFor(server, { fetchImpl: corruptingFetch, partSize: 64 })
+    await expect(uploadBlob(enc('this will be corrupted in transit'), deps)).rejects.toThrow(BlobHashMismatchError)
+    expect(server.calls.finalize).toBe(1) // it did reach finalize and was rejected there
+  })
+})
+
+// ── Reference helpers ────────────────────────────────────────────────────────
+
+describe('blobTransport — reference helpers', () => {
+  it('addBlobRef / releaseBlobRef call the server endpoints', async () => {
+    const server = makeVaultServer()
+    const deps = depsFor(server)
+    const hash = await uploadBlob(enc('ref me'), deps)
+
+    await addBlobRef(hash, deps)
+    await addBlobRef(hash, deps)
+    expect(server.blobs.get(hash).refs).toBe(2)
+    expect(server.calls.refAdd).toBe(2)
+
+    await releaseBlobRef(hash, deps)
+    expect(server.blobs.get(hash).refs).toBe(1)
+    expect(server.calls.refRelease).toBe(1)
+  })
+})
+
+// ── Auth seam ────────────────────────────────────────────────────────────────
+
+describe('blobTransport — auth', () => {
+  it('a wrong device token is rejected by the server (401 surfaces as an error)', async () => {
+    const server = makeVaultServer()
+    const badConn = { vaultUrl: VAULT_URL, vaultToken: 'wrong-token', accountId: ACCOUNT }
+    await expect(
+      blobExists('deadbeef', { connection: badConn, fetchImpl: server.fetchImpl, getRootKey: provideKey }),
+    ).rejects.toThrow()
+  })
+})

--- a/src/blobs/blobTransport.ts
+++ b/src/blobs/blobTransport.ts
@@ -1,0 +1,452 @@
+// =============================================================================
+// blobTransport — client for the glance-vault blob endpoints (Phase 7, step 2)
+// =============================================================================
+//
+// Drives the glance-vault blob HTTP API on top of the crypto core
+// (./blobCrypto.ts). It does NOT generate thumbnails and does NOT wire blobs to
+// milestone entities — those are later steps. This file owns only the transport:
+// encrypt → existence-check → resumable upload → finalize, and download →
+// decrypt, plus existence and reference helpers.
+//
+// CONNECTION MODEL — it reuses the SAME vault connection lifeGLANCE's sync uses:
+// `{ vaultUrl, vaultToken, accountId }`, the GLANCEvault server coordinates
+// (mirrors @glance-apps/sync's createVaultClient — Bearer token, account-scoped).
+// lifeGLANCE persists that under `lifeglance-cloud-sync-config` (the sync engine's
+// KEY_CONFIG). We read it from there. The connection, the fetch implementation,
+// and the root-key source are all INJECTABLE so this module is testable in
+// isolation and so a native/Electron shell can supply its own network bridge —
+// exactly as the sync vault client makes `fetchImpl` injectable.
+//
+// AUTH + SCOPING (mirrors @glance-apps/sync vaultClient.js):
+//   • Every request carries `Authorization: Bearer <vaultToken>`.
+//   • `accountId` scopes every endpoint: a query param on GET/HEAD/PUT-part,
+//     a body field on the JSON POSTs (initiate / finalize / ref-add / ref-release).
+//
+// THE SERVER CONTRACT (all device-token auth, account-scoped):
+//   HEAD /blobs/:hash                      → 200 exists / 404 absent
+//   POST /blobs/uploads                    → initiate (idempotent on hash) { uploadId }
+//   PUT  /blobs/uploads/:id/parts/:i       → store one part (raw octet-stream body)
+//   GET  /blobs/uploads/:id                → resume point { received:[i,...], partSize, size }
+//   POST /blobs/uploads/:id/finalize       → reassemble, VERIFY hash, store
+//   GET  /blobs/:hash       (Range)        → download (full or partial) stored bytes
+//   POST /blobs/:hash/ref-add | ref-release→ reference tracking
+//
+// THE HASH SEAM (the load-bearing invariant this step proves):
+//   The stored blob bytes are [nonce(12) || ciphertext+tag] and the address is
+//   `hash = SHA-256(those exact bytes)` (see blobCrypto.ts). The client uploads
+//   those exact bytes in order; on finalize the server reassembles the parts,
+//   recomputes SHA-256 over the reassembled bytes, and MUST get the same hash the
+//   client declared. Same bytes hashed the same way ⇒ finalize accepts. The
+//   end-to-end test exercises precisely this seam.
+//
+// NEVER PLAINTEXT TO THE VAULT: upload always encrypts first; if the blob key is
+// unavailable, BlobKeyUnavailableError propagates and NOTHING is sent — the
+// caller treats it as a hold/retry, mirroring the intents key-absent path.
+//
+// FUTURE: like blobCrypto.ts, this is structured for extraction into a shared
+// `@glance-apps/*` package — it imports only the crypto core and reads the
+// connection through an injectable seam, with no UI or milestone dependencies.
+// (Native binary routing — Range + arrayBuffer over CapacitorHttp — is a
+// follow-up for the native-shell cutover; the default global-fetch path covers
+// browser/PWA and is what `fetchImpl` injection swaps out.)
+// =============================================================================
+
+import {
+  encryptBlob,
+  decryptBlob,
+  type Plaintext,
+  type RootKeyProvider,
+} from './blobCrypto.ts'
+
+/** The glance-vault connection coordinates (same shape sync's vault client uses). */
+export interface VaultConnection {
+  vaultUrl: string
+  vaultToken: string
+  accountId: string
+}
+
+/** Minimal fetch shape we depend on — global `fetch` satisfies it. */
+export type FetchImpl = (url: string, init: FetchInit) => Promise<FetchResponse>
+export interface FetchInit {
+  method: string
+  headers: Record<string, string>
+  body?: Uint8Array | ArrayBuffer | string
+}
+export interface FetchResponse {
+  ok: boolean
+  status: number
+  arrayBuffer(): Promise<ArrayBuffer>
+  json(): Promise<any>
+}
+
+/** Injectable dependencies; every public fn accepts these, all with safe defaults. */
+export interface BlobTransportDeps {
+  /** The vault connection to use. Defaults to reading the sync config. */
+  connection?: VaultConnection | null
+  /** The fetch implementation. Defaults to global fetch. */
+  fetchImpl?: FetchImpl
+  /** The blob root-key source, threaded into the crypto core. */
+  getRootKey?: RootKeyProvider
+  /** Upload part size in bytes. Defaults to 1 MiB. */
+  partSize?: number
+}
+
+/** Default resumable-upload part size: 1 MiB. */
+export const DEFAULT_PART_SIZE = 1024 * 1024
+
+const SYNC_CONFIG_KEY = 'lifeglance-cloud-sync-config'
+
+/**
+ * The vault connection is not configured / not ready yet (no URL, token, or
+ * accountId). A TRANSIENT, hold/retry condition — mirrors how the sync engine
+ * treats ACCOUNT_ID_REQUIRED as "not ready yet, retry next cycle", never a hard
+ * error. The caller should retry once the vault connection is populated.
+ */
+export class VaultConnectionUnavailableError extends Error {
+  readonly code = 'VAULT_NOT_READY'
+  readonly transient = true
+  constructor(message = 'vault connection not available (URL, token, or accountId missing)') {
+    super(message)
+    this.name = 'VaultConnectionUnavailableError'
+  }
+}
+
+/** A blob endpoint returned a non-OK status. Carries the HTTP status. */
+export class BlobTransportError extends Error {
+  readonly status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'BlobTransportError'
+    this.status = status
+  }
+}
+
+/**
+ * Finalize rejected the upload because the server's hash of the reassembled
+ * bytes did not equal the client's declared hash. This should never happen for
+ * an intact upload — it means the bytes the server reassembled differ from the
+ * bytes the client hashed (corruption / a contract bug), and is the failure the
+ * end-to-end test asserts does NOT occur on the happy path.
+ */
+export class BlobHashMismatchError extends Error {
+  readonly hash: string
+  constructor(hash: string) {
+    super(`finalize rejected: server hash of reassembled bytes != declared hash ${hash}`)
+    this.name = 'BlobHashMismatchError'
+    this.hash = hash
+  }
+}
+
+// ── Connection resolution ────────────────────────────────────────────────────
+
+/**
+ * Read the vault connection from lifeGLANCE's sync config (the same place
+ * @glance-apps/sync's vault transport reads it). Returns null if absent or
+ * incomplete — callers turn that into a VaultConnectionUnavailableError.
+ */
+export function readVaultConnection(): VaultConnection | null {
+  let cfg: any
+  try {
+    const raw = localStorage.getItem(SYNC_CONFIG_KEY)
+    cfg = raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+  if (!cfg) return null
+  const vaultUrl = cfg.vaultUrl
+  const vaultToken = cfg.vaultToken
+  const accountId = cfg.accountId
+  if (
+    typeof vaultUrl !== 'string' || vaultUrl.trim() === '' ||
+    typeof vaultToken !== 'string' || vaultToken.trim() === '' ||
+    typeof accountId !== 'string' || accountId.trim() === ''
+  ) {
+    return null
+  }
+  return { vaultUrl, vaultToken, accountId }
+}
+
+function resolveConnection(deps: BlobTransportDeps): VaultConnection {
+  const conn = deps.connection ?? readVaultConnection()
+  if (!conn) throw new VaultConnectionUnavailableError()
+  return conn
+}
+
+function resolveFetch(deps: BlobTransportDeps): FetchImpl {
+  const f = deps.fetchImpl ?? (globalThis.fetch as unknown as FetchImpl | undefined)
+  if (typeof f !== 'function') {
+    throw new Error('blobTransport: no fetch implementation available')
+  }
+  return f
+}
+
+// ── Request helper (mirrors vaultClient.js request/authHeaders) ───────────────
+
+interface RequestOpts {
+  query?: Record<string, string>
+  jsonBody?: unknown
+  binaryBody?: Uint8Array | ArrayBuffer
+  headers?: Record<string, string>
+}
+
+async function vaultRequest(
+  conn: VaultConnection,
+  doFetch: FetchImpl,
+  method: string,
+  path: string,
+  opts: RequestOpts = {},
+): Promise<FetchResponse> {
+  let url = conn.vaultUrl.replace(/\/+$/, '') + path
+  if (opts.query) {
+    const qs = new URLSearchParams(opts.query).toString()
+    if (qs) url += `?${qs}`
+  }
+  const init: FetchInit = {
+    method,
+    headers: { Authorization: `Bearer ${conn.vaultToken}`, ...opts.headers },
+  }
+  if (opts.jsonBody !== undefined) {
+    init.headers['Content-Type'] = 'application/json'
+    init.body = JSON.stringify(opts.jsonBody)
+  } else if (opts.binaryBody !== undefined) {
+    init.headers['Content-Type'] = 'application/octet-stream'
+    init.body = opts.binaryBody
+  }
+  return doFetch(url, init)
+}
+
+async function jsonOrThrow(res: FetchResponse, context: string): Promise<any> {
+  if (!res.ok) throw new BlobTransportError(`${context} failed: ${res.status}`, res.status)
+  return res.json()
+}
+
+// ── Existence check ──────────────────────────────────────────────────────────
+
+/**
+ * HEAD /blobs/:hash — does the server already hold this content?
+ * @returns true if present (2xx), false if absent (404).
+ * @throws  BlobTransportError on any other status.
+ */
+export async function blobExists(hash: string, deps: BlobTransportDeps = {}): Promise<boolean> {
+  const conn = resolveConnection(deps)
+  const doFetch = resolveFetch(deps)
+  const res = await vaultRequest(conn, doFetch, 'HEAD', `/blobs/${encodeURIComponent(hash)}`, {
+    query: { accountId: conn.accountId },
+  })
+  if (res.ok) return true
+  if (res.status === 404) return false
+  throw new BlobTransportError(`blob existence check failed: ${res.status}`, res.status)
+}
+
+// ── Upload ───────────────────────────────────────────────────────────────────
+
+function splitIntoParts(bytes: Uint8Array, partSize: number): Uint8Array[] {
+  const parts: Uint8Array[] = []
+  for (let off = 0; off < bytes.length; off += partSize) {
+    parts.push(bytes.subarray(off, Math.min(off + partSize, bytes.length)))
+  }
+  // A zero-length blob still uploads exactly one (empty) part so finalize has a
+  // session to reassemble.
+  if (parts.length === 0) parts.push(bytes.subarray(0, 0))
+  return parts
+}
+
+/** POST /blobs/uploads — initiate (idempotent on hash) → uploadId. */
+async function initiateUpload(
+  conn: VaultConnection,
+  doFetch: FetchImpl,
+  hash: string,
+  size: number,
+  partSize: number,
+): Promise<string> {
+  const res = await vaultRequest(conn, doFetch, 'POST', '/blobs/uploads', {
+    jsonBody: { accountId: conn.accountId, hash, size, partSize },
+  })
+  const body = await jsonOrThrow(res, 'initiate upload')
+  if (!body || typeof body.uploadId !== 'string') {
+    throw new BlobTransportError('initiate upload: missing uploadId in response', res.status)
+  }
+  return body.uploadId
+}
+
+/** GET /blobs/uploads/:id — which part indices the server already holds. */
+async function getResumePoint(
+  conn: VaultConnection,
+  doFetch: FetchImpl,
+  uploadId: string,
+): Promise<Set<number>> {
+  const res = await vaultRequest(conn, doFetch, 'GET', `/blobs/uploads/${encodeURIComponent(uploadId)}`, {
+    query: { accountId: conn.accountId },
+  })
+  const body = await jsonOrThrow(res, 'resume point')
+  const received: number[] = Array.isArray(body?.received) ? body.received : []
+  return new Set(received)
+}
+
+/** PUT /blobs/uploads/:id/parts/:i — send one part (raw bytes). */
+async function putPart(
+  conn: VaultConnection,
+  doFetch: FetchImpl,
+  uploadId: string,
+  index: number,
+  part: Uint8Array,
+): Promise<void> {
+  const res = await vaultRequest(
+    conn,
+    doFetch,
+    'PUT',
+    `/blobs/uploads/${encodeURIComponent(uploadId)}/parts/${index}`,
+    { query: { accountId: conn.accountId }, binaryBody: part },
+  )
+  if (!res.ok) throw new BlobTransportError(`upload part ${index} failed: ${res.status}`, res.status)
+}
+
+/** POST /blobs/uploads/:id/finalize — reassemble + verify hash + store. */
+async function finalizeUpload(
+  conn: VaultConnection,
+  doFetch: FetchImpl,
+  uploadId: string,
+  hash: string,
+): Promise<void> {
+  const res = await vaultRequest(
+    conn,
+    doFetch,
+    'POST',
+    `/blobs/uploads/${encodeURIComponent(uploadId)}/finalize`,
+    { jsonBody: { accountId: conn.accountId, hash } },
+  )
+  if (res.ok) return
+  // The server signals a hash mismatch distinctly so we can surface it clearly.
+  if (res.status === 409 || res.status === 422 || res.status === 400) {
+    let err: any = null
+    try {
+      err = await res.json()
+    } catch {
+      /* fall through to generic */
+    }
+    if (err && err.error === 'hash_mismatch') throw new BlobHashMismatchError(hash)
+  }
+  throw new BlobTransportError(`finalize failed: ${res.status}`, res.status)
+}
+
+/**
+ * Encrypt, then upload a blob to the vault, returning its content address (hash).
+ *
+ * 1. encryptBlob(plaintext) → { bytes, hash }. If the blob key is unavailable,
+ *    BlobKeyUnavailableError propagates and NOTHING is uploaded — never plaintext.
+ * 2. Existence check (HEAD): if the server already holds this hash, skip the
+ *    upload entirely (dedup) and return the hash — a re-upload is a no-op.
+ * 3. Otherwise a resumable upload: initiate (idempotent on hash), read the resume
+ *    point, send only the parts the server is still missing, then finalize. An
+ *    interrupted upload resumes from the server's resume point rather than
+ *    restarting.
+ * 4. Return the hash on success.
+ *
+ * @throws {import('./blobCrypto.ts').BlobKeyUnavailableError} if the key is absent.
+ * @throws {VaultConnectionUnavailableError} if the vault connection is not ready.
+ * @throws {BlobHashMismatchError} if finalize rejects the declared hash.
+ * @throws {BlobTransportError} on other non-OK responses.
+ */
+export async function uploadBlob(plaintext: Plaintext, deps: BlobTransportDeps = {}): Promise<string> {
+  const conn = resolveConnection(deps)
+  const doFetch = resolveFetch(deps)
+  const partSize = deps.partSize ?? DEFAULT_PART_SIZE
+
+  // Encrypt FIRST. A missing key throws BlobKeyUnavailableError here, before any
+  // network call — so nothing is sent and the caller can hold/retry.
+  const { bytes, hash } = await encryptBlob(plaintext, deps.getRootKey)
+
+  // Dedup: if the server already has these exact bytes, we're done.
+  if (await blobExists(hash, deps)) return hash
+
+  // Resumable upload. Initiate is idempotent on the hash, so a retry after an
+  // interruption returns the same session with its already-received parts.
+  const uploadId = await initiateUpload(conn, doFetch, hash, bytes.length, partSize)
+  const received = await getResumePoint(conn, doFetch, uploadId)
+
+  const parts = splitIntoParts(bytes, partSize)
+  for (let i = 0; i < parts.length; i++) {
+    if (received.has(i)) continue // resume: skip parts the server already holds
+    await putPart(conn, doFetch, uploadId, i, parts[i])
+  }
+
+  await finalizeUpload(conn, doFetch, uploadId, hash)
+  return hash
+}
+
+// ── Download ─────────────────────────────────────────────────────────────────
+
+/** A byte range for partial download. Inclusive, like an HTTP Range header. */
+export interface ByteRange {
+  start: number
+  /** Inclusive end. Omit for "to the end". */
+  end?: number
+}
+
+function rangeHeader(range: ByteRange): string {
+  return range.end === undefined
+    ? `bytes=${range.start}-`
+    : `bytes=${range.start}-${range.end}`
+}
+
+/**
+ * GET /blobs/:hash — fetch the raw STORED bytes ([nonce || ciphertext]), optionally
+ * a byte range for partial/streaming use. This returns ciphertext, NOT plaintext:
+ * a partial range cannot be GCM-decrypted on its own (the tag covers the whole
+ * message), so range fetches are for streaming/transfer, and full decryption goes
+ * through {@link downloadBlob}.
+ *
+ * @throws {VaultConnectionUnavailableError} if the vault connection is not ready.
+ * @throws {BlobTransportError} on a non-OK response.
+ */
+export async function downloadBlobBytes(
+  hash: string,
+  deps: BlobTransportDeps & { range?: ByteRange } = {},
+): Promise<Uint8Array> {
+  const conn = resolveConnection(deps)
+  const doFetch = resolveFetch(deps)
+  const headers: Record<string, string> = {}
+  if (deps.range) headers['Range'] = rangeHeader(deps.range)
+  const res = await vaultRequest(conn, doFetch, 'GET', `/blobs/${encodeURIComponent(hash)}`, {
+    query: { accountId: conn.accountId },
+    headers,
+  })
+  if (!res.ok) throw new BlobTransportError(`download failed: ${res.status}`, res.status)
+  return new Uint8Array(await res.arrayBuffer())
+}
+
+/**
+ * Download a full blob and decrypt it to plaintext. Decryption verifies the
+ * GCM tag, so a tampered/corrupt blob fails clearly (the decrypt rejects).
+ *
+ * @throws {import('./blobCrypto.ts').BlobKeyUnavailableError} if the key is absent.
+ * @throws if the downloaded bytes fail GCM verification (tampered/corrupt).
+ */
+export async function downloadBlob(hash: string, deps: BlobTransportDeps = {}): Promise<Uint8Array> {
+  const bytes = await downloadBlobBytes(hash, deps)
+  return decryptBlob(bytes, deps.getRootKey)
+}
+
+// ── Reference tracking ───────────────────────────────────────────────────────
+// Thin wrappers over the server's ref-add / ref-release. WHEN these are called
+// (on milestone create/delete) is the wiring step — not this module.
+
+/** POST /blobs/:hash/ref-add — increment the reference count for a blob. */
+export async function addBlobRef(hash: string, deps: BlobTransportDeps = {}): Promise<void> {
+  const conn = resolveConnection(deps)
+  const doFetch = resolveFetch(deps)
+  const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-add`, {
+    jsonBody: { accountId: conn.accountId },
+  })
+  if (!res.ok) throw new BlobTransportError(`ref-add failed: ${res.status}`, res.status)
+}
+
+/** POST /blobs/:hash/ref-release — decrement the reference count for a blob. */
+export async function releaseBlobRef(hash: string, deps: BlobTransportDeps = {}): Promise<void> {
+  const conn = resolveConnection(deps)
+  const doFetch = resolveFetch(deps)
+  const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-release`, {
+    jsonBody: { accountId: conn.accountId },
+  })
+  if (!res.ok) throw new BlobTransportError(`ref-release failed: ${res.status}`, res.status)
+}

--- a/src/blobs/thumbnail.test.js
+++ b/src/blobs/thumbnail.test.js
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateThumbnail,
+  fitWithin,
+  sourceKind,
+  ThumbnailGenerationError,
+  MAX_THUMBNAIL_EDGE,
+  DEFAULT_OUTPUT_MIME,
+  POSTER_FRAME_TIME_SECONDS,
+} from './thumbnail.ts'
+
+// =============================================================================
+// TEST ENVIRONMENT NOTE
+//
+// The REAL image-processing primitive (browserImageProcessor) uses webview canvas
+// APIs — createImageBitmap, OffscreenCanvas, a <video> element + frame grab. Those
+// do NOT exist in the vitest 'node' environment (no canvas, no DOM video), so they
+// are exercised IN-APP, not here. Per the module's injectable design, these tests
+// supply a FAKE ImageProcessor that records its calls and produces deterministic
+// bytes, letting us assert the generation logic (kind routing, downscale bounds,
+// poster-frame path, clean typed failure, plaintext output) without any canvas.
+// =============================================================================
+
+// A fake source "blob": 4-byte big-endian width/height header + a marker.
+function fakeSource(width, height, marker = 'ok') {
+  const head = new Uint8Array([
+    (width >> 8) & 0xff, width & 0xff,
+    (height >> 8) & 0xff, height & 0xff,
+  ])
+  const tail = new TextEncoder().encode(marker)
+  const out = new Uint8Array(head.length + tail.length)
+  out.set(head, 0)
+  out.set(tail, head.length)
+  return out
+}
+
+function readDims(bytes) {
+  if (bytes.length < 4) throw new Error('fake decode: too short')
+  const width = (bytes[0] << 8) | bytes[1]
+  const height = (bytes[2] << 8) | bytes[3]
+  if (width === 0 || height === 0) throw new Error('fake decode: corrupt (zero dims)')
+  return { width, height }
+}
+
+// Fake-encoded output: a 4-byte target-dims header + an ASCII tag for the mime.
+// This lets a test read the encoded thumbnail's dimensions straight out of the
+// returned bytes (proving the size bound from the real output, not just a spy).
+function fakeEncodedBytes(targetWidth, targetHeight, mimeType) {
+  const head = new Uint8Array([
+    (targetWidth >> 8) & 0xff, targetWidth & 0xff,
+    (targetHeight >> 8) & 0xff, targetHeight & 0xff,
+  ])
+  const tag = new TextEncoder().encode(`ENC:${mimeType}`)
+  const out = new Uint8Array(head.length + tag.length)
+  out.set(head, 0)
+  out.set(tag, head.length)
+  return out
+}
+
+function readEncodedDims(bytes) {
+  return { width: (bytes[0] << 8) | bytes[1], height: (bytes[2] << 8) | bytes[3] }
+}
+
+// A recording fake ImageProcessor. `behavior` lets a test force decode/encode
+// failures to exercise the clean-failure path.
+function makeFakeProcessor(behavior = {}) {
+  const calls = {
+    decodeImage: 0,
+    decodeVideoFrame: 0,
+    encode: 0,
+    lastEncode: null,
+    lastPosterTime: null,
+  }
+  const processor = {
+    async decodeImage(bytes) {
+      calls.decodeImage++
+      if (behavior.decodeThrows) throw new Error('fake decode failure')
+      return { ...readDims(bytes), source: { kind: 'image-bitmap' } }
+    },
+    async decodeVideoFrame(bytes, _mime, atSeconds) {
+      calls.decodeVideoFrame++
+      calls.lastPosterTime = atSeconds
+      if (behavior.decodeThrows) throw new Error('fake video decode failure')
+      return { ...readDims(bytes), source: { kind: 'video-frame' } }
+    },
+    async encode(image, targetWidth, targetHeight, mimeType, quality) {
+      calls.encode++
+      calls.lastEncode = { targetWidth, targetHeight, mimeType, quality, source: image.source }
+      if (behavior.encodeThrows) throw new Error('fake encode failure')
+      if (behavior.encodeEmpty) return new Uint8Array(0)
+      return fakeEncodedBytes(targetWidth, targetHeight, mimeType)
+    },
+  }
+  return { processor, calls }
+}
+
+describe('thumbnail — sourceKind', () => {
+  it('classifies image and video mime types, rejects the rest', () => {
+    expect(sourceKind('image/jpeg')).toBe('image')
+    expect(sourceKind('image/png')).toBe('image')
+    expect(sourceKind('video/mp4')).toBe('video')
+    expect(sourceKind('VIDEO/QUICKTIME')).toBe('video')
+    expect(sourceKind('application/pdf')).toBeNull()
+    expect(sourceKind('')).toBeNull()
+    expect(sourceKind(undefined)).toBeNull()
+  })
+})
+
+describe('thumbnail — fitWithin (pure downscale math)', () => {
+  it('downscales the longest edge to the bound, preserving aspect ratio', () => {
+    expect(fitWithin(2000, 1000, 512)).toEqual({ width: 512, height: 256 })
+    expect(fitWithin(1000, 2000, 512)).toEqual({ width: 256, height: 512 })
+    expect(fitWithin(1024, 1024, 512)).toEqual({ width: 512, height: 512 })
+  })
+
+  it('never upscales a source already within the bound', () => {
+    expect(fitWithin(100, 80, 512)).toEqual({ width: 100, height: 80 })
+    expect(fitWithin(512, 300, 512)).toEqual({ width: 512, height: 300 })
+  })
+})
+
+describe('thumbnail — image source', () => {
+  it('produces downscaled bytes within the size bound, aspect preserved', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const src = fakeSource(2000, 1000) // 2:1, larger than the bound
+
+    const out = await generateThumbnail(src, 'image/jpeg', { processor })
+
+    // Routed to the image decoder (not the video path).
+    expect(calls.decodeImage).toBe(1)
+    expect(calls.decodeVideoFrame).toBe(0)
+
+    // Downscaled to the longest-edge bound, aspect preserved.
+    expect(calls.lastEncode.targetWidth).toBe(512)
+    expect(calls.lastEncode.targetHeight).toBe(256)
+    expect(Math.max(calls.lastEncode.targetWidth, calls.lastEncode.targetHeight))
+      .toBeLessThanOrEqual(MAX_THUMBNAIL_EDGE)
+
+    // Output mime + dimensions read back from the ACTUAL returned bytes.
+    expect(out.mimeType).toBe(DEFAULT_OUTPUT_MIME)
+    const dims = readEncodedDims(out.bytes)
+    expect(dims).toEqual({ width: 512, height: 256 })
+    expect(Math.max(dims.width, dims.height)).toBeLessThanOrEqual(MAX_THUMBNAIL_EDGE)
+  })
+
+  it('does not upscale a small image', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(120, 90), 'image/png', { processor })
+    expect(calls.lastEncode.targetWidth).toBe(120)
+    expect(calls.lastEncode.targetHeight).toBe(90)
+    expect(readEncodedDims(out.bytes)).toEqual({ width: 120, height: 90 })
+  })
+
+  it('honors a custom maxEdge and output mime', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(800, 400), 'image/jpeg', {
+      processor,
+      maxEdge: 256,
+      outputMimeType: 'image/webp',
+    })
+    expect(calls.lastEncode.targetWidth).toBe(256)
+    expect(calls.lastEncode.targetHeight).toBe(128)
+    expect(out.mimeType).toBe('image/webp')
+  })
+})
+
+describe('thumbnail — video source (poster frame)', () => {
+  it('grabs a poster frame and downscales it to an image', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    const src = fakeSource(1920, 1080) // 16:9 video
+
+    const out = await generateThumbnail(src, 'video/mp4', { processor })
+
+    // Routed to the video poster path, at the default poster timestamp.
+    expect(calls.decodeVideoFrame).toBe(1)
+    expect(calls.decodeImage).toBe(0)
+    expect(calls.lastPosterTime).toBe(POSTER_FRAME_TIME_SECONDS)
+    expect(calls.lastEncode.source).toEqual({ kind: 'video-frame' })
+
+    // Poster frame downscaled to the bound, output is a still image.
+    expect(calls.lastEncode.targetWidth).toBe(512)
+    expect(calls.lastEncode.targetHeight).toBe(288)
+    expect(out.mimeType).toBe(DEFAULT_OUTPUT_MIME) // an image, not a video
+    expect(readEncodedDims(out.bytes)).toEqual({ width: 512, height: 288 })
+  })
+
+  it('honors a custom poster timestamp', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    await generateThumbnail(fakeSource(640, 480), 'video/webm', {
+      processor,
+      posterTimeSeconds: 3.5,
+    })
+    expect(calls.lastPosterTime).toBe(3.5)
+  })
+})
+
+describe('thumbnail — clean failure (ThumbnailGenerationError, no partial output)', () => {
+  it('throws on an unsupported source type WITHOUT invoking the processor', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    await expect(generateThumbnail(fakeSource(10, 10), 'application/pdf', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.decodeImage).toBe(0)
+    expect(calls.decodeVideoFrame).toBe(0)
+    expect(calls.encode).toBe(0)
+  })
+
+  it('throws on empty source bytes', async () => {
+    const { processor } = makeFakeProcessor()
+    await expect(generateThumbnail(new Uint8Array(0), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('throws (and never encodes) when the decoder fails on a corrupt source', async () => {
+    const { processor, calls } = makeFakeProcessor({ decodeThrows: true })
+    await expect(generateThumbnail(fakeSource(100, 100), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.encode).toBe(0) // no partial output — it failed before encoding
+  })
+
+  it('throws when the decoder reports zero/garbage dimensions', async () => {
+    const { processor, calls } = makeFakeProcessor()
+    // A header of 0x0 makes the fake decoder treat the source as corrupt.
+    await expect(generateThumbnail(fakeSource(0, 0), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+    expect(calls.encode).toBe(0)
+  })
+
+  it('throws when the encoder fails', async () => {
+    const { processor } = makeFakeProcessor({ encodeThrows: true })
+    await expect(generateThumbnail(fakeSource(800, 600), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('throws when the encoder produces no bytes', async () => {
+    const { processor } = makeFakeProcessor({ encodeEmpty: true })
+    await expect(generateThumbnail(fakeSource(800, 600), 'image/jpeg', { processor }))
+      .rejects.toThrow(ThumbnailGenerationError)
+  })
+
+  it('wraps the underlying failure as the cause', async () => {
+    const { processor } = makeFakeProcessor({ decodeThrows: true })
+    const err = await generateThumbnail(fakeSource(100, 100), 'image/jpeg', { processor })
+      .then(() => null, (e) => e)
+    expect(err).toBeInstanceOf(ThumbnailGenerationError)
+    expect(err.cause).toBeInstanceOf(Error)
+  })
+})
+
+describe('thumbnail — output is plaintext bytes ready for the upload path', () => {
+  it('returns exactly the processor-produced image bytes (not encrypted/transformed)', async () => {
+    const { processor } = makeFakeProcessor()
+    const out = await generateThumbnail(fakeSource(1000, 500), 'image/jpeg', { processor })
+
+    // The returned bytes are precisely what the image processor produced — this
+    // module performs no encryption/addressing. (Encryption + content-addressing
+    // happen later, when these bytes go through blobTransport.uploadBlob.)
+    const expected = fakeEncodedBytes(512, 256, 'image/jpeg')
+    expect([...out.bytes]).toEqual([...expected])
+    expect(out.bytes).toBeInstanceOf(Uint8Array)
+    expect(typeof out.mimeType).toBe('string')
+  })
+})

--- a/src/blobs/thumbnail.ts
+++ b/src/blobs/thumbnail.ts
@@ -1,0 +1,303 @@
+// =============================================================================
+// thumbnail — blob thumbnail / poster generation (Phase 7, client step 3)
+// =============================================================================
+//
+// Produces a thumbnail as its OWN plaintext image bytes, ready to hand to the
+// blob upload path (blobTransport.uploadBlob), which encrypts + content-addresses
+// them like any blob. Per the spec, a thumbnail is CONTENT, not a per-device
+// derivative: the uploading device generates it ONCE at upload time, and it then
+// becomes its own content-addressed, encrypted blob — synced and cached like any
+// other content, never regenerated per device.
+//
+// THIS MODULE GENERATES BYTES ONLY. It does NOT encrypt, address, or upload (that
+// is blobCrypto/blobTransport's job), and it does NOT touch milestones or the
+// upload flow (that is the next wiring step). It has no UI, sync, milestone, or
+// crypto imports, so — like the other blob modules — it can be lifted into a
+// shared `@glance-apps/*` package later. (FUTURE: extract.)
+//
+// ENVIRONMENT: this runs on-device in a webview (browser / Capacitor), NOT in
+// Node. Images are downscaled/re-encoded with createImageBitmap + OffscreenCanvas;
+// video poster frames are grabbed with a <video> element + canvas. Those
+// primitives don't exist in jsdom/node, so the image-processing primitive is an
+// INJECTABLE dependency (`ImageProcessor`) — mirroring how blobCrypto/blobTransport
+// made their root-key/connection/fetch dependencies injectable. The real,
+// browser-backed processor (`browserImageProcessor`) is the default and is
+// exercised IN-APP; tests inject a fake processor (see thumbnail.test.js).
+//
+// FAIL CLEANLY (load-bearing): if the source is corrupt, an unsupported format,
+// or generation otherwise fails, this throws a typed `ThumbnailGenerationError`
+// and returns NOTHING — no partial bytes. The caller (the milestone upload flow,
+// next step) must treat that as a failed upload and NOT publish a milestone that
+// references a thumbnail which was never made. This module only throws the clean
+// typed error; it does not itself touch milestones.
+// =============================================================================
+
+/** Longest-edge bound (px) for a generated thumbnail. Aspect ratio is preserved. */
+export const MAX_THUMBNAIL_EDGE = 512
+
+/** Default output encoding for the thumbnail bytes. */
+export const DEFAULT_OUTPUT_MIME = 'image/jpeg'
+
+/** Default lossy-encode quality (0..1) for the thumbnail. */
+export const DEFAULT_QUALITY = 0.8
+
+/** Default timestamp (seconds) to grab a video poster frame from. */
+export const POSTER_FRAME_TIME_SECONDS = 1
+
+/**
+ * Thrown when a thumbnail cannot be produced (corrupt/unsupported source, or any
+ * decode/encode failure). A clean, typed failure with NO partial output — the
+ * caller treats it as a failed upload and publishes nothing referencing a
+ * thumbnail that was never made.
+ */
+export class ThumbnailGenerationError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'ThumbnailGenerationError'
+  }
+}
+
+/** A decoded raster image: its pixel dimensions plus an opaque drawable source. */
+export interface RasterImage {
+  width: number
+  height: number
+  /** Opaque handle the processor's own `encode` knows how to draw (e.g. ImageBitmap). */
+  source: unknown
+}
+
+/**
+ * The platform image-processing primitive. The real implementation uses browser
+ * canvas APIs; tests inject a fake. Kept tiny and side-effect-explicit so it can
+ * be swapped per platform.
+ */
+export interface ImageProcessor {
+  /** Decode still-image bytes into a drawable raster (with dimensions). */
+  decodeImage(bytes: Uint8Array, mimeType: string): Promise<RasterImage>
+  /** Grab a poster frame from video bytes at ~`atSeconds` into a drawable raster. */
+  decodeVideoFrame(bytes: Uint8Array, mimeType: string, atSeconds: number): Promise<RasterImage>
+  /** Downscale `image` to `targetWidth`×`targetHeight` and encode to `mimeType` bytes. */
+  encode(
+    image: RasterImage,
+    targetWidth: number,
+    targetHeight: number,
+    mimeType: string,
+    quality: number,
+  ): Promise<Uint8Array>
+}
+
+/** Options for {@link generateThumbnail}. All optional; sensible defaults apply. */
+export interface ThumbnailOptions {
+  /** Image-processing primitive. Defaults to the browser-backed processor. */
+  processor?: ImageProcessor
+  /** Longest-edge bound in px. Defaults to {@link MAX_THUMBNAIL_EDGE}. */
+  maxEdge?: number
+  /** Output mime type. Defaults to {@link DEFAULT_OUTPUT_MIME}. */
+  outputMimeType?: string
+  /** Encode quality 0..1. Defaults to {@link DEFAULT_QUALITY}. */
+  quality?: number
+  /** Video poster timestamp (s). Defaults to {@link POSTER_FRAME_TIME_SECONDS}. */
+  posterTimeSeconds?: number
+}
+
+export type SourceKind = 'image' | 'video'
+
+/** Classify a source mime type. Returns null for anything we can't thumbnail. */
+export function sourceKind(mimeType: string | undefined | null): SourceKind | null {
+  if (typeof mimeType !== 'string') return null
+  const m = mimeType.toLowerCase().trim()
+  if (m.startsWith('image/')) return 'image'
+  if (m.startsWith('video/')) return 'video'
+  return null
+}
+
+function isPositiveInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+/**
+ * Fit `(width, height)` within a `maxEdge` longest-edge bound, preserving aspect
+ * ratio. Never upscales: a source already within the bound is returned unchanged.
+ * Pure — no platform dependency — so it's directly testable.
+ */
+export function fitWithin(
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } {
+  const longest = Math.max(width, height)
+  if (longest <= maxEdge) return { width, height }
+  const scale = maxEdge / longest
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+/**
+ * Generate a thumbnail / poster image from a source blob's bytes.
+ *
+ * - IMAGE source: decode → downscale to {@link MAX_THUMBNAIL_EDGE} (longest edge,
+ *   aspect preserved) → re-encode → bytes.
+ * - VIDEO source: grab a poster frame (~`posterTimeSeconds`) → downscale the same
+ *   way → encode → bytes. (A static poster is the required minimum; a short
+ *   preview clip is an optional future addition.)
+ *
+ * Returns the thumbnail's RAW PLAINTEXT image bytes plus their mime type. It does
+ * NOT encrypt, address, or upload — hand the result to blobTransport.uploadBlob,
+ * which encrypts + content-addresses it like any blob.
+ *
+ * @throws {ThumbnailGenerationError} on unsupported/corrupt source or any
+ *         decode/encode failure — cleanly, with no partial output.
+ */
+export async function generateThumbnail(
+  sourceBytes: Uint8Array,
+  mimeType: string,
+  opts: ThumbnailOptions = {},
+): Promise<{ bytes: Uint8Array; mimeType: string }> {
+  const processor = opts.processor ?? browserImageProcessor
+  const maxEdge = opts.maxEdge ?? MAX_THUMBNAIL_EDGE
+  const outputMimeType = opts.outputMimeType ?? DEFAULT_OUTPUT_MIME
+  const quality = opts.quality ?? DEFAULT_QUALITY
+  const posterTime = opts.posterTimeSeconds ?? POSTER_FRAME_TIME_SECONDS
+
+  if (!(sourceBytes instanceof Uint8Array) || sourceBytes.length === 0) {
+    throw new ThumbnailGenerationError('source bytes are empty or not a Uint8Array')
+  }
+
+  const kind = sourceKind(mimeType)
+  if (!kind) {
+    throw new ThumbnailGenerationError(`unsupported source type: ${mimeType || '(none)'}`)
+  }
+
+  // Decode (platform). A corrupt or undecodable source surfaces here.
+  let decoded: RasterImage
+  try {
+    decoded =
+      kind === 'video'
+        ? await processor.decodeVideoFrame(sourceBytes, mimeType, posterTime)
+        : await processor.decodeImage(sourceBytes, mimeType)
+  } catch (err) {
+    throw new ThumbnailGenerationError(`failed to decode ${kind} source`, { cause: err })
+  }
+  if (!decoded || !isPositiveInt(decoded.width) || !isPositiveInt(decoded.height)) {
+    throw new ThumbnailGenerationError('decoder returned invalid dimensions')
+  }
+
+  const target = fitWithin(decoded.width, decoded.height, maxEdge)
+
+  // Downscale + encode (platform).
+  let bytes: Uint8Array
+  try {
+    bytes = await processor.encode(decoded, target.width, target.height, outputMimeType, quality)
+  } catch (err) {
+    throw new ThumbnailGenerationError('failed to encode thumbnail', { cause: err })
+  }
+  if (!(bytes instanceof Uint8Array) || bytes.length === 0) {
+    throw new ThumbnailGenerationError('encoder produced no bytes')
+  }
+
+  return { bytes, mimeType: outputMimeType }
+}
+
+// =============================================================================
+// browserImageProcessor — the real, on-device primitive (NOT run in tests)
+// -----------------------------------------------------------------------------
+// Uses webview canvas APIs. None of these globals are touched at import time
+// (every reference is inside a method), so importing this module under jsdom/node
+// is safe; the methods themselves only run in-app, where tests inject a fake.
+// =============================================================================
+
+function requireGlobal<T>(name: string): T {
+  const g = (globalThis as any)[name]
+  if (g == null) throw new Error(`thumbnail: ${name} is not available in this environment`)
+  return g as T
+}
+
+async function decodeWith(createBitmap: () => Promise<any>): Promise<RasterImage> {
+  const bitmap = await createBitmap()
+  return { width: bitmap.width, height: bitmap.height, source: bitmap }
+}
+
+export const browserImageProcessor: ImageProcessor = {
+  async decodeImage(bytes, mimeType) {
+    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
+    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    return decodeWith(() => createImageBitmap(blob))
+  },
+
+  async decodeVideoFrame(bytes, mimeType, atSeconds) {
+    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
+    const doc = requireGlobal<any>('document')
+    const URLg = requireGlobal<any>('URL')
+    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    const url = URLg.createObjectURL(blob)
+    const video: any = doc.createElement('video')
+    video.muted = true
+    video.preload = 'auto'
+    video.playsInline = true
+    try {
+      video.src = url
+      await onceEvent(video, 'loadedmetadata')
+      const duration = Number.isFinite(video.duration) ? video.duration : atSeconds
+      const seekTo = Math.min(atSeconds, Math.max(0, duration))
+      await seekVideo(video, Number.isFinite(seekTo) ? seekTo : 0)
+      const frame = await createImageBitmap(video)
+      return {
+        width: frame.width || video.videoWidth,
+        height: frame.height || video.videoHeight,
+        source: frame,
+      }
+    } finally {
+      URLg.revokeObjectURL(url)
+    }
+  },
+
+  async encode(image, targetWidth, targetHeight, mimeType, quality) {
+    const OffscreenCanvasG = requireGlobal<any>('OffscreenCanvas')
+    const canvas = new OffscreenCanvasG(targetWidth, targetHeight)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('thumbnail: could not get a 2d canvas context')
+    ctx.drawImage(image.source as any, 0, 0, targetWidth, targetHeight)
+    const blob = await canvas.convertToBlob({ type: mimeType, quality })
+    return new Uint8Array(await blob.arrayBuffer())
+  },
+}
+
+function onceEvent(target: any, name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onOk = () => {
+      cleanup()
+      resolve()
+    }
+    const onErr = () => {
+      cleanup()
+      reject(new Error(`thumbnail: <video> emitted "error" waiting for "${name}"`))
+    }
+    const cleanup = () => {
+      target.removeEventListener(name, onOk)
+      target.removeEventListener('error', onErr)
+    }
+    target.addEventListener(name, onOk, { once: true })
+    target.addEventListener('error', onErr, { once: true })
+  })
+}
+
+function seekVideo(video: any, seconds: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onSeeked = () => {
+      cleanup()
+      resolve()
+    }
+    const onErr = () => {
+      cleanup()
+      reject(new Error('thumbnail: <video> errored while seeking'))
+    }
+    const cleanup = () => {
+      video.removeEventListener('seeked', onSeeked)
+      video.removeEventListener('error', onErr)
+    }
+    video.addEventListener('seeked', onSeeked, { once: true })
+    video.addEventListener('error', onErr, { once: true })
+    video.currentTime = seconds
+  })
+}


### PR DESCRIPTION
## Summary

Follow-up to get the **blob transport** and **thumbnail generation** steps onto `main`. The original three PRs (#193/#194/#195) were stacked, so only #193 (the crypto core) merged into `main`; #194 and #195 merged into their parent branches and never reached `main`.

This PR targets `main` directly from the top of the stack, so its diff is exactly the two steps that are still missing — `main` already has the crypto core, so nothing is duplicated:

- `src/blobs/blobTransport.ts` + `blobTransport.test.js` (step 2 — glance-vault blob transfer client)
- `src/blobs/thumbnail.ts` + `thumbnail.test.js` (step 3 — thumbnail/poster generation)

No code changes versus what was already reviewed in #194 and #195 — this is purely about routing those commits to `main`. Full suite and `npm run build` pass (the two pre-existing `dates.test.js` timezone failures are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_