### PR TITLE
fix(sync): propagate category & birthday edits over GLANCEvault (push-on-write + UI refresh)

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -175,6 +175,26 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     showToast(ts('vaultSkippedToast', { count: vaultSkipped.count }), 'error')
   }, [vaultSkipped])
 
+  // Re-read categories/birthday after a GLANCEvault sync applied new bundle
+  // values to storage. These live in component state (unlike milestones/chapters,
+  // which the engine refreshes via setMilestones/setChapters), so without this
+  // they'd stay stale until an app reload. Set only when changed so an idle sync
+  // cycle doesn't trigger a needless re-render.
+  useEffect(() => {
+    const onSyncApplied = () => {
+      setCategories(prev => {
+        const next = loadCategories()
+        return JSON.stringify(prev) === JSON.stringify(next) ? prev : next
+      })
+      setBirthday(prev => {
+        const next = localStorage.getItem('lifeglance-birthday') || ''
+        return prev === next ? prev : next
+      })
+    }
+    window.addEventListener('lifeglance:sync-applied', onSyncApplied)
+    return () => window.removeEventListener('lifeglance:sync-applied', onSyncApplied)
+  }, [])
+
   // Apply font size globally
   useEffect(() => {
     document.documentElement.style.fontSize = TEXT_SIZES[textSize]

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -120,7 +120,6 @@ export const initDbSyncEngine = (opts = {}) => {
   })
 
   holder.markDirty = engine.markDirty
-  registerDirtyTarget({ markDirty: engine.markDirty })
 
   // HWM=0 full-snapshot seed: on first activation, mark every entity this device
   // already holds dirty so a brand-new vault device uploads its whole state. The
@@ -138,9 +137,14 @@ export const initDbSyncEngine = (opts = {}) => {
     opts.setChapters?.(ch)
     opts.setCategories?.(loadCategories())
     opts.setBirthday?.(localStorage.getItem('lifeglance-birthday') || '')
-    // Nudge UI that reads categories/birthday straight from storage (settings,
-    // widget) to re-read after a merge applied new bundle values.
-    if (typeof window !== 'undefined') window.dispatchEvent(new Event('lifeglance:widget-refresh'))
+    // Nudge UI that reads categories/birthday straight from storage to re-read
+    // after a merge applied new bundle values. milestones/chapters refresh via
+    // the setters above; categories/birthday live in component state (TimelineView)
+    // and re-read on this event, so a synced bundle shows without an app reload.
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('lifeglance:sync-applied'))
+      window.dispatchEvent(new Event('lifeglance:widget-refresh'))
+    }
   }
 
   const sync = async () => {
@@ -160,6 +164,14 @@ export const initDbSyncEngine = (opts = {}) => {
     clearTimeout(_pushTimer)
     _pushTimer = setTimeout(() => { pushNow().catch(err => console.warn('[dbsync] push failed', err)) }, ms)
   }
+
+  // Register the dirty target so EVERY local write (not just milestone/chapter
+  // edits) both marks its row dirty and schedules a vault push. Without the push
+  // nudge, a category/birthday/tombstone-only edit would mark dirty but wait for
+  // the 60s cycle to upload — and could miss it entirely if the app backgrounds
+  // first. Routing the push through markDirty makes push-on-write uniform across
+  // all entity types.
+  registerDirtyTarget({ markDirty: (id) => { engine.markDirty(id); pushDebounced() } })
 
   _dbEngine = { engine, sync, pushNow, pushDebounced, seedSnapshot, refresh, markDirty: engine.markDirty }
   return _dbEngine

--- a/src/sync/dbSync.test.js
+++ b/src/sync/dbSync.test.js
@@ -122,4 +122,63 @@ describe('Stage 2 Part B — DB sync engine wiring', () => {
     expect(onDevice2).not.toBeNull()
     expect(onDevice2.title).toBe('Pre-existing')
   })
+
+  // Gap B: a bundle-only edit (categories/birthday/tombstones) must trigger the
+  // push-on-write, not just milestone/chapter edits. Marking the categories
+  // bundle dirty schedules the debounced vault push and the row reaches the vault.
+  it('a category-only edit schedules a vault push (push-on-write for bundles)', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    localStorage.setItem('lifeglance-db-sync-seeded', '1') // skip seed so only the dirty bundle pushes
+    localStorage.setItem('lifeglance-categories', JSON.stringify([{ id: 'side', label: 'Side', color: '#FF8800' }]))
+    localStorage.setItem('lifeglance-categories-updated-at', new Date(2000).toISOString())
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    await m.setupDbRootKey('pw', new Uint8Array(16).fill(8), { cryptoDBName: 'lifeglance-crypto' })
+    m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+
+    const { markDirty } = await import('./dirty.js')
+    const { bundleEntityId } = await import('./entityIds.js')
+    const catId = bundleEntityId('categories')
+
+    // A local edit marks the bundle dirty AND schedules a push. Use fake timers
+    // so the scheduled push is observed (setTimeout) without firing real crypto
+    // under fake time; discard it on useRealTimers (no leak).
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    markDirty(catId)
+    expect(setTimeoutSpy).toHaveBeenCalled() // push-on-write scheduled
+    expect(JSON.parse(localStorage.getItem('lifeglance-db-sync-dirty'))).toContain(catId) // row marked dirty
+    setTimeoutSpy.mockRestore()
+    vi.useRealTimers()
+
+    // Flushing the push (what the debounce would do) delivers the bundle row.
+    const dbSync = m.getDbSyncEngine()
+    await dbSync.pushNow()
+    expect(vault._rows.has(catId)).toBe(true)
+    expect(vault._rows.get(catId).deleted).toBe(false)
+  })
+
+  // Gap A: after a cycle applies bundle values to storage, a sync-applied event
+  // fires so component-state UI (categories/birthday in TimelineView) re-reads
+  // without an app reload.
+  it('a sync dispatches lifeglance:sync-applied so the UI re-reads bundles', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    await m.setupDbRootKey('pw', new Uint8Array(16).fill(8), { cryptoDBName: 'lifeglance-crypto' })
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+
+    const prevWindow = globalThis.window
+    globalThis.window = new EventTarget()
+    let fired = 0
+    globalThis.window.addEventListener('lifeglance:sync-applied', () => { fired += 1 })
+    try {
+      await dbSync.sync()
+    } finally {
+      globalThis.window = prevWindow
+    }
+    expect(fired).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Problem

Categories appeared not to sync over GLANCEvault (they do over WebDAV). The data path was actually fine — a synced category reaches the other device's localStorage — but two **wiring gaps** around the per-row DB tier made it look broken. WebDAV never hit these because it ships the whole payload on every upload; the per-entity GLANCEvault tier exposed both.

- **Gap A — receive-side UI didn't refresh.** Synced bundle values are written to localStorage, but `categories`/`birthday` live in `TimelineView` component state, read once on mount. Milestones/chapters update live (their setters are wired into the engine's post-cycle `refresh()`); categories/birthday weren't — so they only showed after an app reload.
- **Gap B — push-on-write fired only for milestone/chapter edits.** The debounced vault push was triggered by `[milestones, chapters]` state changes, so a category/birthday/tombstone-only edit marked its row dirty but waited for the 60s cycle to upload (and could miss it if the app backgrounded first).

## Fix (trigger + refresh wiring only — no merge/engine changes)

1. **Gap A:** `dbSync.refresh()` now dispatches a `lifeglance:sync-applied` event; `TimelineView` listens and re-reads `loadCategories()` / birthday from storage (set-only-if-changed, so an idle cycle doesn't churn renders). Categories/birthday now show without a reload.
2. **Gap B:** the dirty forwarder now schedules `pushDebounced()` on **every** `markDirty`, making push-on-write uniform across all entity types (categories, birthday, tombstones — not just milestones/chapters). `registerDirtyTarget` moved after `pushDebounced` is defined.

The data path (dirty-marking, merge, seed) was already correct — this is purely the trigger + refresh wiring. WebDAV, merge logic, and engine internals are untouched.

## Testing

- New tests: a category-only edit schedules a push and the bundle row reaches the vault; a sync dispatches `lifeglance:sync-applied`.
- Full suite passes except the pre-existing `dates.test.js` "today" time-of-day flakiness (unrelated); `npm run build` exits 0; ESLint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_