### PR TITLE
feat(media): wire milestone media to GLANCEvault blobs (Phase 8.1 — new attachments + display)

### DIFF
--- a/src/blobs/milestoneMedia.js
+++ b/src/blobs/milestoneMedia.js
@@ -1,0 +1,133 @@
+// =============================================================================
+// milestoneMedia — wire milestone media to the GLANCEvault blob store (Phase 8.1)
+// =============================================================================
+//
+// Points the reserved milestone reference slots (media_id / photo_id /
+// thumbnail_id) at REAL content-addressed blob hashes, and resolves them back to
+// bytes for display. New-attachment path + display path only — NOT a backfill of
+// existing local media (that's a separate step).
+//
+// Building blocks (Phase 7, native-safe): blobTransport.uploadBlob (HEAD-dedup +
+// resumable, idempotent), downloadBlob, addBlobRef/releaseBlobRef; thumbnail
+// .generateThumbnail. All injectable via `deps` so this is unit-testable with the
+// faked native primitive / fake image processor the Phase 7 modules already use.
+//
+// INVARIANTS:
+//  • BLOBS-BEFORE-REFERENCE: the full-res blob AND its thumbnail are uploaded and
+//    confirmed stored BEFORE the caller writes any reference slot. uploadBlob is
+//    idempotent (HEAD-dedup), so a retry after a partial failure is safe.
+//  • NO REFERENCE TO A THUMBNAIL THAT WASN'T MADE: thumbnail generation runs
+//    FIRST; if it throws, we abort before any upload or ref — nothing is written.
+//  • The CALLER writes the returned slot hashes via updateMilestone(), which
+//    bumps updated_at — real hashes are not device-derivable, so the change must
+//    propagate via LWW (unlike the old deterministic backfill, which did not bump).
+
+import {
+  uploadBlob as _uploadBlob,
+  downloadBlob as _downloadBlob,
+  addBlobRef as _addBlobRef,
+  releaseBlobRef as _releaseBlobRef,
+} from './blobTransport.js'
+import { generateThumbnail as _generateThumbnail, sourceKind } from './thumbnail.js'
+
+// A real blob slot is a lowercase 64-hex SHA-256. The legacy placeholders are the
+// milestone id (`<uuid>`) or `<uuid>-photo` — never 64 hex — so this cleanly
+// distinguishes a vault-backed slot from a local-only one.
+const HASH_RE = /^[0-9a-f]{64}$/
+export function isRealBlobHash(value) {
+  return typeof value === 'string' && HASH_RE.test(value)
+}
+
+/**
+ * Upload a milestone's media bytes (+ a thumbnail for image/video) to the vault
+ * and reference-count them. Returns `{ fullHash, thumbHash }` (thumbHash is null
+ * for audio, which has no visual thumbnail). The caller writes these to the slots
+ * ONLY after this resolves.
+ *
+ * Ordering: generate thumbnail → upload full → upload thumb → ref-add both. A
+ * throw at any step leaves NOTHING referenced (uploads are idempotent on retry).
+ *
+ * @throws {import('./thumbnail.js').ThumbnailGenerationError} bad/corrupt source — before any upload.
+ * @throws {import('./blobCrypto.js').BlobKeyUnavailableError} no vault key yet — before any network write.
+ * @throws on any upload / ref failure (caller treats as "reference not established yet", retriable).
+ */
+export async function uploadMilestoneMedia({ bytes, mimeType }, deps = {}) {
+  const uploadBlob = deps.uploadBlob ?? _uploadBlob
+  const generateThumbnail = deps.generateThumbnail ?? _generateThumbnail
+  const addBlobRef = deps.addBlobRef ?? _addBlobRef
+
+  const kind = sourceKind(mimeType)
+  const wantsThumb = kind === 'image' || kind === 'video'
+
+  // 1. Thumbnail FIRST — if it can't be made, abort before any upload/reference.
+  let thumb = null
+  if (wantsThumb) thumb = await generateThumbnail(bytes, mimeType)
+
+  // 2. Upload both blobs, confirm stored, BEFORE the caller writes any slot.
+  const fullHash = await uploadBlob(bytes)
+  const thumbHash = thumb ? await uploadBlob(thumb.bytes) : null
+
+  // 3. Reference-count on the server (feeds eventual reclaim).
+  await addBlobRef(fullHash)
+  if (thumbHash) await addBlobRef(thumbHash)
+
+  return { fullHash, thumbHash }
+}
+
+/**
+ * Release server references for a milestone's REAL-hash slots (delete path).
+ * Releasing a reference is not deleting a blob — it lets the server's ref count
+ * drop toward eventual reclaim. Best-effort and idempotent; placeholders are
+ * ignored. Returns the unique hashes it released.
+ */
+export async function releaseMilestoneMedia(milestone, deps = {}) {
+  const releaseBlobRef = deps.releaseBlobRef ?? _releaseBlobRef
+  const hashes = [milestone?.photo_id, milestone?.media_id, milestone?.thumbnail_id].filter(isRealBlobHash)
+  const unique = [...new Set(hashes)]
+  for (const h of unique) {
+    try {
+      await releaseBlobRef(h)
+    } catch (err) {
+      // Best-effort: a failed release just delays reclaim; never block the delete.
+      if (import.meta?.env?.DEV) console.warn('[media] releaseBlobRef failed (non-fatal):', err)
+    }
+  }
+  return unique
+}
+
+// ── Display: decrypted-thumbnail cache (timeline re-render) ──────────────────
+// Keyed by content hash. A content address is immutable, so a decrypted thumbnail
+// can be cached for the session and never re-fetched. Failures are NOT cached, so
+// a missing blob re-fetches next time (self-heal once a holder re-uploads).
+const _thumbCache = new Map()
+
+/**
+ * Fetch + decrypt a thumbnail by its blob hash, cached in memory. Returns null
+ * for a non-real-hash (legacy/local) slot. Rejects only on a genuine fetch/
+ * decrypt failure — callers render the missing-media placeholder on rejection.
+ */
+export function fetchThumbnailBytes(hash, deps = {}) {
+  if (!isRealBlobHash(hash)) return Promise.resolve(null)
+  if (_thumbCache.has(hash)) return _thumbCache.get(hash)
+  const downloadBlob = deps.downloadBlob ?? _downloadBlob
+  const p = downloadBlob(hash).then(
+    (bytes) => { _thumbCache.set(hash, Promise.resolve(bytes)); return bytes },
+    (err) => { _thumbCache.delete(hash); throw err },
+  )
+  _thumbCache.set(hash, p)
+  return p
+}
+
+export function clearThumbnailCache() {
+  _thumbCache.clear()
+}
+
+/**
+ * Fetch + decrypt full-res photo / video bytes by hash (lazy, uncached — large).
+ * Returns null for a non-real-hash slot. Rejects on fetch/decrypt failure.
+ */
+export function fetchFullResBytes(hash, deps = {}) {
+  if (!isRealBlobHash(hash)) return Promise.resolve(null)
+  const downloadBlob = deps.downloadBlob ?? _downloadBlob
+  return downloadBlob(hash)
+}

--- a/src/blobs/milestoneMedia.test.js
+++ b/src/blobs/milestoneMedia.test.js
@@ -1,0 +1,150 @@
+// Tests for the Phase 8.1 milestone↔blob wiring. Pure unit tests with injected
+// fakes (the real native upload + canvas thumbnail run on-device only — the
+// Phase 7 modules are already structured for exactly this fake-deps testing).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  isRealBlobHash,
+  uploadMilestoneMedia,
+  releaseMilestoneMedia,
+  fetchThumbnailBytes,
+  fetchFullResBytes,
+  clearThumbnailCache,
+} from './milestoneMedia.js'
+
+const HASH_A = 'a'.repeat(64) // full-res
+const HASH_T = 'b'.repeat(64) // thumbnail
+const bytes = new Uint8Array([1, 2, 3])
+
+beforeEach(() => clearThumbnailCache())
+
+describe('isRealBlobHash — real hash vs legacy placeholder', () => {
+  it('accepts a 64-hex sha256', () => expect(isRealBlobHash('f'.repeat(64))).toBe(true))
+  it('rejects the deterministic placeholders and junk', () => {
+    expect(isRealBlobHash('11111111-2222-4333-8444-555555555555')).toBe(false) // uuid
+    expect(isRealBlobHash('11111111-2222-4333-8444-555555555555-photo')).toBe(false)
+    expect(isRealBlobHash(null)).toBe(false)
+    expect(isRealBlobHash('ABC')).toBe(false)
+    expect(isRealBlobHash('g'.repeat(64))).toBe(false) // non-hex
+  })
+})
+
+describe('uploadMilestoneMedia — ordering + clean-fail', () => {
+  function recorder(overrides = {}) {
+    const calls = []
+    return {
+      calls,
+      generateThumbnail: overrides.generateThumbnail ?? (async () => { calls.push('thumb'); return { bytes: new Uint8Array([9]), mimeType: 'image/jpeg' } }),
+      uploadBlob: overrides.uploadBlob ?? (async (b) => { calls.push(`upload:${b[0]}`); return b[0] === 9 ? HASH_T : HASH_A }),
+      addBlobRef: overrides.addBlobRef ?? (async (h) => { calls.push(`ref:${h === HASH_T ? 'T' : 'A'}`) }),
+    }
+  }
+
+  it('image: generates thumbnail, uploads full THEN thumb, refs both — in order, before returning slots', async () => {
+    const d = recorder()
+    const out = await uploadMilestoneMedia({ bytes, mimeType: 'image/png' }, d)
+    expect(out).toEqual({ fullHash: HASH_A, thumbHash: HASH_T })
+    // thumbnail made first, then both uploads, then both refs — references last.
+    expect(d.calls).toEqual(['thumb', 'upload:1', 'upload:9', 'ref:A', 'ref:T'])
+  })
+
+  it('video: same path (poster thumbnail)', async () => {
+    const d = recorder()
+    const out = await uploadMilestoneMedia({ bytes, mimeType: 'video/mp4' }, d)
+    expect(out).toEqual({ fullHash: HASH_A, thumbHash: HASH_T })
+    expect(d.calls).toEqual(['thumb', 'upload:1', 'upload:9', 'ref:A', 'ref:T'])
+  })
+
+  it('audio: no thumbnail — one upload, one ref, thumbHash null', async () => {
+    const d = recorder()
+    const out = await uploadMilestoneMedia({ bytes, mimeType: 'audio/webm' }, d)
+    expect(out).toEqual({ fullHash: HASH_A, thumbHash: null })
+    expect(d.calls).toEqual(['upload:1', 'ref:A']) // no 'thumb'
+  })
+
+  it('thumbnail-generation failure aborts BEFORE any upload or ref (no reference to a thumbnail that was never made)', async () => {
+    const err = new Error('corrupt source')
+    const d = recorder({ generateThumbnail: async () => { throw err } })
+    await expect(uploadMilestoneMedia({ bytes, mimeType: 'image/png' }, d)).rejects.toThrow('corrupt source')
+    expect(d.calls).toEqual([]) // nothing uploaded, nothing referenced
+  })
+
+  it('upload failure throws and never reaches ref-add (no half-written reference)', async () => {
+    const calls = []
+    const d = {
+      generateThumbnail: async () => { calls.push('thumb'); return { bytes: new Uint8Array([9]), mimeType: 'image/jpeg' } },
+      uploadBlob: async (b) => { calls.push(`upload:${b[0]}`); if (b[0] === 9) throw new Error('upload failed') ; return HASH_A },
+      addBlobRef: async () => { calls.push('ref') },
+    }
+    await expect(uploadMilestoneMedia({ bytes, mimeType: 'image/png' }, d)).rejects.toThrow('upload failed')
+    // full uploaded, thumb upload threw → no ref-add at all
+    expect(calls).toEqual(['thumb', 'upload:1', 'upload:9'])
+  })
+})
+
+describe('releaseMilestoneMedia — delete path', () => {
+  it('releases each unique real-hash slot, ignores placeholders', async () => {
+    const released = []
+    const m = { photo_id: HASH_A, thumbnail_id: HASH_T, media_id: 'some-uuid-placeholder' }
+    const out = await releaseMilestoneMedia(m, { releaseBlobRef: async (h) => { released.push(h) } })
+    expect(released.sort()).toEqual([HASH_A, HASH_T].sort())
+    expect(out.sort()).toEqual([HASH_A, HASH_T].sort())
+  })
+
+  it('dedups when full-res and thumbnail share a slot value', async () => {
+    const released = []
+    const m = { photo_id: HASH_A, thumbnail_id: HASH_A }
+    await releaseMilestoneMedia(m, { releaseBlobRef: async (h) => { released.push(h) } })
+    expect(released).toEqual([HASH_A]) // once
+  })
+
+  it('is best-effort: a failing release never throws (delete must not be blocked)', async () => {
+    const m = { photo_id: HASH_A }
+    await expect(
+      releaseMilestoneMedia(m, { releaseBlobRef: async () => { throw new Error('network') } }),
+    ).resolves.toEqual([HASH_A])
+  })
+
+  it('no-ops for a local-only milestone (no real-hash slots)', async () => {
+    let called = false
+    const m = { photo_id: 'uuid-photo', media_id: null, thumbnail_id: null }
+    const out = await releaseMilestoneMedia(m, { releaseBlobRef: async () => { called = true } })
+    expect(out).toEqual([])
+    expect(called).toBe(false)
+  })
+})
+
+describe('display fetch — cache + discrimination', () => {
+  it('fetchThumbnailBytes downloads a real hash and caches it (no second download)', async () => {
+    let downloads = 0
+    const downloadBlob = async () => { downloads += 1; return new Uint8Array([7, 7]) }
+    const a = await fetchThumbnailBytes(HASH_T, { downloadBlob })
+    const b = await fetchThumbnailBytes(HASH_T, { downloadBlob })
+    expect(a).toEqual(new Uint8Array([7, 7]))
+    expect(b).toEqual(new Uint8Array([7, 7]))
+    expect(downloads).toBe(1) // cached
+  })
+
+  it('fetchThumbnailBytes returns null for a placeholder slot (no fetch)', async () => {
+    let called = false
+    const r = await fetchThumbnailBytes('uuid-photo', { downloadBlob: async () => { called = true } })
+    expect(r).toBeNull()
+    expect(called).toBe(false)
+  })
+
+  it('fetchThumbnailBytes does NOT cache a failure (re-fetch allows self-heal)', async () => {
+    let n = 0
+    const downloadBlob = async () => { n += 1; if (n === 1) throw new Error('missing'); return new Uint8Array([5]) }
+    await expect(fetchThumbnailBytes(HASH_T, { downloadBlob })).rejects.toThrow('missing')
+    const second = await fetchThumbnailBytes(HASH_T, { downloadBlob })
+    expect(second).toEqual(new Uint8Array([5]))
+    expect(n).toBe(2)
+  })
+
+  it('fetchFullResBytes downloads a real hash, null for placeholder', async () => {
+    const downloadBlob = vi.fn(async () => new Uint8Array([1]))
+    expect(await fetchFullResBytes(HASH_A, { downloadBlob })).toEqual(new Uint8Array([1]))
+    expect(await fetchFullResBytes('uuid', { downloadBlob })).toBeNull()
+    expect(downloadBlob).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Capacitor } from '@capacitor/core'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
+import { isRealBlobHash, fetchFullResBytes } from '../../blobs/milestoneMedia.js'
 
 const PINS_KEY = 'lifeglance-pins'
 // Color pin slots — each maps to its own countdown widget. Keep in sync with PIN_SLOTS
@@ -43,27 +44,43 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
     return () => window.removeEventListener('keydown', handler)
   }, [onClose])
 
+  // Media (audio/video): a real-hash media_id resolves from the GLANCEvault blob
+  // store (lazy, on open); a legacy/placeholder slot resolves from the local
+  // media store. A fetch failure (blob not yet uploaded / reclaimed) leaves
+  // audioUrl null → the graceful "media unavailable" placeholder renders below.
   useEffect(() => {
     if (!m.media_type) return
-    let objectUrl
-    dbGetMedia(m.id).then(result => {
-      if (!result) return
-      objectUrl = URL.createObjectURL(result.blob)
+    let objectUrl, cancelled = false
+    const show = (blob) => {
+      if (cancelled || !blob) return
+      objectUrl = URL.createObjectURL(blob)
       setAudioUrl(objectUrl)
-    })
-    return () => { if (objectUrl) URL.revokeObjectURL(objectUrl) }
-  }, [m.id, m.media_type])
+    }
+    if (isRealBlobHash(m.media_id)) {
+      const type = m.media_type === 'video' ? 'video/mp4' : 'audio/mpeg'
+      fetchFullResBytes(m.media_id).then(b => show(b && new Blob([b], { type }))).catch(() => {})
+    } else {
+      dbGetMedia(m.id).then(result => show(result?.blob)).catch(() => {})
+    }
+    return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl) }
+  }, [m.id, m.media_type, m.media_id])
 
   useEffect(() => {
     if (!m.has_photo) return
-    let objectUrl
-    dbGetPhoto(m.id).then(result => {
-      if (!result) return
-      objectUrl = URL.createObjectURL(result.blob)
+    let objectUrl, cancelled = false
+    const show = (blob) => {
+      if (cancelled || !blob) return
+      objectUrl = URL.createObjectURL(blob)
       setPhotoUrl(objectUrl)
-    })
-    return () => { if (objectUrl) URL.revokeObjectURL(objectUrl) }
-  }, [m.id, m.has_photo])
+    }
+    if (isRealBlobHash(m.photo_id)) {
+      // No stored mime on the slot; <img> content-sniffs an untyped image blob.
+      fetchFullResBytes(m.photo_id).then(b => show(b && new Blob([b]))).catch(() => {})
+    } else {
+      dbGetPhoto(m.id).then(result => show(result?.blob)).catch(() => {})
+    }
+    return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl) }
+  }, [m.id, m.has_photo, m.photo_id])
 
   function doDelete()       { onDelete(m.id); onClose() }
   function doDeleteSeries() { onDeleteSeries(m.recurrence_id); onClose() }

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -24,6 +24,8 @@ import { listChapters, restoreChapters, createChapter, updateChapter, deleteChap
 import { writeMilestoneTombstone } from '../../sync/tombstones'
 import { getSyncEngine } from '../../sync/engine'
 import { dirtyBirthday } from '../../sync/dirty'
+import { readVaultConfig } from '../../sync/dbSync'
+import { uploadMilestoneMedia, releaseMilestoneMedia } from '../../blobs/milestoneMedia.js'
 import ChapterSheet from '../chapter/ChapterSheet'
 import CloudSyncModal from '../sync/CloudSyncModal'
 import SyncPassphraseModal from '../sync/SyncPassphraseModal'
@@ -797,6 +799,44 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     toastTimerRef.current = setTimeout(() => setToast(null), 5000)
   }
 
+  // Phase 8: when vault sync is on, upload a newly-attached file's bytes (+ a
+  // thumbnail for image/video) to the GLANCEvault blob store and point the
+  // milestone's reference slots at the REAL content hashes. BLOBS-BEFORE-
+  // REFERENCE: the slots are written — via updateMilestone, which BUMPS updated_at
+  // so the now-non-deterministic hashes propagate by LWW — only after both blobs
+  // are confirmed stored. Clean-fail: on thumbnail-generation or upload failure
+  // the milestone keeps its local media with placeholder slots (nothing
+  // half-written); the vault reference just isn't established yet, and is
+  // retriable. No-op when vault is off (local/WebDAV path unchanged).
+  async function establishVaultMediaRefs(milestone, file, slot) {
+    if (!file || !readVaultConfig()) return milestone
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer())
+      const { fullHash, thumbHash } = await uploadMilestoneMedia({ bytes, mimeType: file.type })
+      const updates = slot === 'photo' ? { photo_id: fullHash } : { media_id: fullHash }
+      if (thumbHash) updates.thumbnail_id = thumbHash
+      return await updateMilestone(milestone.id, updates, milestone)
+    } catch (err) {
+      console.warn('[media] vault blob sync deferred (kept local, retriable):', err)
+      showToast(t('mediaVaultDeferred'), 'info')
+      return milestone
+    }
+  }
+
+  // Establish vault blob refs in the BACKGROUND after the milestone is already
+  // shown locally (snappy UI), then refresh just that milestone in state with the
+  // real-hash slots. Chains photo then media so the second write builds on the
+  // first (no slot clobber). No-op when vault is off or no new file was attached.
+  function backgroundEstablishMedia(milestone, photoFile, mediaFile) {
+    if (!readVaultConfig() || (!photoFile && !mediaFile)) return
+    ;(async () => {
+      let m = milestone
+      if (photoFile) m = await establishVaultMediaRefs(m, photoFile, 'photo')
+      if (mediaFile) m = await establishVaultMediaRefs(m, mediaFile, 'media')
+      if (m !== milestone) setMilestones(prev => prev.map(x => (x.id === m.id ? m : x)))
+    })().catch(err => console.warn('[media] establish failed:', err))
+  }
+
   // ── CRUD ─────────────────────────────────────────────────────────────────────
   async function executeSave(data, existing) {
     // photoFile / photoRemoved / mediaFile / mediaRemoved are transfer-only fields
@@ -829,6 +869,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         const newMs = milestones.map(m => m.id === existing.id ? updated : m)
         pushHistory(newMs)
         setMilestones(newMs)
+        backgroundEstablishMedia(updated, photoFile, mediaFile)
         audio.playEditSave()
         // Emit create if the user just enabled dayGLANCE tracking for the first time.
         if (updated.dayglance_linked && !existing.dayglance_linked) {
@@ -876,6 +917,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         const newMs = [...milestones, ...created]
         pushHistory(newMs)
         setMilestones(newMs)
+        backgroundEstablishMedia(created[0], photoFile, mediaFile) // base-year instance holds the media
         setNewlyAddedId(created[0].id)
         audio.playChime()
       } else {
@@ -891,6 +933,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         const newMs = [...milestones, m]
         pushHistory(newMs)
         setMilestones(newMs)
+        backgroundEstablishMedia(m, photoFile, mediaFile)
         setNewlyAddedId(m.id)
         // Emit outbound create to dayGLANCE if the user checked "track as dayGLANCE Goal".
         if (dgLinked) {
@@ -968,6 +1011,9 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     try {
       const target = milestones.find(m => m.id === id)
       await deleteMilestone(id)
+      // Phase 8: drop the server ref counts for any real-hash blob slots so the
+      // vault can eventually reclaim them. Best-effort; never blocks the delete.
+      if (target && readVaultConfig()) releaseMilestoneMedia(target).catch(() => {})
       const newMs = milestones.filter(m => m.id !== id)
       pushHistory(newMs)
       setMilestones(newMs)
@@ -986,9 +1032,11 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   async function handleDeleteSeries(recurrence_id) {
     try {
       const toDelete = milestones.filter(m => m.recurrence_id === recurrence_id)
+      const vaultOn = !!readVaultConfig()
       for (const m of toDelete) {
         writeMilestoneTombstone(m.id)
         await deleteMilestone(m.id)
+        if (vaultOn) releaseMilestoneMedia(m).catch(() => {})
       }
       const newMs = milestones.filter(m => m.recurrence_id !== recurrence_id)
       pushHistory(newMs)

--- a/src/data/milestones.test.js
+++ b/src/data/milestones.test.js
@@ -65,6 +65,25 @@ describe('updateMilestone', () => {
     expect(all[0].title).toBe('Updated')
   })
 
+  it('bumps updated_at when writing a real blob hash to a media slot (Phase 8)', async () => {
+    // Real blob hashes are not device-derivable (unlike the old deterministic
+    // placeholders), so writing one MUST bump updated_at to propagate via LWW —
+    // i.e. it must go through the normal updateMilestone mutation, not a silent
+    // no-bump backfill.
+    const { addMilestone, updateMilestone, loadMilestones } = await setup()
+    const { dbPut } = await import('./db')
+    const m = await addMilestone({ title: 'Has photo', date: new Date('2020-01-01'), has_photo: true })
+    // Force an old updated_at so the bump is unambiguous.
+    const old = '2000-01-01T00:00:00.000Z'
+    await dbPut({ ...m, updated_at: old })
+    const realHash = 'a'.repeat(64)
+    const updated = await updateMilestone(m.id, { photo_id: realHash, thumbnail_id: 'b'.repeat(64) }, { ...m, updated_at: old })
+    expect(updated.photo_id).toBe(realHash)
+    expect(new Date(updated.updated_at).getTime()).toBeGreaterThan(new Date(old).getTime())
+    const all = await loadMilestones()
+    expect(all[0].updated_at).toBe(updated.updated_at)
+  })
+
   it('recalculates direction on date change', async () => {
     const { addMilestone, updateMilestone, loadMilestones } = await setup()
     const m = await addMilestone({ title: 'Test', date: new Date('2000-01-01') })

--- a/src/locales/en/timeline.json
+++ b/src/locales/en/timeline.json
@@ -55,5 +55,7 @@
   "mediaStorageRemaining": "You have {{size}} of storage remaining.",
   "mediaAttachAnyway": "attach anyway",
   "yearsAgo_one": "{{count}} year ago",
-  "yearsAgo_other": "{{count}} years ago"
+  "yearsAgo_other": "{{count}} years ago",
+  "mediaVaultDeferred": "Saved locally — syncing this media to the cloud will retry shortly.",
+  "mediaUnavailable": "media unavailable"
 }


### PR DESCRIPTION
Points the reserved milestone reference slots (`media_id` / `photo_id` / `thumbnail_id`) at **real content-addressed blob hashes** and renders them. New-attachment path + display path only — **not** a backfill of existing local media (separate next step). Built on the Phase 7 blob blocks (now native-safe).

## Core — `src/blobs/milestoneMedia.js` (fully unit-tested with injected fakes)
- **`uploadMilestoneMedia`** — thumbnail **first** (image/video; skipped for audio), then upload full + thumbnail, then ref-add both. **Blobs-before-reference** ordering: a thumbnail-generation or upload failure leaves *nothing* referenced (uploads are HEAD-dedup'd + idempotent, so retry is safe).
- **`releaseMilestoneMedia`** — best-effort, dedup'd `releaseBlobRef` for real-hash slots on delete; never blocks the delete.
- **`isRealBlobHash`** — 64-hex discriminates a vault slot from the legacy `<id>` / `<id>-photo` placeholder.
- **`fetchThumbnailBytes`** (in-memory cache; failures **not** cached → self-heal) / **`fetchFullResBytes`** for display.

## Upload path (`TimelineView`, vault-on only)
After the local media persist, a background establish uploads the file + thumbnail and writes the real hashes via `updateMilestone` — which **bumps `updated_at`** (real hashes aren't device-derivable, so they must propagate by LWW; the old no-bump `backfillMediaIds` behavior is **not** carried here). Clean-fail: a soft toast, placeholder slots kept, nothing half-written. **Delete** releases the refs. Gated on `readVaultConfig()` (not platform) — the local/WebDAV path is unchanged when vault is off, and the path runs on **PWA and native alike** (web uses `globalThis.fetch` against the CORS-serving vault; native rides the Phase 7 `CapacitorHttp` adapter).

## Display (`MilestoneDetail`)
A real-hash `photo_id`/`media_id` resolves from the blob store (lazy, on open); a placeholder resolves from the local media store; a fetch failure falls through to the existing graceful "media unavailable" placeholder.

## Tests (16 new, all pass)
Ordering; audio-no-thumbnail; thumbnail-gen failure aborts before any upload/ref; upload failure leaves no ref; delete releases (dedup, best-effort, no-op for local-only); cache hit + no-cache-on-failure; placeholder discrimination; and the `updated_at` bump on a real-hash slot write. Full suite passes except the pre-existing `dates.test.js` time-of-day flakiness; `npm run build` exits 0; ESLint 0 errors.

## Confirmable only on-device / in a real browser (what to test next)
1. Real round-trip: `CapacitorHttp` (native) / `globalThis.fetch` (PWA) upload to a live GLANCEvault, and a second device pulling + fetching the blob (tests fake the native primitive).
2. Real thumbnail generation via canvas/`OffscreenCanvas` (tests use a fake processor; throws → clean-fail on browsers without `OffscreenCanvas`).
3. Cross-device display fidelity (untyped image `Blob` content-sniff; video mime is best-effort since the slot stores no mime).
4. **Timeline inline thumbnails — deliberately deferred:** the cached `fetchThumbnailBytes` helper is ready and tested, but async `<image>` thumbnails were **not** wired into the complex SVG timeline render (needs visual verification). Detail-view display is fully wired.

## Not in scope
No backfill of existing local media; no merge/engine/`@glance-apps/*` changes; no entity remodel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_