### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
@@ -387,7 +387,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.4.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -549,7 +549,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.3.8",
+  "version": "2.4.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v2.4.0

Minor bump from 2.3.8. `package.json` is the single source of truth: Android derives `versionName 2.4.0` / `versionCode 20400000` (above 2.3.8's `20308000`); iOS `MARKETING_VERSION` synced to `2.4.0` via `scripts/sync-ios-version.mjs`.

### What's in this release (since v2.3.8)
- **New: Quick Settings tile** — one-tap "Add milestone" from the notification shade.
- **New: app shortcuts** — long-press the launcher icon for "Add milestone" and "Search".
- **New: Android share target** — share a link/text from another app to create a milestone, with the Add sheet pre-filled.
- **Fix: image export** — restored after the CSS-token migration (cards/text/colours render again), and the wordmark moved to the top-left so it no longer overlaps the timeline in compact views.
- **Fix: widget picker** — widgets no longer show a perpetual loading spinner; they show a branded preview (and an icon-only preview for the 1×1 quick-add), with a coloured wordmark.

### Files
- `package.json` → 2.4.0
- `ios/App/App.xcodeproj/project.pbxproj` → `MARKETING_VERSION = 2.4.0`

### Verification
Full web suite **161/161**, `npm run build` passes. Android/iOS native versions are derived/synced from `package.json` (Android not compiled in this environment).

After this merges, tag `v2.4.0` on `main` and cut the build (`build.sh` / `npm run build:mobile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXuKfG63KdjG7w8bpDpa9D)_