### PR TITLE
refactor(blobs): convert Phase 7 blob modules from .ts to .js

### DIFF
--- a/src/blobs/blobCrypto.js
+++ b/src/blobs/blobCrypto.js
@@ -104,23 +104,9 @@ export class BlobKeyUnavailableError extends Error {
   }
 }
 
-/** The derived blob key, materialised as the two WebCrypto keys we need. */
-export interface BlobKey {
-  /** AES-256-GCM key for encrypt/decrypt. */
-  aesKey: CryptoKey
-  /** HMAC-SHA256 key for the content-derived nonce (same key bytes as `aesKey`). */
-  hmacKey: CryptoKey
-}
-
-/** A source of the vault root key: resolves to the key, or null if unavailable. */
-export type RootKeyProvider = () => Promise<CryptoKey | null>
-
-/** Plaintext accepted for encryption (binary blob data). */
-export type Plaintext = Uint8Array | ArrayBuffer
-
 const textEncoder = new TextEncoder()
 
-function toBytes(data: Plaintext): Uint8Array {
+function toBytes(data) {
   return data instanceof Uint8Array ? data : new Uint8Array(data)
 }
 
@@ -134,11 +120,9 @@ function toBytes(data: Plaintext): Uint8Array {
  *
  * @param getRootKey  Source of the root key (default: the vault intents store).
  *                    Injectable so this module stays decoupled and testable.
- * @returns the BlobKey, or `null` if the root key is not available.
+ * @returns the BlobKey ({ aesKey, hmacKey }), or `null` if the root key is not available.
  */
-export async function deriveBlobKey(
-  getRootKey: RootKeyProvider = loadIntentsRootKey,
-): Promise<BlobKey | null> {
+export async function deriveBlobKey(getRootKey = loadIntentsRootKey) {
   const rootKey = await getRootKey()
   if (!rootKey) return null
 
@@ -167,7 +151,7 @@ export async function deriveBlobKey(
 }
 
 /** SHA-256 of `bytes`, lowercase hex. */
-async function sha256Hex(bytes: Uint8Array): Promise<string> {
+async function sha256Hex(bytes) {
   const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
   let hex = ''
   for (const b of digest) hex += b.toString(16).padStart(2, '0')
@@ -177,17 +161,14 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 /**
  * Encrypt a blob deterministically and compute its content address.
  *
- * @param plaintext   The blob bytes.
+ * @param plaintext   The blob bytes (Uint8Array or ArrayBuffer).
  * @param getRootKey  Root key source (default: the vault intents store).
  * @returns `{ bytes, hash }` where `bytes` is the stored form [nonce || ciphertext]
  *          and `hash` is SHA-256(bytes) hex — the server-visible content address.
  * @throws  {BlobKeyUnavailableError} if the root key is unavailable. NEVER falls
  *          back to plaintext.
  */
-export async function encryptBlob(
-  plaintext: Plaintext,
-  getRootKey: RootKeyProvider = loadIntentsRootKey,
-): Promise<{ bytes: Uint8Array; hash: string }> {
+export async function encryptBlob(plaintext, getRootKey = loadIntentsRootKey) {
   const blobKey = await deriveBlobKey(getRootKey)
   if (!blobKey) throw new BlobKeyUnavailableError()
 
@@ -222,10 +203,7 @@ export async function encryptBlob(
  * @throws  if the blob has been tampered with (AES-GCM tag verification fails)
  *          or is malformed.
  */
-export async function decryptBlob(
-  stored: Uint8Array,
-  getRootKey: RootKeyProvider = loadIntentsRootKey,
-): Promise<Uint8Array> {
+export async function decryptBlob(stored, getRootKey = loadIntentsRootKey) {
   const blobKey = await deriveBlobKey(getRootKey)
   if (!blobKey) throw new BlobKeyUnavailableError()
 

--- a/src/blobs/blobCrypto.test.js
+++ b/src/blobs/blobCrypto.test.js
@@ -5,7 +5,7 @@ import {
   deriveBlobKey,
   BlobKeyUnavailableError,
   NONCE_LENGTH,
-} from './blobCrypto.ts'
+} from './blobCrypto.js'
 
 // The module reaches the vault root key through an injectable provider
 // (default: the intents key store). In tests we inject a provider that returns

--- a/src/blobs/blobTransport.js
+++ b/src/blobs/blobTransport.js
@@ -3,7 +3,7 @@
 // =============================================================================
 //
 // Drives the glance-vault blob HTTP API on top of the crypto core
-// (./blobCrypto.ts). It does NOT generate thumbnails and does NOT wire blobs to
+// (./blobCrypto.js). It does NOT generate thumbnails and does NOT wire blobs to
 // milestone entities — those are later steps. This file owns only the transport:
 // encrypt → existence-check → resumable upload → finalize, and download →
 // decrypt, plus existence and reference helpers.
@@ -33,7 +33,7 @@
 //
 // THE HASH SEAM (the load-bearing invariant this step proves):
 //   The stored blob bytes are [nonce(12) || ciphertext+tag] and the address is
-//   `hash = SHA-256(those exact bytes)` (see blobCrypto.ts). The client uploads
+//   `hash = SHA-256(those exact bytes)` (see blobCrypto.js). The client uploads
 //   those exact bytes in order; on finalize the server reassembles the parts,
 //   recomputes SHA-256 over the reassembled bytes, and MUST get the same hash the
 //   client declared. Same bytes hashed the same way ⇒ finalize accepts. The
@@ -43,7 +43,7 @@
 // unavailable, BlobKeyUnavailableError propagates and NOTHING is sent — the
 // caller treats it as a hold/retry, mirroring the intents key-absent path.
 //
-// FUTURE: like blobCrypto.ts, this is structured for extraction into a shared
+// FUTURE: like blobCrypto.js, this is structured for extraction into a shared
 // `@glance-apps/*` package — it imports only the crypto core and reads the
 // connection through an injectable seam, with no UI or milestone dependencies.
 // (Native binary routing — Range + arrayBuffer over CapacitorHttp — is a
@@ -51,46 +51,8 @@
 // browser/PWA and is what `fetchImpl` injection swaps out.)
 // =============================================================================
 
-import {
-  encryptBlob,
-  decryptBlob,
-  type Plaintext,
-  type RootKeyProvider,
-} from './blobCrypto.ts'
+import { encryptBlob, decryptBlob } from './blobCrypto.js'
 import { nativeVaultFetchImpl } from '../sync/nativeVaultFetch.js'
-
-/** The glance-vault connection coordinates (same shape sync's vault client uses). */
-export interface VaultConnection {
-  vaultUrl: string
-  vaultToken: string
-  accountId: string
-}
-
-/** Minimal fetch shape we depend on — global `fetch` satisfies it. */
-export type FetchImpl = (url: string, init: FetchInit) => Promise<FetchResponse>
-export interface FetchInit {
-  method: string
-  headers: Record<string, string>
-  body?: Uint8Array | ArrayBuffer | string
-}
-export interface FetchResponse {
-  ok: boolean
-  status: number
-  arrayBuffer(): Promise<ArrayBuffer>
-  json(): Promise<any>
-}
-
-/** Injectable dependencies; every public fn accepts these, all with safe defaults. */
-export interface BlobTransportDeps {
-  /** The vault connection to use. Defaults to reading the sync config. */
-  connection?: VaultConnection | null
-  /** The fetch implementation. Defaults to global fetch. */
-  fetchImpl?: FetchImpl
-  /** The blob root-key source, threaded into the crypto core. */
-  getRootKey?: RootKeyProvider
-  /** Upload part size in bytes. Defaults to 1 MiB. */
-  partSize?: number
-}
 
 /** Default resumable-upload part size: 1 MiB. */
 export const DEFAULT_PART_SIZE = 1024 * 1024
@@ -104,8 +66,8 @@ const SYNC_CONFIG_KEY = 'lifeglance-cloud-sync-config'
  * error. The caller should retry once the vault connection is populated.
  */
 export class VaultConnectionUnavailableError extends Error {
-  readonly code = 'VAULT_NOT_READY'
-  readonly transient = true
+  code = 'VAULT_NOT_READY'
+  transient = true
   constructor(message = 'vault connection not available (URL, token, or accountId missing)') {
     super(message)
     this.name = 'VaultConnectionUnavailableError'
@@ -114,8 +76,7 @@ export class VaultConnectionUnavailableError extends Error {
 
 /** A blob endpoint returned a non-OK status. Carries the HTTP status. */
 export class BlobTransportError extends Error {
-  readonly status: number
-  constructor(message: string, status: number) {
+  constructor(message, status) {
     super(message)
     this.name = 'BlobTransportError'
     this.status = status
@@ -130,8 +91,7 @@ export class BlobTransportError extends Error {
  * end-to-end test asserts does NOT occur on the happy path.
  */
 export class BlobHashMismatchError extends Error {
-  readonly hash: string
-  constructor(hash: string) {
+  constructor(hash) {
     super(`finalize rejected: server hash of reassembled bytes != declared hash ${hash}`)
     this.name = 'BlobHashMismatchError'
     this.hash = hash
@@ -145,8 +105,8 @@ export class BlobHashMismatchError extends Error {
  * @glance-apps/sync's vault transport reads it). Returns null if absent or
  * incomplete — callers turn that into a VaultConnectionUnavailableError.
  */
-export function readVaultConnection(): VaultConnection | null {
-  let cfg: any
+export function readVaultConnection() {
+  let cfg
   try {
     const raw = localStorage.getItem(SYNC_CONFIG_KEY)
     cfg = raw ? JSON.parse(raw) : null
@@ -167,20 +127,20 @@ export function readVaultConnection(): VaultConnection | null {
   return { vaultUrl, vaultToken, accountId }
 }
 
-function resolveConnection(deps: BlobTransportDeps): VaultConnection {
+function resolveConnection(deps) {
   const conn = deps.connection ?? readVaultConnection()
   if (!conn) throw new VaultConnectionUnavailableError()
   return conn
 }
 
-function resolveFetch(deps: BlobTransportDeps): FetchImpl {
+function resolveFetch(deps) {
   // On native, route vault blob requests through CapacitorHttp (undefined on web,
   // so the browser/PWA keeps using global fetch — the vault serves CORS there).
   // This is the same native-safe adapter the sync vault client and verify probe
   // use, so the blob control plane reaches the vault on native ahead of the
   // Phase 8 media round-trip.
-  const native = nativeVaultFetchImpl() as unknown as FetchImpl | undefined
-  const f = deps.fetchImpl ?? native ?? (globalThis.fetch as unknown as FetchImpl | undefined)
+  const native = nativeVaultFetchImpl()
+  const f = deps.fetchImpl ?? native ?? globalThis.fetch
   if (typeof f !== 'function') {
     throw new Error('blobTransport: no fetch implementation available')
   }
@@ -189,26 +149,13 @@ function resolveFetch(deps: BlobTransportDeps): FetchImpl {
 
 // ── Request helper (mirrors vaultClient.js request/authHeaders) ───────────────
 
-interface RequestOpts {
-  query?: Record<string, string>
-  jsonBody?: unknown
-  binaryBody?: Uint8Array | ArrayBuffer
-  headers?: Record<string, string>
-}
-
-async function vaultRequest(
-  conn: VaultConnection,
-  doFetch: FetchImpl,
-  method: string,
-  path: string,
-  opts: RequestOpts = {},
-): Promise<FetchResponse> {
+async function vaultRequest(conn, doFetch, method, path, opts = {}) {
   let url = conn.vaultUrl.replace(/\/+$/, '') + path
   if (opts.query) {
     const qs = new URLSearchParams(opts.query).toString()
     if (qs) url += `?${qs}`
   }
-  const init: FetchInit = {
+  const init = {
     method,
     headers: { Authorization: `Bearer ${conn.vaultToken}`, ...opts.headers },
   }
@@ -222,7 +169,7 @@ async function vaultRequest(
   return doFetch(url, init)
 }
 
-async function jsonOrThrow(res: FetchResponse, context: string): Promise<any> {
+async function jsonOrThrow(res, context) {
   if (!res.ok) throw new BlobTransportError(`${context} failed: ${res.status}`, res.status)
   return res.json()
 }
@@ -234,7 +181,7 @@ async function jsonOrThrow(res: FetchResponse, context: string): Promise<any> {
  * @returns true if present (2xx), false if absent (404).
  * @throws  BlobTransportError on any other status.
  */
-export async function blobExists(hash: string, deps: BlobTransportDeps = {}): Promise<boolean> {
+export async function blobExists(hash, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
   const res = await vaultRequest(conn, doFetch, 'HEAD', `/blobs/${encodeURIComponent(hash)}`, {
@@ -247,8 +194,8 @@ export async function blobExists(hash: string, deps: BlobTransportDeps = {}): Pr
 
 // ── Upload ───────────────────────────────────────────────────────────────────
 
-function splitIntoParts(bytes: Uint8Array, partSize: number): Uint8Array[] {
-  const parts: Uint8Array[] = []
+function splitIntoParts(bytes, partSize) {
+  const parts = []
   for (let off = 0; off < bytes.length; off += partSize) {
     parts.push(bytes.subarray(off, Math.min(off + partSize, bytes.length)))
   }
@@ -259,13 +206,7 @@ function splitIntoParts(bytes: Uint8Array, partSize: number): Uint8Array[] {
 }
 
 /** POST /blobs/uploads — initiate (idempotent on hash) → uploadId. */
-async function initiateUpload(
-  conn: VaultConnection,
-  doFetch: FetchImpl,
-  hash: string,
-  size: number,
-  partSize: number,
-): Promise<string> {
+async function initiateUpload(conn, doFetch, hash, size, partSize) {
   const res = await vaultRequest(conn, doFetch, 'POST', '/blobs/uploads', {
     jsonBody: { accountId: conn.accountId, hash, size, partSize },
   })
@@ -277,27 +218,17 @@ async function initiateUpload(
 }
 
 /** GET /blobs/uploads/:id — which part indices the server already holds. */
-async function getResumePoint(
-  conn: VaultConnection,
-  doFetch: FetchImpl,
-  uploadId: string,
-): Promise<Set<number>> {
+async function getResumePoint(conn, doFetch, uploadId) {
   const res = await vaultRequest(conn, doFetch, 'GET', `/blobs/uploads/${encodeURIComponent(uploadId)}`, {
     query: { accountId: conn.accountId },
   })
   const body = await jsonOrThrow(res, 'resume point')
-  const received: number[] = Array.isArray(body?.received) ? body.received : []
+  const received = Array.isArray(body?.received) ? body.received : []
   return new Set(received)
 }
 
 /** PUT /blobs/uploads/:id/parts/:i — send one part (raw bytes). */
-async function putPart(
-  conn: VaultConnection,
-  doFetch: FetchImpl,
-  uploadId: string,
-  index: number,
-  part: Uint8Array,
-): Promise<void> {
+async function putPart(conn, doFetch, uploadId, index, part) {
   const res = await vaultRequest(
     conn,
     doFetch,
@@ -309,12 +240,7 @@ async function putPart(
 }
 
 /** POST /blobs/uploads/:id/finalize — reassemble + verify hash + store. */
-async function finalizeUpload(
-  conn: VaultConnection,
-  doFetch: FetchImpl,
-  uploadId: string,
-  hash: string,
-): Promise<void> {
+async function finalizeUpload(conn, doFetch, uploadId, hash) {
   const res = await vaultRequest(
     conn,
     doFetch,
@@ -325,7 +251,7 @@ async function finalizeUpload(
   if (res.ok) return
   // The server signals a hash mismatch distinctly so we can surface it clearly.
   if (res.status === 409 || res.status === 422 || res.status === 400) {
-    let err: any = null
+    let err = null
     try {
       err = await res.json()
     } catch {
@@ -349,12 +275,12 @@ async function finalizeUpload(
  *    restarting.
  * 4. Return the hash on success.
  *
- * @throws {import('./blobCrypto.ts').BlobKeyUnavailableError} if the key is absent.
+ * @throws {import('./blobCrypto.js').BlobKeyUnavailableError} if the key is absent.
  * @throws {VaultConnectionUnavailableError} if the vault connection is not ready.
  * @throws {BlobHashMismatchError} if finalize rejects the declared hash.
  * @throws {BlobTransportError} on other non-OK responses.
  */
-export async function uploadBlob(plaintext: Plaintext, deps: BlobTransportDeps = {}): Promise<string> {
+export async function uploadBlob(plaintext, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
   const partSize = deps.partSize ?? DEFAULT_PART_SIZE
@@ -383,14 +309,7 @@ export async function uploadBlob(plaintext: Plaintext, deps: BlobTransportDeps =
 
 // ── Download ─────────────────────────────────────────────────────────────────
 
-/** A byte range for partial download. Inclusive, like an HTTP Range header. */
-export interface ByteRange {
-  start: number
-  /** Inclusive end. Omit for "to the end". */
-  end?: number
-}
-
-function rangeHeader(range: ByteRange): string {
+function rangeHeader(range) {
   return range.end === undefined
     ? `bytes=${range.start}-`
     : `bytes=${range.start}-${range.end}`
@@ -406,13 +325,10 @@ function rangeHeader(range: ByteRange): string {
  * @throws {VaultConnectionUnavailableError} if the vault connection is not ready.
  * @throws {BlobTransportError} on a non-OK response.
  */
-export async function downloadBlobBytes(
-  hash: string,
-  deps: BlobTransportDeps & { range?: ByteRange } = {},
-): Promise<Uint8Array> {
+export async function downloadBlobBytes(hash, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
-  const headers: Record<string, string> = {}
+  const headers = {}
   if (deps.range) headers['Range'] = rangeHeader(deps.range)
   const res = await vaultRequest(conn, doFetch, 'GET', `/blobs/${encodeURIComponent(hash)}`, {
     query: { accountId: conn.accountId },
@@ -426,10 +342,10 @@ export async function downloadBlobBytes(
  * Download a full blob and decrypt it to plaintext. Decryption verifies the
  * GCM tag, so a tampered/corrupt blob fails clearly (the decrypt rejects).
  *
- * @throws {import('./blobCrypto.ts').BlobKeyUnavailableError} if the key is absent.
+ * @throws {import('./blobCrypto.js').BlobKeyUnavailableError} if the key is absent.
  * @throws if the downloaded bytes fail GCM verification (tampered/corrupt).
  */
-export async function downloadBlob(hash: string, deps: BlobTransportDeps = {}): Promise<Uint8Array> {
+export async function downloadBlob(hash, deps = {}) {
   const bytes = await downloadBlobBytes(hash, deps)
   return decryptBlob(bytes, deps.getRootKey)
 }
@@ -439,7 +355,7 @@ export async function downloadBlob(hash: string, deps: BlobTransportDeps = {}): 
 // (on milestone create/delete) is the wiring step — not this module.
 
 /** POST /blobs/:hash/ref-add — increment the reference count for a blob. */
-export async function addBlobRef(hash: string, deps: BlobTransportDeps = {}): Promise<void> {
+export async function addBlobRef(hash, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
   const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-add`, {
@@ -449,7 +365,7 @@ export async function addBlobRef(hash: string, deps: BlobTransportDeps = {}): Pr
 }
 
 /** POST /blobs/:hash/ref-release — decrement the reference count for a blob. */
-export async function releaseBlobRef(hash: string, deps: BlobTransportDeps = {}): Promise<void> {
+export async function releaseBlobRef(hash, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
   const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-release`, {

--- a/src/blobs/blobTransport.test.js
+++ b/src/blobs/blobTransport.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { encryptBlob } from './blobCrypto.ts'
+import { encryptBlob } from './blobCrypto.js'
 import {
   uploadBlob,
   downloadBlob,
@@ -10,8 +10,8 @@ import {
   readVaultConnection,
   VaultConnectionUnavailableError,
   BlobHashMismatchError,
-} from './blobTransport.ts'
-import { BlobKeyUnavailableError } from './blobCrypto.ts'
+} from './blobTransport.js'
+import { BlobKeyUnavailableError } from './blobCrypto.js'
 
 // =============================================================================
 // END-TO-END / SEAM NOTE

--- a/src/blobs/thumbnail.js
+++ b/src/blobs/thumbnail.js
@@ -51,58 +51,14 @@ export const POSTER_FRAME_TIME_SECONDS = 1
  * thumbnail that was never made.
  */
 export class ThumbnailGenerationError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
+  constructor(message, options) {
     super(message, options)
     this.name = 'ThumbnailGenerationError'
   }
 }
 
-/** A decoded raster image: its pixel dimensions plus an opaque drawable source. */
-export interface RasterImage {
-  width: number
-  height: number
-  /** Opaque handle the processor's own `encode` knows how to draw (e.g. ImageBitmap). */
-  source: unknown
-}
-
-/**
- * The platform image-processing primitive. The real implementation uses browser
- * canvas APIs; tests inject a fake. Kept tiny and side-effect-explicit so it can
- * be swapped per platform.
- */
-export interface ImageProcessor {
-  /** Decode still-image bytes into a drawable raster (with dimensions). */
-  decodeImage(bytes: Uint8Array, mimeType: string): Promise<RasterImage>
-  /** Grab a poster frame from video bytes at ~`atSeconds` into a drawable raster. */
-  decodeVideoFrame(bytes: Uint8Array, mimeType: string, atSeconds: number): Promise<RasterImage>
-  /** Downscale `image` to `targetWidth`×`targetHeight` and encode to `mimeType` bytes. */
-  encode(
-    image: RasterImage,
-    targetWidth: number,
-    targetHeight: number,
-    mimeType: string,
-    quality: number,
-  ): Promise<Uint8Array>
-}
-
-/** Options for {@link generateThumbnail}. All optional; sensible defaults apply. */
-export interface ThumbnailOptions {
-  /** Image-processing primitive. Defaults to the browser-backed processor. */
-  processor?: ImageProcessor
-  /** Longest-edge bound in px. Defaults to {@link MAX_THUMBNAIL_EDGE}. */
-  maxEdge?: number
-  /** Output mime type. Defaults to {@link DEFAULT_OUTPUT_MIME}. */
-  outputMimeType?: string
-  /** Encode quality 0..1. Defaults to {@link DEFAULT_QUALITY}. */
-  quality?: number
-  /** Video poster timestamp (s). Defaults to {@link POSTER_FRAME_TIME_SECONDS}. */
-  posterTimeSeconds?: number
-}
-
-export type SourceKind = 'image' | 'video'
-
 /** Classify a source mime type. Returns null for anything we can't thumbnail. */
-export function sourceKind(mimeType: string | undefined | null): SourceKind | null {
+export function sourceKind(mimeType) {
   if (typeof mimeType !== 'string') return null
   const m = mimeType.toLowerCase().trim()
   if (m.startsWith('image/')) return 'image'
@@ -110,7 +66,7 @@ export function sourceKind(mimeType: string | undefined | null): SourceKind | nu
   return null
 }
 
-function isPositiveInt(n: unknown): n is number {
+function isPositiveInt(n) {
   return typeof n === 'number' && Number.isFinite(n) && n > 0
 }
 
@@ -119,11 +75,7 @@ function isPositiveInt(n: unknown): n is number {
  * ratio. Never upscales: a source already within the bound is returned unchanged.
  * Pure — no platform dependency — so it's directly testable.
  */
-export function fitWithin(
-  width: number,
-  height: number,
-  maxEdge: number,
-): { width: number; height: number } {
+export function fitWithin(width, height, maxEdge) {
   const longest = Math.max(width, height)
   if (longest <= maxEdge) return { width, height }
   const scale = maxEdge / longest
@@ -149,11 +101,7 @@ export function fitWithin(
  * @throws {ThumbnailGenerationError} on unsupported/corrupt source or any
  *         decode/encode failure — cleanly, with no partial output.
  */
-export async function generateThumbnail(
-  sourceBytes: Uint8Array,
-  mimeType: string,
-  opts: ThumbnailOptions = {},
-): Promise<{ bytes: Uint8Array; mimeType: string }> {
+export async function generateThumbnail(sourceBytes, mimeType, opts = {}) {
   const processor = opts.processor ?? browserImageProcessor
   const maxEdge = opts.maxEdge ?? MAX_THUMBNAIL_EDGE
   const outputMimeType = opts.outputMimeType ?? DEFAULT_OUTPUT_MIME
@@ -170,7 +118,7 @@ export async function generateThumbnail(
   }
 
   // Decode (platform). A corrupt or undecodable source surfaces here.
-  let decoded: RasterImage
+  let decoded
   try {
     decoded =
       kind === 'video'
@@ -186,7 +134,7 @@ export async function generateThumbnail(
   const target = fitWithin(decoded.width, decoded.height, maxEdge)
 
   // Downscale + encode (platform).
-  let bytes: Uint8Array
+  let bytes
   try {
     bytes = await processor.encode(decoded, target.width, target.height, outputMimeType, quality)
   } catch (err) {
@@ -207,31 +155,31 @@ export async function generateThumbnail(
 // is safe; the methods themselves only run in-app, where tests inject a fake.
 // =============================================================================
 
-function requireGlobal<T>(name: string): T {
-  const g = (globalThis as any)[name]
+function requireGlobal(name) {
+  const g = globalThis[name]
   if (g == null) throw new Error(`thumbnail: ${name} is not available in this environment`)
-  return g as T
+  return g
 }
 
-async function decodeWith(createBitmap: () => Promise<any>): Promise<RasterImage> {
+async function decodeWith(createBitmap) {
   const bitmap = await createBitmap()
   return { width: bitmap.width, height: bitmap.height, source: bitmap }
 }
 
-export const browserImageProcessor: ImageProcessor = {
+export const browserImageProcessor = {
   async decodeImage(bytes, mimeType) {
-    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
-    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    const createImageBitmap = requireGlobal('createImageBitmap')
+    const blob = new Blob([bytes], { type: mimeType })
     return decodeWith(() => createImageBitmap(blob))
   },
 
   async decodeVideoFrame(bytes, mimeType, atSeconds) {
-    const createImageBitmap = requireGlobal<(b: any) => Promise<any>>('createImageBitmap')
-    const doc = requireGlobal<any>('document')
-    const URLg = requireGlobal<any>('URL')
-    const blob = new Blob([bytes as BlobPart], { type: mimeType })
+    const createImageBitmap = requireGlobal('createImageBitmap')
+    const doc = requireGlobal('document')
+    const URLg = requireGlobal('URL')
+    const blob = new Blob([bytes], { type: mimeType })
     const url = URLg.createObjectURL(blob)
-    const video: any = doc.createElement('video')
+    const video = doc.createElement('video')
     video.muted = true
     video.preload = 'auto'
     video.playsInline = true
@@ -253,17 +201,17 @@ export const browserImageProcessor: ImageProcessor = {
   },
 
   async encode(image, targetWidth, targetHeight, mimeType, quality) {
-    const OffscreenCanvasG = requireGlobal<any>('OffscreenCanvas')
+    const OffscreenCanvasG = requireGlobal('OffscreenCanvas')
     const canvas = new OffscreenCanvasG(targetWidth, targetHeight)
     const ctx = canvas.getContext('2d')
     if (!ctx) throw new Error('thumbnail: could not get a 2d canvas context')
-    ctx.drawImage(image.source as any, 0, 0, targetWidth, targetHeight)
+    ctx.drawImage(image.source, 0, 0, targetWidth, targetHeight)
     const blob = await canvas.convertToBlob({ type: mimeType, quality })
     return new Uint8Array(await blob.arrayBuffer())
   },
 }
 
-function onceEvent(target: any, name: string): Promise<void> {
+function onceEvent(target, name) {
   return new Promise((resolve, reject) => {
     const onOk = () => {
       cleanup()
@@ -282,7 +230,7 @@ function onceEvent(target: any, name: string): Promise<void> {
   })
 }
 
-function seekVideo(video: any, seconds: number): Promise<void> {
+function seekVideo(video, seconds) {
   return new Promise((resolve, reject) => {
     const onSeeked = () => {
       cleanup()

--- a/src/blobs/thumbnail.test.js
+++ b/src/blobs/thumbnail.test.js
@@ -7,7 +7,7 @@ import {
   MAX_THUMBNAIL_EDGE,
   DEFAULT_OUTPUT_MIME,
   POSTER_FRAME_TIME_SECONDS,
-} from './thumbnail.ts'
+} from './thumbnail.js'
 
 // =============================================================================
 // TEST ENVIRONMENT NOTE

--- a/src/sync/nativeVaultFetch.test.js
+++ b/src/sync/nativeVaultFetch.test.js
@@ -107,7 +107,7 @@ describe('wiring — injection sites pass the adapter on native, undefined on we
   })
 
   it('blob transport uses global fetch on web (adapter undefined), not throwing for missing fetch', async () => {
-    const { blobExists } = await import('../blobs/blobTransport.ts')
+    const { blobExists } = await import('../blobs/blobTransport.js')
     // Inject an explicit fetch so we exercise resolveFetch without hitting network;
     // proves the native fallback does not interfere on web.
     const fetchImpl = async () => ({ ok: false, status: 404, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) })


### PR DESCRIPTION
lifeGLANCE is a pure-JavaScript project (no tsconfig, ESLint globs .js/.jsx, vitest node env). The Phase 7 blob modules were the only TypeScript files — an island that escaped linting and looked out of place. Convert them to plain JS.

Type-stripping only, behavior unchanged:
- src/blobs/blobCrypto.ts  -> .js
- src/blobs/blobTransport.ts -> .js
- src/blobs/thumbnail.ts   -> .js
Removed interfaces/type aliases/generics/`as` casts/param+return annotations and
the `import type`s; kept the runtime logic byte-for-byte, including the typed
error classes (BlobKeyUnavailableError, VaultConnectionUnavailableError,
BlobTransportError, BlobHashMismatchError, ThumbnailGenerationError) — their
`readonly` field annotations dropped, real fields kept. The native-fetch adapter
wiring in resolveFetch is preserved exactly (casts removed, logic identical).

Updated importers' explicit .ts paths to .js: the three blob test files, the blobTransport->blobCrypto import, the @throws JSDoc import() refs, and nativeVaultFetch.test.js. No .ts files or .ts import references remain under src/.

These three files are now linted (they enter the .js glob) and pass with zero errors and zero warnings — no behavior change was needed to satisfy lint. No .ts files exist outside src/blobs/.

Blob tests pass unchanged (57), full suite green (the 2 dates.test.js failures are pre-existing time-of-day flakiness), build passes.


Claude-Session: https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH