### PR TITLE
polish(android): colour widget-preview wordmark + compact preview for quick-add

### DIFF
--- a/android/app/src/main/res/layout/widget_preview.xml
+++ b/android/app/src/main/res/layout/widget_preview.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Static preview shown in the Android widget picker (long-press home screen →
-  Widgets). The widgets use Jetpack Glance, whose default initialLayout
-  (@layout/glance_default_loading_layout) is a loading spinner. Using that spinner
-  as the previewLayout makes every widget look like it's perpetually loading in
-  the picker, because Glance never composes real content there. This static,
-  on-brand tile replaces the spinner — actual content still renders once the
-  widget is placed on the home screen.
+  Widgets) for the standard-size widgets. The widgets use Jetpack Glance, whose
+  default initialLayout (@layout/glance_default_loading_layout) is a loading
+  spinner; using that as the previewLayout made every widget look like it was
+  perpetually loading. This on-brand "lifeGLANCE" wordmark replaces it (life in
+  the off-white text colour, GLANCE in purple to match the app). Real content
+  still renders once the widget is placed on the home screen.
+
+  The 1x1 quick-add widget is too narrow for the wordmark and uses
+  @layout/widget_preview_compact (icon only) instead.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
@@ -17,17 +20,28 @@
     android:padding="12dp">
 
     <ImageView
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="10dp"
         android:src="@mipmap/ic_launcher"
         android:contentDescription="@null" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
-        android:text="@string/app_name"
+        android:maxLines="1"
+        android:includeFontPadding="false"
+        android:text="life"
         android:textColor="#E8E0D0"
+        android:textSize="16sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="1"
+        android:includeFontPadding="false"
+        android:text="GLANCE"
+        android:textColor="#9370DB"
         android:textSize="16sp"
-        android:textStyle="bold" />
+        android:textStyle="bold|italic" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_preview_compact.xml
+++ b/android/app/src/main/res/layout/widget_preview_compact.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Compact widget-picker preview for the 1x1 quick-add widget (~80dp wide), where
+  the "lifeGLANCE" wordmark won't fit on one line. Icon only — no text, so
+  nothing wraps. See widget_preview.xml for the standard-size widgets.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#0F1117">
+
+    <ImageView
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        android:src="@mipmap/ic_launcher"
+        android:contentDescription="@null" />
+</FrameLayout>

--- a/android/app/src/main/res/xml/quick_add_widget_info.xml
+++ b/android/app/src/main/res/xml/quick_add_widget_info.xml
@@ -8,5 +8,5 @@
     android:widgetCategory="home_screen"
     android:description="@string/widget_quick_add_description"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:previewLayout="@layout/widget_preview"
+    android:previewLayout="@layout/widget_preview_compact"
     android:previewImage="@mipmap/ic_launcher" />


### PR DESCRIPTION
## Summary

Follow-up to #198 (the widget-picker spinner fix, already merged). Two small polish items requested on the preview tile:

1. **Colour the wordmark.** `life` stays in the off-white text colour and `GLANCE` is now purple (`--purple` → `#9370DB`), bold-italic to match the app wordmark. A single XML `TextView` can't colour part of its text, so it's split into two adjacent `TextView`s sharing a baseline.

2. **Fix the "Add milestone" wrap.** That widget is 1×1 (~80dp wide) vs 160–180dp for the others, so "lifeGLANCE" wrapped (`CE` onto a second line). It now uses its own icon-only preview (`widget_preview_compact.xml`) — no text, nothing wraps. The six standard-size widgets keep the wordmark tile.

## Files
- `widget_preview.xml` — split wordmark, `GLANCE` in purple bold-italic, `maxLines="1"`.
- `widget_preview_compact.xml` (new) — centered app icon on the dark background.
- `quick_add_widget_info.xml` — `previewLayout` → `@layout/widget_preview_compact`.

## Verification
Android-native resource change, not covered by CI/web build and not compilable in this environment (no Android SDK/Gradle). I verified all changed XML is well-formed and every reference resolves (`@layout/widget_preview_compact`, `@mipmap/ic_launcher`, the `--purple` literal). A local `npm run build:mobile` and a look at the widget picker is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_