### PR TITLE
fix(native): send/receive blob bytes as binary over CapacitorHttp

### DIFF
--- a/src/blobs/blobTransport.js
+++ b/src/blobs/blobTransport.js
@@ -166,6 +166,10 @@ async function vaultRequest(conn, doFetch, method, path, opts = {}) {
     init.headers['Content-Type'] = 'application/octet-stream'
     init.body = opts.binaryBody
   }
+  // Hint for a binary response body (blob download). Ignored by the browser's
+  // real fetch (which reads .arrayBuffer() natively); used by the native
+  // CapacitorHttp adapter to request an arraybuffer/base64 read.
+  if (opts.responseType) init.responseType = opts.responseType
   return doFetch(url, init)
 }
 
@@ -333,6 +337,7 @@ export async function downloadBlobBytes(hash, deps = {}) {
   const res = await vaultRequest(conn, doFetch, 'GET', `/blobs/${encodeURIComponent(hash)}`, {
     query: { accountId: conn.accountId },
     headers,
+    responseType: 'arraybuffer', // native adapter reads bytes; browser fetch ignores it
   })
   if (!res.ok) throw new BlobTransportError(`download failed: ${res.status}`, res.status)
   return new Uint8Array(await res.arrayBuffer())

--- a/src/sync/nativeVaultFetch.js
+++ b/src/sync/nativeVaultFetch.js
@@ -4,45 +4,100 @@
 // both issue requests with the standard `fetch(url, init)` signature and read
 // `.ok / .status / .json() / .text()` (the blob transport also `.arrayBuffer()`)
 // off the result. On a native Capacitor WebView, the default `globalThis.fetch`
-// to the cross-origin vault is blocked by CORS — which is why the verify probe,
-// vault sync, and blob upload/download all fail on native.
+// to the cross-origin vault is CORS-blocked, so this routes the same call through
+// CapacitorHttp and synthesizes a Response.
 //
-// This adapter routes that same `(url, init)` call through lifeGLANCE's existing
-// native HTTP primitive (CapacitorHttp, via nativeRequest) and synthesizes a
-// minimal Response so callers don't know the difference — the same shape
-// lastGLANCE's vaultFetchImpl uses. It is the EXPLICIT half of the fix; the
-// other half is the global CapacitorHttp patch in capacitor.config.ts, which
-// covers the engine's internal vault client that we don't inject into.
+// BINARY (Phase 8 blob media): CapacitorHttp does NOT accept a raw Uint8Array
+// body — a typed array serialises to `{"0":..}` via its JSON path, corrupting or
+// rejecting the request (this broke blob part-uploads on native). The plugin's
+// binary contract, verified against @capacitor/android Capacitor 8:
+//   • REQUEST binary  → `data` = base64 string + `dataType: 'file'`; the native
+//     side base64-DECODES it and writes raw bytes (CapacitorHttpUrlConnection).
+//   • RESPONSE binary → `responseType: 'arraybuffer'`; `res.data` comes back as a
+//     base64 string (readStreamAsBase64), so it must be base64-DECODED here.
+// Text/JSON control-plane calls keep `responseType: 'text'` (res.data is a
+// string) exactly as before. An ERROR response body is always a plain string
+// even under 'arraybuffer', so we only base64-decode on a 2xx binary read.
 //
 // Web is untouched: nativeVaultFetchImpl() returns undefined off-native, so
-// every injection site falls back to global fetch (the vault serves CORS in a
-// browser, so plain fetch is correct there).
+// callers fall back to global fetch (the vault serves CORS in a browser).
 
-import { isNativePlatform, nativeRequest } from './nativeHttp.js'
+import { CapacitorHttp } from '@capacitor/core'
+import { isNativePlatform } from './nativeHttp.js'
+
+// ── base64 <-> bytes (chunked; avoids spread-arg overflow on large blobs) ────
+function bytesToBase64(bytes) {
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+function base64ToBytes(b64) {
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}
+
+const etagOf = (headers) => {
+  if (!headers) return null
+  for (const k of Object.keys(headers)) if (k.toLowerCase() === 'etag') return headers[k]
+  return null
+}
+
+// Default native primitive: the real CapacitorHttp.request. Injectable so tests
+// exercise the base64 encode/decode + Response mapping with a fake, never the
+// (device-only) plugin.
+const defaultNativeHttp = (opts) => CapacitorHttp.request(opts)
 
 /**
- * Build a fetch-shaped adapter over a native request primitive.
- *
- * @param {(method:string,url:string,headers:object,body:any)=>Promise<{status:number,ok:boolean,etag:string|null,body:string}>} [requestFn]
- *   lifeGLANCE's native primitive (defaults to nativeRequest). It returns the raw
- *   response body as a STRING (responseType 'text'), so .json()/.text() parse.
- * @returns {(url:string, init?:object)=>Promise<object>} a Response-like fetcher.
+ * Build a fetch-shaped adapter over a CapacitorHttp-shaped request primitive.
+ * `httpRequest(opts)` takes `{ url, method, headers, data?, dataType?, responseType }`
+ * and resolves `{ status, data, headers }` (the CapacitorHttp response shape).
  */
-export function makeNativeVaultFetch(requestFn = nativeRequest) {
+export function makeNativeVaultFetch(httpRequest = defaultNativeHttp) {
   return async (url, init = {}) => {
-    const r = await requestFn(init.method || 'GET', url, init.headers || {}, init.body)
-    const body = typeof r.body === 'string' ? r.body : (r.body == null ? '' : String(r.body))
+    const method = init.method || 'GET'
+    const headers = init.headers || {}
+    const wantBinary = init.responseType === 'arraybuffer'
+
+    const opts = { url, method, headers, responseType: wantBinary ? 'arraybuffer' : 'text' }
+    const body = init.body
+    if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
+      // Binary request body → base64 + dataType 'file' so native writes raw bytes.
+      opts.data = bytesToBase64(body instanceof Uint8Array ? body : new Uint8Array(body))
+      opts.dataType = 'file'
+    } else if (body != null) {
+      opts.data = body // string (JSON etc.) — native writes it as UTF-8
+    }
+
+    const res = await httpRequest(opts)
+    const status = res.status
+    const ok = status >= 200 && status < 300
+
+    // Binary success → res.data is base64 of the raw bytes. Text responses, and
+    // ANY error body (native reads the error stream as a plain string even under
+    // 'arraybuffer'), come back as a plain string.
+    let bytes = null
+    let text = ''
+    if (wantBinary && ok && typeof res.data === 'string') {
+      bytes = base64ToBytes(res.data)
+    } else if (typeof res.data === 'string') {
+      text = res.data
+    } else if (res.data != null) {
+      text = JSON.stringify(res.data) // native may auto-parse JSON; re-stringify to parse below
+    }
+
     return {
-      ok: r.ok ?? (r.status >= 200 && r.status < 300),
-      status: r.status,
+      ok,
+      status,
       statusText: '',
-      headers: { get: (name) => (String(name).toLowerCase() === 'etag' ? (r.etag ?? null) : null) },
-      json: async () => JSON.parse(body),
-      text: async () => body,
-      // Control-plane responses are text/JSON; this covers them. True binary blob
-      // bytes (Range / arrayBuffer downloads) over CapacitorHttp are the Phase 8
-      // media follow-up flagged in blobTransport.ts — not wired here.
-      arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+      headers: { get: (n) => (String(n).toLowerCase() === 'etag' ? (etagOf(res.headers) ?? null) : null) },
+      text: async () => (bytes ? new TextDecoder().decode(bytes) : text),
+      json: async () => JSON.parse(bytes ? new TextDecoder().decode(bytes) : text),
+      arrayBuffer: async () => (bytes ? bytes.buffer : new TextEncoder().encode(text).buffer),
     }
   }
 }

--- a/src/sync/nativeVaultFetch.test.js
+++ b/src/sync/nativeVaultFetch.test.js
@@ -1,95 +1,130 @@
 // Tests for the native-safe vault fetch adapter.
 //
-// The real CapacitorHttp path can only run on-device, so these tests cover the
-// adapter LOGIC and WIRING with a faked native primitive: that it maps a native
-// response to the Response-like contract the vault client / blob transport read
-// (.ok / .status / .json() / .text() / .arrayBuffer()), and that the gating
-// helper returns undefined on web so global fetch is used in the browser/PWA.
+// The real CapacitorHttp path runs on-device only, so these cover the adapter
+// LOGIC with a fake CapacitorHttp-shaped primitive: text mapping (.ok/.status/
+// .json()/.text()), the BINARY request body (base64 + dataType 'file') and
+// BINARY response (arraybuffer/base64 → bytes) that fix native blob upload/
+// download, and the web-vs-native gating.
 
 import { describe, it, expect, vi } from 'vitest'
 import { makeNativeVaultFetch, nativeVaultFetchImpl } from './nativeVaultFetch.js'
 
-// Fake native primitive: lifeGLANCE's (method, url, headers, body) shape,
-// returning the raw body as a string (responseType 'text').
-function fakeRequest(result, captured) {
-  return async (method, url, headers, body) => {
-    if (captured) Object.assign(captured, { method, url, headers, body })
-    return result
+// Fake CapacitorHttp: records the request opts and returns a canned response
+// `{ status, data, headers }` (the real plugin's shape).
+function fakeHttp(response, captured) {
+  return async (opts) => {
+    if (captured) Object.assign(captured, opts)
+    return typeof response === 'function' ? response(opts) : response
   }
 }
+const b64 = (bytes) => Buffer.from(bytes).toString('base64')
 
-describe('makeNativeVaultFetch — maps native response to the Response-like contract', () => {
-  it('exposes .ok/.status and parses .json()/.text() from the string body', async () => {
-    const fetchLike = makeNativeVaultFetch(fakeRequest({ status: 200, ok: true, etag: null, body: '{"salt":"abc"}' }))
-    const res = await fetchLike('https://vault/salt/acct', { method: 'GET', headers: { Authorization: 'Bearer t' } })
+describe('makeNativeVaultFetch — text / control-plane mapping', () => {
+  it('maps .ok/.status and parses .json()/.text() from a text response', async () => {
+    const captured = {}
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: '{"salt":"abc"}', headers: {} }, captured))
+    const res = await f('https://vault/salt/acct', { method: 'GET', headers: { Authorization: 'Bearer t' } })
     expect(res.ok).toBe(true)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ salt: 'abc' })
     expect(await res.text()).toBe('{"salt":"abc"}')
-  })
-
-  it('derives .ok from the status when the primitive omits it', async () => {
-    const ok = makeNativeVaultFetch(fakeRequest({ status: 204, body: '' }))
-    const bad = makeNativeVaultFetch(fakeRequest({ status: 404, body: '' }))
-    expect((await ok('u', {})).ok).toBe(true)
-    expect((await bad('u', {})).ok).toBe(false)
-    expect((await bad('u', {})).status).toBe(404)
-  })
-
-  it('forwards method/url/headers/body to the native primitive', async () => {
-    const captured = {}
-    const fetchLike = makeNativeVaultFetch(fakeRequest({ status: 200, ok: true, body: '{}' }, captured))
-    await fetchLike('https://vault/blobs/uploads', { method: 'POST', headers: { Authorization: 'Bearer t' }, body: '{"hash":"h"}' })
-    expect(captured.method).toBe('POST')
-    expect(captured.url).toBe('https://vault/blobs/uploads')
-    expect(captured.headers).toEqual({ Authorization: 'Bearer t' })
-    expect(captured.body).toBe('{"hash":"h"}')
-  })
-
-  it('defaults method to GET and headers to {} when init is omitted', async () => {
-    const captured = {}
-    const fetchLike = makeNativeVaultFetch(fakeRequest({ status: 200, ok: true, body: '{}' }, captured))
-    await fetchLike('https://vault/x')
+    expect(captured.responseType).toBe('text') // non-binary read
     expect(captured.method).toBe('GET')
-    expect(captured.headers).toEqual({})
+    expect(captured.url).toBe('https://vault/salt/acct')
+    expect(captured.dataType).toBeUndefined()
+  })
+
+  it('passes a string (JSON) body straight through as opts.data with no dataType', async () => {
+    const captured = {}
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: '{}', headers: {} }, captured))
+    await f('https://vault/blobs/uploads', { method: 'POST', headers: {}, body: '{"hash":"h"}' })
+    expect(captured.data).toBe('{"hash":"h"}')
+    expect(captured.dataType).toBeUndefined()
+  })
+
+  it('derives .ok from status; a 404 error body stays a plain string', async () => {
+    const bad = makeNativeVaultFetch(fakeHttp({ status: 404, data: 'not found', headers: {} }))
+    const res = await bad('u', { responseType: 'arraybuffer' }) // even a binary read: error body is text
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('not found') // NOT base64-decoded
   })
 
   it('exposes a case-insensitive headers.get for etag', async () => {
-    const fetchLike = makeNativeVaultFetch(fakeRequest({ status: 200, ok: true, etag: 'W/"v1"', body: '{}' }))
-    const res = await fetchLike('u', {})
-    expect(res.headers.get('ETag')).toBe('W/"v1"')
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: '{}', headers: { ETag: 'W/"v1"' } }))
+    const res = await f('u', {})
+    expect(res.headers.get('etag')).toBe('W/"v1"')
     expect(res.headers.get('x-other')).toBeNull()
   })
+})
 
-  it('.arrayBuffer() returns the control-plane body bytes', async () => {
-    const fetchLike = makeNativeVaultFetch(fakeRequest({ status: 200, ok: true, body: 'hello' }))
-    const buf = await (await fetchLike('u', {})).arrayBuffer()
-    expect(new TextDecoder().decode(new Uint8Array(buf))).toBe('hello')
+describe('makeNativeVaultFetch — binary (the native blob upload/download fix)', () => {
+  it('REQUEST: a Uint8Array body is base64-encoded and marked dataType "file"', async () => {
+    const captured = {}
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: '', headers: {} }, captured))
+    const payload = new Uint8Array([0, 1, 2, 250, 255]) // includes non-UTF8 bytes
+    await f('https://vault/blobs/uploads/x/parts/0', { method: 'PUT', headers: {}, body: payload })
+    expect(captured.dataType).toBe('file') // native Base64-decodes → raw bytes
+    expect(captured.data).toBe(b64(payload)) // exact base64 of the bytes
+    expect(captured.responseType).toBe('text')
+  })
+
+  it('REQUEST: an ArrayBuffer body is handled the same way', async () => {
+    const captured = {}
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: '', headers: {} }, captured))
+    const payload = new Uint8Array([9, 8, 7])
+    await f('u', { method: 'PUT', body: payload.buffer })
+    expect(captured.dataType).toBe('file')
+    expect(captured.data).toBe(b64(payload))
+  })
+
+  it('RESPONSE: an arraybuffer read base64-decodes res.data back to the exact bytes', async () => {
+    const original = new Uint8Array([12, 0, 200, 5, 255, 128])
+    const captured = {}
+    const f = makeNativeVaultFetch(fakeHttp({ status: 200, data: b64(original), headers: {} }, captured))
+    const res = await f('https://vault/blobs/deadbeef', { method: 'GET', responseType: 'arraybuffer' })
+    expect(captured.responseType).toBe('arraybuffer')
+    const out = new Uint8Array(await res.arrayBuffer())
+    expect(out).toEqual(original) // round-trips byte-for-byte
+  })
+
+  it('round-trip: upload bytes then download them back through the adapter', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 254, 0, 77])
+    // Upload: capture what the adapter sent as base64.
+    const up = {}
+    await makeNativeVaultFetch(fakeHttp({ status: 200, data: '', headers: {} }, up))(
+      'u', { method: 'PUT', body: bytes },
+    )
+    // The server would store exactly those bytes; a download returns them base64.
+    const res = await makeNativeVaultFetch(fakeHttp({ status: 200, data: up.data, headers: {} }))(
+      'u', { method: 'GET', responseType: 'arraybuffer' },
+    )
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes)
   })
 })
 
 describe('nativeVaultFetchImpl — web vs native gating', () => {
   it('returns undefined on web (non-native) so callers keep global fetch', () => {
-    // The test env is non-native (Capacitor.isNativePlatform() === false).
     expect(nativeVaultFetchImpl()).toBeUndefined()
   })
 
-  it('returns the adapter on native', async () => {
+  it('returns a working adapter on native (over a mocked CapacitorHttp)', async () => {
     vi.resetModules()
-    vi.doMock('./nativeHttp.js', () => ({
-      isNativePlatform: () => true,
-      nativeRequest: async () => ({ status: 200, ok: true, etag: null, body: '{"ok":1}' }),
+    vi.doMock('./nativeHttp.js', () => ({ isNativePlatform: () => true }))
+    vi.doMock('@capacitor/core', () => ({
+      CapacitorHttp: { request: async () => ({ status: 200, data: '{"ok":1}', headers: {} }) },
     }))
     const { nativeVaultFetchImpl: impl } = await import('./nativeVaultFetch.js')
     const f = impl()
     expect(typeof f).toBe('function')
-    expect((await (await f('u', {})).json())).toEqual({ ok: 1 })
+    expect(await (await f('u', {})).json()).toEqual({ ok: 1 })
+    vi.doUnmock('@capacitor/core')
     vi.doUnmock('./nativeHttp.js')
     vi.resetModules()
   })
 })
 
-describe('wiring — injection sites pass the adapter on native, undefined on web', () => {
+describe('wiring — injection sites, undefined on web', () => {
   it('verify probe passes fetchImpl into createVaultClient (undefined on web)', async () => {
     const { verifyVaultCredentials } = await import('./vaultSetup.js')
     let seenFetchImpl = 'UNSET'
@@ -102,14 +137,11 @@ describe('wiring — injection sites pass the adapter on native, undefined on we
       { createVaultClient },
     )
     expect(r.kind).toBe('success')
-    // On web (test env) the adapter is undefined → the package uses global fetch.
-    expect(seenFetchImpl).toBeUndefined()
+    expect(seenFetchImpl).toBeUndefined() // web → package uses global fetch
   })
 
-  it('blob transport uses global fetch on web (adapter undefined), not throwing for missing fetch', async () => {
+  it('blob transport uses global fetch on web (adapter undefined)', async () => {
     const { blobExists } = await import('../blobs/blobTransport.js')
-    // Inject an explicit fetch so we exercise resolveFetch without hitting network;
-    // proves the native fallback does not interfere on web.
     const fetchImpl = async () => ({ ok: false, status: 404, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) })
     const exists = await blobExists('deadbeef', {
       connection: { vaultUrl: 'https://v', vaultToken: 't', accountId: 'a' },


### PR DESCRIPTION
## Root cause
The on-device `Media sync deferred: Error: <blob URL with accountId>` was the blob **part upload**: it sends a raw `Uint8Array` body, but `CapacitorHttp` serialises a typed array through its JSON path (`{"0":..}`), corrupting/rejecting the request — a bare native `Error` echoing the request URL. (Encryption and thumbnail generation both succeed first, which is why the earlier "missing blob key" theory was wrong.)

Confirmed against `@capacitor/android` (Capacitor 8) `CapacitorHttpUrlConnection` / `HttpRequestHandler`: binary I/O uses **base64**:
- **REQUEST binary** → `data` = base64 string **+ `dataType: 'file'`** → native `Base64.decode` writes raw bytes.
- **RESPONSE binary** → `responseType: 'arraybuffer'` → `res.data` comes back **base64** (`readStreamAsBase64`) → must be base64-decoded.

## Fix — make the native vault adapter binary-capable both ways
- `nativeVaultFetch`: a `Uint8Array`/`ArrayBuffer` request body is base64-encoded and sent with `dataType: 'file'`; an `arraybuffer` response is base64-decoded back to bytes. Text/JSON control-plane calls keep `responseType: 'text'` (unchanged), and an error body — always a plain string even under `arraybuffer` — is not decoded. The adapter now drives `CapacitorHttp.request` directly (injectable for tests).
- `blobTransport.downloadBlobBytes` passes `responseType: 'arraybuffer'` (a no-op for the browser's real `fetch`, which reads `.arrayBuffer()` natively; used by the native adapter).

This is the deferred "native binary routing" the blob transport had flagged as a follow-up. **Web/PWA is unchanged** — real `fetch` handles `Uint8Array` bodies and `.arrayBuffer()` directly.

## Tests
base64 request-body encode + `dataType: 'file'`; arraybuffer response base64-decode; an upload→download **byte-for-byte round-trip**; error-body-stays-text; plus the existing text-mapping / web-vs-native gating / injection-site wiring. Full suite green (bar the pre-existing `dates.test.js` time-of-day flakiness); ESLint 0 errors; `npm run build` exits 0.

## What still needs the on-device check
The real `CapacitorHttp` binary decode/encode only runs on-device — this PR makes the JS send the format the plugin's native code base64-decodes. On rebuild+redeploy, attaching a photo should upload and (once the slot becomes a real hash) render on the originating device. If it still fails, the new toast will show the next error in the chain (e.g. a `BlobHashMismatchError` would mean the base64 didn't decode as expected — different problem, and I'd know exactly where to look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_