### PR TITLE
diag(media): surface the swallowed blob-upload error on-device

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -817,8 +817,14 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       if (thumbHash) updates.thumbnail_id = thumbHash
       return await updateMilestone(milestone.id, updates, milestone)
     } catch (err) {
-      console.warn('[media] vault blob sync deferred (kept local, retriable):', err)
-      showToast(t('mediaVaultDeferred'), 'info')
+      // Behavior unchanged (kept local, retriable, slots left as placeholders).
+      // TEMPORARY DIAGNOSTIC: surface the real error name+message on-screen so a
+      // non-debuggable release build reveals WHY the blob upload failed
+      // (BlobKeyUnavailableError / ThumbnailGenerationError / VaultError / …).
+      console.error('[media] vault blob sync deferred (kept local, retriable):', err)
+      const name = err?.name || 'Error'
+      const message = err?.message || String(err)
+      showToast(`Media sync deferred: ${name}: ${message}`, 'error')
       return milestone
     }
   }


### PR DESCRIPTION
Temporary, reversible diagnostic. `establishVaultMediaRefs` was catching any background blob-upload failure into a `console.warn` + a generic "will retry" toast, hiding the real error — impossible to diagnose on a non-debuggable release build (the symptom behind the "attaching a photo produces no blob-backed photo" report).

## Change (error surfacing only)
The single catch block that both the photo and media/audio paths flow through:

```js
} catch (err) {
  console.error('[media] vault blob sync deferred (kept local, retriable):', err)
  const name = err?.name || 'Error'
  const message = err?.message || String(err)
  showToast(`Media sync deferred: ${name}: ${message}`, 'error')
  return milestone
}
```

- Toast now shows **`Media sync deferred: <error.name>: <error.message>`** so `BlobKeyUnavailableError` / `ThumbnailGenerationError` / a `VaultError` is identifiable at a glance on-screen.
- `console.warn` → `console.error` with the full error object.
- Non-blocking (`error` toast, auto-dismisses).

## Explicitly NOT changed
`return milestone` (kept-local, retriable, slots left as placeholders), the upload path, key handling, thumbnail generation, and the retry/soft-fail semantics — all unchanged. Purely makes the existing swallowed error readable.

Verified: ESLint clean, `npm run build` exits 0. (The now-unused `mediaVaultDeferred` i18n key is left in place — out of scope for this minimal change.)

Once reproduced on-device, the toast text pinpoints which of the four candidate failure points it is (my read: `BlobKeyUnavailableError`, confirming the missing intents/blob key on the UNINITIALIZED vault-setup path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_