### PR TITLE
feat(android): share target — add a milestone from a shared link/text

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Share target: receive a shared link / text to add as a milestone -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <!-- App shortcuts (long-press the launcher icon) -->
             <meta-data
                 android:name="android.app.shortcuts"

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -3,6 +3,8 @@ package com.lifeglance.app;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.json.JSONObject;
+
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
@@ -22,6 +24,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(WidgetBridgePlugin.class);
         super.onCreate(savedInstanceState);
         handleWidgetIntent(getIntent());
+        handleShareIntent(getIntent());
         enableImmersiveMode();
     }
 
@@ -30,6 +33,7 @@ public class MainActivity extends BridgeActivity {
         super.onNewIntent(intent);
         setIntent(intent);
         handleWidgetIntent(intent);
+        handleShareIntent(intent);
     }
 
     // Stash a widget tap's milestone id where the web layer can read it via
@@ -45,6 +49,33 @@ public class MainActivity extends BridgeActivity {
         editor.apply();
         intent.removeExtra(EXTRA_WIDGET_MILESTONE_ID);
         intent.removeExtra(EXTRA_WIDGET_ACTION);
+    }
+
+    // Stash an ACTION_SEND text/link share where the web layer reads it via
+    // WidgetBridge.consumeLaunchTarget(); it opens the add-milestone sheet
+    // pre-filled (see consumeWidgetLaunchTarget → shareToMilestoneDraft).
+    private void handleShareIntent(Intent intent) {
+        if (intent == null) return;
+        if (!Intent.ACTION_SEND.equals(intent.getAction())) return;
+        String type = intent.getType();
+        if (type == null || !type.startsWith("text/")) return;
+        String text    = intent.getStringExtra(Intent.EXTRA_TEXT);
+        String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+        if (text == null && subject == null) return;
+        try {
+            JSONObject obj = new JSONObject();
+            if (text != null)    obj.put("text", text);
+            if (subject != null) obj.put("subject", subject);
+            getSharedPreferences(WidgetData.PREFS, MODE_PRIVATE).edit()
+                .putString(WidgetData.KEY_PENDING_SHARE, obj.toString())
+                .apply();
+        } catch (org.json.JSONException ignored) {
+            // Malformed share payload — skip it rather than crash.
+        }
+        // Consume so a recreate/config-change doesn't re-open the sheet.
+        intent.removeExtra(Intent.EXTRA_TEXT);
+        intent.removeExtra(Intent.EXTRA_SUBJECT);
+        intent.setAction(null);
     }
 
     @Override

--- a/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/WidgetBridgePlugin.java
@@ -42,22 +42,25 @@ public class WidgetBridgePlugin extends Plugin {
         call.resolve();
     }
 
-    // Returns and clears a pending deep-link target left by a widget tap.
+    // Returns and clears a pending deep-link target left by a widget tap or a share.
     @PluginMethod
     public void consumeLaunchTarget(PluginCall call) {
         Context ctx = getContext();
         SharedPreferences prefs = ctx.getSharedPreferences(WidgetData.PREFS, Context.MODE_PRIVATE);
         String target = prefs.getString(WidgetData.KEY_PENDING_TARGET, null);
         String action = prefs.getString(WidgetData.KEY_PENDING_ACTION, null);
-        if (target != null || action != null) {
+        String share  = prefs.getString(WidgetData.KEY_PENDING_SHARE, null);
+        if (target != null || action != null || share != null) {
             prefs.edit()
                 .remove(WidgetData.KEY_PENDING_TARGET)
                 .remove(WidgetData.KEY_PENDING_ACTION)
+                .remove(WidgetData.KEY_PENDING_SHARE)
                 .apply();
         }
         JSObject ret = new JSObject();
         ret.put("milestoneId", target); // null when nothing is pending
         ret.put("action", action);
+        ret.put("share", share);        // JSON string { text, subject } or null
         call.resolve(ret);
     }
 }

--- a/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
+++ b/android/app/src/main/java/com/lifeglance/app/widget/WidgetData.kt
@@ -23,6 +23,8 @@ object WidgetData {
     const val KEY_SNAPSHOT = "snapshot"
     const val KEY_PENDING_TARGET = "pending_target"
     const val KEY_PENDING_ACTION = "pending_action"
+    // JSON { "text": ..., "subject": ... } from an ACTION_SEND text share.
+    const val KEY_PENDING_SHARE = "pending_share"
 
     fun prefs(context: Context) =
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -6,21 +6,25 @@ import { dbGetPhoto } from '../../data/db'
 import { getMilestoneVisibility } from '../../utils/visibility'
 import { isIntegrationEnabled } from '../../lib/intentsTransport.js'
 
-export default function AddMilestoneSheet({ onSave, onClose, existing, categories = DEFAULT_CATEGORIES, chapters = [], visibilityPrecomputed = { endpointChapterNames: new Map() }, drilledChapter = null }) {
+export default function AddMilestoneSheet({ onSave, onClose, existing, draft = null, categories = DEFAULT_CATEGORIES, chapters = [], visibilityPrecomputed = { endpointChapterNames: new Map() }, drilledChapter = null }) {
   const { t } = useTranslation('milestone')
   const { t: tc } = useTranslation('common')
   const { i18n } = useTranslation()
   const months = monthNames(i18n.language, 'short')
   const isEdit = !!existing
+  // `draft` pre-fills a NEW milestone (e.g. from the Android share sheet). It only
+  // seeds title/note/url; it never sets `isEdit`, so the rest stays new-milestone
+  // defaults. `existing` (edit mode) always wins over a draft.
+  const seed = existing ?? draft
 
-  const [title,      setTitle]      = useState(existing?.title     ?? '')
+  const [title,      setTitle]      = useState(seed?.title      ?? '')
   const [month,      setMonth]      = useState('6')
   const [day,        setDay]        = useState('')
   const [year,       setYear]       = useState('')
   const [precision,  setPrecision]  = useState(existing?.date_precision ?? 'month')
   const [category,   setCategory]   = useState(existing?.category  ?? 'personal')
-  const [note,       setNote]       = useState(existing?.note       ?? '')
-  const [url,        setUrl]        = useState(existing?.url        ?? '')
+  const [note,       setNote]       = useState(seed?.note        ?? '')
+  const [url,        setUrl]        = useState(seed?.url         ?? '')
 
   const [photoFile,       setPhotoFile]       = useState(null)
   const [photoObjectUrl,  setPhotoObjectUrl]  = useState(null)

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import Timeline          from './Timeline'
 import { collectCssVariables } from './exportImageHelpers'
+import { shareToMilestoneDraft } from '../../native/shareDraft'
 import StatsPanel        from '../stats/StatsPanel'
 import AddMilestoneSheet from '../milestone/AddMilestoneSheet'
 import MilestoneDetail   from '../milestone/MilestoneDetail'
@@ -87,6 +88,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   const [zoomAnim,      setZoomAnim]      = useState('')
   const [filter,        setFilter]        = useState(new Set())
   const [addOpen,       setAddOpen]       = useState(false)
+  const [shareDraft,    setShareDraft]    = useState(null)
   const [editTarget,    setEditTarget]    = useState(null)
   const [detail,        setDetail]        = useState(null)
   const [textSize,      setTextSize]      = useState(() => {
@@ -489,6 +491,14 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       }
       if (target.action === 'search') {   // "Search" app shortcut
         setSearchOpen(true)
+        return
+      }
+      if (target.share) {                 // shared a link/text from another app
+        const d = shareToMilestoneDraft(target.share)
+        if (!d) return
+        setEditTarget(null)
+        setShareDraft(d)
+        setAddOpen(true)
         return
       }
       const m = milestonesRef.current.find(x => x.id === target.milestoneId)
@@ -970,7 +980,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   }
 
   function openEdit(m)  { setEditTarget(m); setAddOpen(true) }
-  function closeSheet() { setAddOpen(false); setEditTarget(null) }
+  function closeSheet() { setAddOpen(false); setEditTarget(null); setShareDraft(null) }
 
   // ── Chapter CRUD ─────────────────────────────────────────────────────────────
   function openChapterCreate() { setEditChapter(null); setChapterSheetOpen(true) }
@@ -1967,7 +1977,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       {/* ── Sheets ─────────────────────────────────────────────────────────── */}
       {addOpen && (
         <AddMilestoneSheet
-          onSave={handleSave} onClose={closeSheet} existing={editTarget}
+          onSave={handleSave} onClose={closeSheet} existing={editTarget} draft={shareDraft}
           categories={categories}
           chapters={chapters}
           visibilityPrecomputed={visibilityPrecomputed}

--- a/src/native/shareDraft.js
+++ b/src/native/shareDraft.js
@@ -1,0 +1,42 @@
+// Maps a shared item (from the Android share sheet — ACTION_SEND text/plain) into
+// a draft milestone the Add sheet can be pre-filled with. Pure and platform-free
+// so it's unit-testable without a DOM; the native side only forwards { text,
+// subject } and this decides how they become a milestone's title / url / note.
+
+const URL_RE = /https?:\/\/\S+/i
+const MAX_TITLE = 120
+
+/**
+ * @param {{ text?: string, subject?: string } | null | undefined} share
+ * @returns {{ title: string, url: string, note: string } | null}
+ *   A draft to seed the Add-milestone sheet, or null if there's nothing usable.
+ */
+export function shareToMilestoneDraft(share) {
+  if (!share || typeof share !== 'object') return null
+  const text = typeof share.text === 'string' ? share.text.trim() : ''
+  const subject = typeof share.subject === 'string' ? share.subject.trim() : ''
+  if (!text && !subject) return null
+
+  // First URL found in the shared text (browsers/apps usually share the link there).
+  const match = text.match(URL_RE)
+  const url = match ? match[0] : ''
+
+  // Title: prefer an explicit subject (e.g. a page title); otherwise the shared
+  // text with the URL removed; otherwise the URL's hostname. One line, capped.
+  let title = subject || (url ? text.replace(url, ' ') : text)
+  title = title.replace(/\s+/g, ' ').trim()
+  if (!title && url) {
+    try {
+      title = new URL(url).hostname.replace(/^www\./, '')
+    } catch {
+      /* leave title empty */
+    }
+  }
+  if (title.length > MAX_TITLE) title = title.slice(0, MAX_TITLE).trim()
+
+  // Keep the full shared text as a note when it carries more than the title/url.
+  const note = text && text !== title && text !== url ? text : ''
+
+  if (!title && !url && !note) return null
+  return { title, url, note }
+}

--- a/src/native/shareDraft.test.js
+++ b/src/native/shareDraft.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { shareToMilestoneDraft } from './shareDraft'
+
+describe('shareToMilestoneDraft', () => {
+  it('returns null for empty / invalid input', () => {
+    expect(shareToMilestoneDraft(null)).toBeNull()
+    expect(shareToMilestoneDraft(undefined)).toBeNull()
+    expect(shareToMilestoneDraft({})).toBeNull()
+    expect(shareToMilestoneDraft({ text: '   ', subject: '' })).toBeNull()
+    expect(shareToMilestoneDraft('a string')).toBeNull()
+  })
+
+  it('uses the subject as the title and pulls the URL out of the text', () => {
+    const d = shareToMilestoneDraft({ subject: 'Our new house', text: 'https://maps.example.com/x' })
+    expect(d.title).toBe('Our new house')
+    expect(d.url).toBe('https://maps.example.com/x')
+    // text is exactly the url → no extra note
+    expect(d.note).toBe('')
+  })
+
+  it('derives a title from text with the URL stripped when no subject', () => {
+    const d = shareToMilestoneDraft({ text: 'Check this out https://example.com/article' })
+    expect(d.url).toBe('https://example.com/article')
+    expect(d.title).toBe('Check this out')
+    expect(d.note).toBe('Check this out https://example.com/article')
+  })
+
+  it('falls back to the URL hostname when there is only a link', () => {
+    const d = shareToMilestoneDraft({ text: 'https://www.example.com/path?q=1' })
+    expect(d.url).toBe('https://www.example.com/path?q=1')
+    expect(d.title).toBe('example.com') // www. stripped
+  })
+
+  it('handles plain text with no URL', () => {
+    const d = shareToMilestoneDraft({ text: 'Graduated today!' })
+    expect(d.url).toBe('')
+    expect(d.title).toBe('Graduated today!')
+    expect(d.note).toBe('') // text === title → no duplicate note
+  })
+
+  it('prefers subject over text for the title but keeps the text as a note', () => {
+    const d = shareToMilestoneDraft({ subject: 'Trip', text: 'Two weeks in Japan, spring 2027' })
+    expect(d.title).toBe('Trip')
+    expect(d.note).toBe('Two weeks in Japan, spring 2027')
+  })
+
+  it('caps an over-long title and collapses whitespace', () => {
+    const long = 'word '.repeat(60).trim() // ~300 chars, many spaces
+    const d = shareToMilestoneDraft({ text: long })
+    expect(d.title.length).toBeLessThanOrEqual(120)
+    expect(d.title).not.toMatch(/\s{2,}/) // collapsed
+    expect(d.note).toBe(long) // full text preserved
+  })
+
+  it('trims and ignores a blank subject', () => {
+    const d = shareToMilestoneDraft({ subject: '   ', text: 'Milestone' })
+    expect(d.title).toBe('Milestone')
+  })
+})

--- a/src/native/widgetBridge.js
+++ b/src/native/widgetBridge.js
@@ -31,6 +31,13 @@ export async function consumeWidgetLaunchTarget() {
   try {
     const res = await WidgetBridge.consumeLaunchTarget()
     if (res?.action) return { action: res.action }
+    if (res?.share) {
+      try {
+        return { share: JSON.parse(res.share) }
+      } catch {
+        return null
+      }
+    }
     if (res?.milestoneId) return { milestoneId: res.milestoneId }
     return null
   } catch (err) {


### PR DESCRIPTION
## Summary

Registers lifeGLANCE as an Android **share target**: share a link or text from any app → lifeGLANCE opens the **Add-milestone sheet pre-filled**. It reuses the existing widget intent → SharedPreferences → web bridge, so it slots into the same pipeline the widgets/shortcuts already use.

### Flow
- **Manifest:** an `ACTION_SEND` `text/plain` `<intent-filter>` on `MainActivity` (already `exported`/`singleTask`).
- **`MainActivity.handleShareIntent`:** stashes `EXTRA_TEXT`/`EXTRA_SUBJECT` as a JSON payload under a new `pending_share` key, then clears the intent so a recreate/config-change doesn't re-open the sheet.
- **`WidgetBridgePlugin.consumeLaunchTarget`:** also returns + clears `pending_share`.
- **`widgetBridge.js`:** surfaces it as `{ share: { text, subject } }`.
- **`shareToMilestoneDraft` (new, pure + unit-tested):** maps the shared text/subject to a draft `{ title, url, note }` — pulls the first URL into `url`, uses the subject (or text-minus-URL) as the title, keeps the full text as a `note`, and caps/collapses the title.
- **`TimelineView`:** on a share target, opens the Add sheet seeded with that draft.
- **`AddMilestoneSheet`:** a new optional `draft` prop that seeds `title`/`note`/`url` for a **new** milestone without flipping into edit mode (`existing` still wins).

The milestone model already has `url`, `note`, `title` fields, so there's no schema change.

### Scope
- **Text/links only** for now. Images (which route into the photo/blob pipeline) and **iOS** (which needs a separate Share Extension target in Xcode) are deliberately out of scope — iOS to follow later.

## Verification
- New `shareToMilestoneDraft` unit tests: **8** (subject vs text titles, URL extraction, hostname fallback, plain text, note preservation, title cap/whitespace).
- Web: full suite **161/161**, lint **0 errors**, `npm run build` passes (covers the `TimelineView`/`AddMilestoneSheet`/bridge changes).
- Android: not compilable in this environment, so the native side (manifest, `MainActivity`, plugin, `WidgetData`) isn't built/run here. Manifest XML is well-formed and the change reuses an already-working bridge. **Recommend a local `npm run build:mobile` / Android Studio build + a device check:** share a URL and a plain-text snippet from another app and confirm the Add sheet opens with the link in the URL field and a sensible title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_