### PR TITLE
Fix native (Capacitor Android) blob-media upload over CapacitorHttp

### DIFF
--- a/src/blobs/blobTransport.js
+++ b/src/blobs/blobTransport.js
@@ -188,9 +188,21 @@ async function jsonOrThrow(res, context) {
 export async function blobExists(hash, deps = {}) {
   const conn = resolveConnection(deps)
   const doFetch = resolveFetch(deps)
-  const res = await vaultRequest(conn, doFetch, 'HEAD', `/blobs/${encodeURIComponent(hash)}`, {
-    query: { accountId: conn.accountId },
-  })
+  let res
+  try {
+    res = await vaultRequest(conn, doFetch, 'HEAD', `/blobs/${encodeURIComponent(hash)}`, {
+      query: { accountId: conn.accountId },
+    })
+  } catch {
+    // The existence check is a dedup OPTIMIZATION, not a correctness gate. If the
+    // HEAD can't even be performed at the transport level — notably some native
+    // HTTP stacks (CapacitorHttp over HttpURLConnection) reject/choke on HEAD —
+    // don't abort the whole upload. Proceed as "not known present": initiate is
+    // idempotent on the hash and finalize verifies, so a redundant upload is safe
+    // (never data loss). Real HTTP errors still surface — a 401/500 comes back as
+    // a status below, or resurfaces on the subsequent initiate call.
+    return false
+  }
   if (res.ok) return true
   if (res.status === 404) return false
   throw new BlobTransportError(`blob existence check failed: ${res.status}`, res.status)

--- a/src/blobs/blobTransport.test.js
+++ b/src/blobs/blobTransport.test.js
@@ -456,3 +456,48 @@ describe('blobTransport — auth', () => {
     ).rejects.toThrow()
   })
 })
+
+// ── HEAD dedup is non-fatal when the transport itself chokes on HEAD ──────────
+// The existence check is a dedup OPTIMIZATION. On native, CapacitorHttp over
+// HttpURLConnection can reject/choke on a bodyless HEAD and the adapter THROWS
+// (a transport-level failure, not an HTTP status). That must NOT abort the whole
+// upload — initiate is idempotent on the hash and finalize re-verifies, so we
+// proceed as "not known present" and upload anyway (never data loss). A wrong
+// token / server 5xx still comes back as an HTTP STATUS (handled above), not a
+// throw, so those keep surfacing.
+describe('blobTransport — HEAD throw is non-fatal (native HEAD choke)', () => {
+  // Wrap a server so an actual HEAD request rejects at the transport level,
+  // as the native adapter would when the HTTP stack cannot perform the HEAD.
+  const headThrows = (server) => (url, init) => {
+    if (init.method === 'HEAD') return Promise.reject(new Error('native HEAD not supported'))
+    return server.fetchImpl(url, init)
+  }
+
+  it('blobExists returns false (not a throw) when the HEAD request throws', async () => {
+    const server = makeVaultServer()
+    const { hash } = await encryptBlob(enc('present?'), provideKey)
+    // Even though the blob IS present server-side, a throwing HEAD → "not known present".
+    await uploadBlob(enc('present?'), depsFor(server))
+    expect(server.blobs.has(hash)).toBe(true)
+    const exists = await blobExists(hash, depsFor(server, { fetchImpl: headThrows(server) }))
+    expect(exists).toBe(false)
+  })
+
+  it('uploadBlob still completes (initiate/parts/finalize) when the dedup HEAD throws', async () => {
+    const server = makeVaultServer()
+    const plaintext = enc('upload despite a broken HEAD ' + 'y'.repeat(200))
+    const deps = depsFor(server, { fetchImpl: headThrows(server), partSize: 64 })
+
+    const hash = await uploadBlob(plaintext, deps)
+
+    // The HEAD threw and was swallowed, so the upload proceeded end-to-end.
+    expect(server.calls.head).toBe(0) // no HEAD ever reached the server (it threw first)
+    expect(server.calls.initiate).toBe(1)
+    expect(server.calls.finalize).toBe(1)
+    expect(server.blobs.has(hash)).toBe(true)
+
+    // And it's a real, decryptable round-trip.
+    const out = await downloadBlob(hash, depsFor(server))
+    expect([...out]).toEqual([...plaintext])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes blob-media upload failing on the native Android shell. Attaching a photo with the vault ON produced no working blob-backed photo — the upload threw and the error was swallowed. Two distinct native-transport bugs were in the path; this PR fixes both. Web/PWA is unchanged throughout (the native adapter is `undefined` off-native, so browsers keep using global `fetch`).

## The two bugs

**1. Binary bytes were corrupted over CapacitorHttp.** `CapacitorHttp` does not accept a raw `Uint8Array` body — a typed array serialises to `{"0":..}` through its JSON path, corrupting the part-PUT and the download read. Per the `@capacitor/android` source, the plugin's binary contract is base64-based in both directions:
- **Request** binary → `data` = base64 string + `dataType: 'file'` (native base64-*decodes* to raw bytes).
- **Response** binary → `responseType: 'arraybuffer'`; `res.data` comes back as a base64 string (native `readStreamAsBase64`), so it must be base64-*decoded* client-side.

The native vault fetch adapter now encodes binary request bodies and decodes binary responses accordingly. Text/JSON control-plane calls keep `responseType: 'text'`. An error body is always a plain string even under `arraybuffer`, so decoding only happens on a 2xx binary read.

**2. The `HEAD` dedup check aborted the whole upload on native.** The first network call in an upload is `HEAD /blobs/:hash` (`blobExists`), a dedup optimization. On native, `CapacitorHttp` over Java's `HttpURLConnection` can choke on a bodyless `HEAD` and throw at the *transport* level (not an HTTP status) — which killed the upload before `initiate` was ever reached. `blobExists` now catches a transport-level throw and returns `false` ("not known present") so the upload proceeds: `initiate` is idempotent on the hash and `finalize` re-verifies, so a redundant upload is always safe (never data loss). Real HTTP errors still surface — a 401/5xx comes back as a *status* (401 → throw, 404 → false), or resurfaces on the subsequent `initiate` call.

## Changes

- `src/sync/nativeVaultFetch.js` — binary-capable native fetch adapter (base64 + `dataType: 'file'` for request bodies; `arraybuffer` → base64-decode for responses); text path unchanged.
- `src/blobs/blobTransport.js` — `blobExists` treats a transport-level throw as non-fatal (returns `false`); binary responses request `responseType: 'arraybuffer'`.

## Tests

- `nativeVaultFetch.test.js` — text/control-plane mapping, binary request/response round-trip (byte-for-byte), and web-vs-native gating against a fake CapacitorHttp-shaped primitive.
- `blobTransport.test.js` — `blobExists` returns `false` when the `HEAD` throws; `uploadBlob` completes end-to-end (initiate/parts/finalize + decryptable round-trip) when the dedup `HEAD` throws.
- Full suite passes (224 tests); clean ESLint; `npm run build` succeeds.

## Note

These fixes are entirely client-side. The GLANCEvault server's blob endpoints (`HEAD /blobs/:hash`, `POST /blobs/uploads`, `PUT .../parts/:i`, `POST .../finalize`, `GET /blobs/:hash`, ref-add/release) are unchanged and required no modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_