### PR TITLE
fix(android): stop widget picker showing a perpetual loading spinner

### DIFF
--- a/android/app/src/main/res/layout/widget_preview.xml
+++ b/android/app/src/main/res/layout/widget_preview.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static preview shown in the Android widget picker (long-press home screen →
+  Widgets). The widgets use Jetpack Glance, whose default initialLayout
+  (@layout/glance_default_loading_layout) is a loading spinner. Using that spinner
+  as the previewLayout makes every widget look like it's perpetually loading in
+  the picker, because Glance never composes real content there. This static,
+  on-brand tile replaces the spinner — actual content still renders once the
+  widget is placed on the home screen.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center"
+    android:background="#0F1117"
+    android:padding="12dp">
+
+    <ImageView
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:src="@mipmap/ic_launcher"
+        android:contentDescription="@null" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:text="@string/app_name"
+        android:textColor="#E8E0D0"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/android/app/src/main/res/xml/current_chapter_widget_info.xml
+++ b/android/app/src/main/res/xml/current_chapter_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_current_chapter_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/next_milestone_widget_info.xml
+++ b/android/app/src/main/res/xml/next_milestone_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_next_milestone_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/on_this_day_widget_info.xml
+++ b/android/app/src/main/res/xml/on_this_day_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_on_this_day_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/pinned_countdown_widget_info.xml
+++ b/android/app/src/main/res/xml/pinned_countdown_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_pinned_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/quick_add_widget_info.xml
+++ b/android/app/src/main/res/xml/quick_add_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_quick_add_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/stats_widget_info.xml
+++ b/android/app/src/main/res/xml/stats_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_stats_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/today_widget_info.xml
+++ b/android/app/src/main/res/xml/today_widget_info.xml
@@ -8,4 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_today_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/glance_default_loading_layout" />
+    android:previewLayout="@layout/widget_preview"
+    android:previewImage="@mipmap/ic_launcher" />


### PR DESCRIPTION
## Summary

In the Android widget picker (long-press home screen → Widgets), every lifeGLANCE widget appeared blank with a perpetual spinning circle. iOS shows real content there.

**Root cause.** The widgets use Jetpack Glance, and each provider XML set `previewLayout` to `@layout/glance_default_loading_layout` — Glance's **built-in loading layout, which is a `ProgressBar` spinner**. That's the right choice for `initialLayout` (the brief placeholder shown when a widget is actually placed, before Glance composes real content), but as the **`previewLayout`** it makes the picker show that spinner forever, because Glance never composes content in the picker. iOS shows content because WidgetKit calls `placeholder()`/`snapshot()` with sample data for the gallery; Glance has no equivalent — the preview must be a static image or layout.

(Note: the layout resource is *not* missing — if it were, the Android build would fail at resource linking rather than show a spinner. It's a Glance library resource that resolves fine; it just happens to be a spinner.)

## Fix

- Add `res/layout/widget_preview.xml` — a small static, on-brand tile (dark widget background + app icon + "lifeGLANCE").
- Point every widget's `previewLayout` at it, and set `android:previewImage="@mipmap/ic_launcher"` as the pre-Android-12 fallback.
- Leave `initialLayout` as the Glance loading layout, so placed widgets render real content exactly as before.

Files: new `widget_preview.xml`; 7 `*_widget_info.xml` updated (`previewLayout` → `@layout/widget_preview`, add `previewImage` → `@mipmap/ic_launcher`).

## Verification

This is an Android-native resource change; the CI/web build doesn't cover it and this environment has no Android SDK/Gradle, so I could not compile or render it. I verified that all 8 XML files are well-formed and that every reference (`@layout/widget_preview`, `@mipmap/ic_launcher`, `@string/app_name`, theme color literals) resolves to an existing resource. **A local `npm run build:mobile` / Android Studio build and a look at the widget picker is recommended before release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_