### PR TITLE
Align blob client to the GLANCEvault server contract (fixes native upload 400)

### DIFF
--- a/src/blobs/blobTransport.js
+++ b/src/blobs/blobTransport.js
@@ -173,8 +173,24 @@ async function vaultRequest(conn, doFetch, method, path, opts = {}) {
   return doFetch(url, init)
 }
 
+// Read a short snippet of the response body to attach to an error message. The
+// server explains a 4xx (missing/invalid field, wrong shape) in its body; without
+// it, callers see a bare status and can't tell WHY the request was rejected. Best
+// effort: never throw from here (a body may be unreadable or already consumed).
+async function readErrorBody(res) {
+  try {
+    const text = typeof res.text === 'function' ? await res.text() : ''
+    const trimmed = (text || '').trim()
+    return trimmed ? ` — ${trimmed.slice(0, 300)}` : ''
+  } catch {
+    return ''
+  }
+}
+
 async function jsonOrThrow(res, context) {
-  if (!res.ok) throw new BlobTransportError(`${context} failed: ${res.status}`, res.status)
+  if (!res.ok) {
+    throw new BlobTransportError(`${context} failed: ${res.status}${await readErrorBody(res)}`, res.status)
+  }
   return res.json()
 }
 
@@ -205,7 +221,7 @@ export async function blobExists(hash, deps = {}) {
   }
   if (res.ok) return true
   if (res.status === 404) return false
-  throw new BlobTransportError(`blob existence check failed: ${res.status}`, res.status)
+  throw new BlobTransportError(`blob existence check failed: ${res.status}${await readErrorBody(res)}`, res.status)
 }
 
 // ── Upload ───────────────────────────────────────────────────────────────────
@@ -252,7 +268,9 @@ async function putPart(conn, doFetch, uploadId, index, part) {
     `/blobs/uploads/${encodeURIComponent(uploadId)}/parts/${index}`,
     { query: { accountId: conn.accountId }, binaryBody: part },
   )
-  if (!res.ok) throw new BlobTransportError(`upload part ${index} failed: ${res.status}`, res.status)
+  if (!res.ok) {
+    throw new BlobTransportError(`upload part ${index} failed: ${res.status}${await readErrorBody(res)}`, res.status)
+  }
 }
 
 /** POST /blobs/uploads/:id/finalize — reassemble + verify hash + store. */
@@ -265,17 +283,26 @@ async function finalizeUpload(conn, doFetch, uploadId, hash) {
     { jsonBody: { accountId: conn.accountId, hash } },
   )
   if (res.ok) return
-  // The server signals a hash mismatch distinctly so we can surface it clearly.
+  // Read the body ONCE (it may only be readable once), then inspect it: the server
+  // signals a hash mismatch distinctly so we can surface that clearly, and any
+  // other 4xx reason is carried through in the generic error message.
+  let bodyText = ''
+  try {
+    bodyText = typeof res.text === 'function' ? await res.text() : ''
+  } catch {
+    /* body unreadable — fall through with no detail */
+  }
   if (res.status === 409 || res.status === 422 || res.status === 400) {
     let err = null
     try {
-      err = await res.json()
+      err = bodyText ? JSON.parse(bodyText) : null
     } catch {
-      /* fall through to generic */
+      /* not JSON — fall through to generic */
     }
     if (err && err.error === 'hash_mismatch') throw new BlobHashMismatchError(hash)
   }
-  throw new BlobTransportError(`finalize failed: ${res.status}`, res.status)
+  const detail = bodyText.trim() ? ` — ${bodyText.trim().slice(0, 300)}` : ''
+  throw new BlobTransportError(`finalize failed: ${res.status}${detail}`, res.status)
 }
 
 /**
@@ -351,7 +378,9 @@ export async function downloadBlobBytes(hash, deps = {}) {
     headers,
     responseType: 'arraybuffer', // native adapter reads bytes; browser fetch ignores it
   })
-  if (!res.ok) throw new BlobTransportError(`download failed: ${res.status}`, res.status)
+  if (!res.ok) {
+    throw new BlobTransportError(`download failed: ${res.status}${await readErrorBody(res)}`, res.status)
+  }
   return new Uint8Array(await res.arrayBuffer())
 }
 
@@ -378,7 +407,7 @@ export async function addBlobRef(hash, deps = {}) {
   const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-add`, {
     jsonBody: { accountId: conn.accountId },
   })
-  if (!res.ok) throw new BlobTransportError(`ref-add failed: ${res.status}`, res.status)
+  if (!res.ok) throw new BlobTransportError(`ref-add failed: ${res.status}${await readErrorBody(res)}`, res.status)
 }
 
 /** POST /blobs/:hash/ref-release — decrement the reference count for a blob. */
@@ -388,5 +417,5 @@ export async function releaseBlobRef(hash, deps = {}) {
   const res = await vaultRequest(conn, doFetch, 'POST', `/blobs/${encodeURIComponent(hash)}/ref-release`, {
     jsonBody: { accountId: conn.accountId },
   })
-  if (!res.ok) throw new BlobTransportError(`ref-release failed: ${res.status}`, res.status)
+  if (!res.ok) throw new BlobTransportError(`ref-release failed: ${res.status}${await readErrorBody(res)}`, res.status)
 }

--- a/src/blobs/blobTransport.js
+++ b/src/blobs/blobTransport.js
@@ -23,11 +23,16 @@
 //     a body field on the JSON POSTs (initiate / finalize / ref-add / ref-release).
 //
 // THE SERVER CONTRACT (all device-token auth, account-scoped):
-//   HEAD /blobs/:hash                      → 200 exists / 404 absent
-//   POST /blobs/uploads                    → initiate (idempotent on hash) { uploadId }
+//   HEAD /blobs/:hash          (?accountId) → 200 exists / 404 absent
+//   POST /blobs/uploads                     → initiate; body { accountId, blobHash,
+//        size }. 200 { exists:true } if already stored (dedup), else 201
+//        { uploadId, received:[] }. (The content-hash field is `blobHash`; the
+//        server picks part boundaries, so partSize is NOT sent.)
 //   PUT  /blobs/uploads/:id/parts/:i       → store one part (raw octet-stream body)
-//   GET  /blobs/uploads/:id                → resume point { received:[i,...], partSize, size }
-//   POST /blobs/uploads/:id/finalize       → reassemble, VERIFY hash, store
+//   GET  /blobs/uploads/:id                → resume point { received:[{index,size}], size }
+//   POST /blobs/uploads/:id/finalize       → reassemble, VERIFY hash, store; body
+//        { accountId } (declared hash is the session's). 400 with an "hash
+//        mismatch…" body + declared/computed on a mismatch.
 //   GET  /blobs/:hash       (Range)        → download (full or partial) stored bytes
 //   POST /blobs/:hash/ref-add | ref-release→ reference tracking
 //
@@ -237,16 +242,28 @@ function splitIntoParts(bytes, partSize) {
   return parts
 }
 
-/** POST /blobs/uploads — initiate (idempotent on hash) → uploadId. */
-async function initiateUpload(conn, doFetch, hash, size, partSize) {
+/**
+ * POST /blobs/uploads — initiate (idempotent on hash).
+ *
+ * Server contract: the content hash field is `blobHash` (a 64-char lowercase hex
+ * sha256); the body also carries `accountId` and `size`. The server chooses the
+ * part boundaries, so `partSize` is NOT sent (the client splits locally for the
+ * PUTs). Two success shapes:
+ *   • 200 { exists: true }          — the server already holds these bytes (dedup
+ *                                     at initiate; there is no upload session).
+ *   • 201 { uploadId, received:[] } — a new/resumable upload session.
+ * Returns { exists: true } or { uploadId }.
+ */
+async function initiateUpload(conn, doFetch, hash, size) {
   const res = await vaultRequest(conn, doFetch, 'POST', '/blobs/uploads', {
-    jsonBody: { accountId: conn.accountId, hash, size, partSize },
+    jsonBody: { accountId: conn.accountId, blobHash: hash, size },
   })
   const body = await jsonOrThrow(res, 'initiate upload')
+  if (body && body.exists === true) return { exists: true }
   if (!body || typeof body.uploadId !== 'string') {
     throw new BlobTransportError('initiate upload: missing uploadId in response', res.status)
   }
-  return body.uploadId
+  return { uploadId: body.uploadId }
 }
 
 /** GET /blobs/uploads/:id — which part indices the server already holds. */
@@ -256,7 +273,13 @@ async function getResumePoint(conn, doFetch, uploadId) {
   })
   const body = await jsonOrThrow(res, 'resume point')
   const received = Array.isArray(body?.received) ? body.received : []
-  return new Set(received)
+  // The server reports received parts as `{ index, size }` objects. Normalize to
+  // a Set of the integer indices (tolerating a bare-index shape too), so the
+  // resume skip-check below matches part numbers rather than whole objects.
+  const indices = received
+    .map((p) => (typeof p === 'number' ? p : p?.index))
+    .filter((i) => Number.isInteger(i))
+  return new Set(indices)
 }
 
 /** PUT /blobs/uploads/:id/parts/:i — send one part (raw bytes). */
@@ -273,14 +296,18 @@ async function putPart(conn, doFetch, uploadId, index, part) {
   }
 }
 
-/** POST /blobs/uploads/:id/finalize — reassemble + verify hash + store. */
+/**
+ * POST /blobs/uploads/:id/finalize — reassemble + verify hash + store.
+ * The declared hash is captured server-side at initiate (from the session), so
+ * the finalize body carries only `accountId`; a `hash` here would be ignored.
+ */
 async function finalizeUpload(conn, doFetch, uploadId, hash) {
   const res = await vaultRequest(
     conn,
     doFetch,
     'POST',
     `/blobs/uploads/${encodeURIComponent(uploadId)}/finalize`,
-    { jsonBody: { accountId: conn.accountId, hash } },
+    { jsonBody: { accountId: conn.accountId } },
   )
   if (res.ok) return
   // Read the body ONCE (it may only be readable once), then inspect it: the server
@@ -299,7 +326,16 @@ async function finalizeUpload(conn, doFetch, uploadId, hash) {
     } catch {
       /* not JSON — fall through to generic */
     }
-    if (err && err.error === 'hash_mismatch') throw new BlobHashMismatchError(hash)
+    // The server returns a 400 whose message begins "hash mismatch: ..." and
+    // includes `declared`/`computed` hashes. Recognise either signal (the exact
+    // token, the message prefix, or the declared+computed pair).
+    if (err && (
+      err.error === 'hash_mismatch' ||
+      /hash mismatch/i.test(err.error || '') ||
+      ('declared' in err && 'computed' in err)
+    )) {
+      throw new BlobHashMismatchError(hash)
+    }
   }
   const detail = bodyText.trim() ? ` — ${bodyText.trim().slice(0, 300)}` : ''
   throw new BlobTransportError(`finalize failed: ${res.status}${detail}`, res.status)
@@ -332,12 +368,17 @@ export async function uploadBlob(plaintext, deps = {}) {
   // network call — so nothing is sent and the caller can hold/retry.
   const { bytes, hash } = await encryptBlob(plaintext, deps.getRootKey)
 
-  // Dedup: if the server already has these exact bytes, we're done.
+  // Dedup: if the server already has these exact bytes, we're done. On native the
+  // HEAD probe may be non-fatally skipped (returns false), so initiate ALSO dedups
+  // below — the two together cover both transports.
   if (await blobExists(hash, deps)) return hash
 
   // Resumable upload. Initiate is idempotent on the hash, so a retry after an
-  // interruption returns the same session with its already-received parts.
-  const uploadId = await initiateUpload(conn, doFetch, hash, bytes.length, partSize)
+  // interruption returns the same session with its already-received parts — and if
+  // the server already holds the bytes it reports { exists: true } and we're done.
+  const initiated = await initiateUpload(conn, doFetch, hash, bytes.length)
+  if (initiated.exists) return hash
+  const uploadId = initiated.uploadId
   const received = await getResumePoint(conn, doFetch, uploadId)
 
   const parts = splitIntoParts(bytes, partSize)

--- a/src/blobs/blobTransport.test.js
+++ b/src/blobs/blobTransport.test.js
@@ -74,22 +74,28 @@ function makeVaultServer({ token = TOKEN, accountId = ACCOUNT } = {}) {
   const partPuts = [] // every part index actually PUT, in order (proves resume skips)
   let failPartOnce = null // set to an index to make that PUT fail once
 
+  // Responses expose .text() as well as .json()/.arrayBuffer(), matching a real
+  // fetch Response and the native adapter — the transport reads .text() to surface
+  // server error bodies.
   const jsonRes = (status, obj) => ({
     ok: status >= 200 && status < 300,
     status,
     json: async () => obj,
+    text: async () => JSON.stringify(obj),
     arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(obj)).buffer,
   })
   const binRes = (status, bytes) => ({
     ok: status >= 200 && status < 300,
     status,
     arrayBuffer: async () => new Uint8Array(bytes).buffer,
+    text: async () => '',
     json: async () => { throw new Error('not json') },
   })
   const emptyRes = (status) => ({
     ok: status >= 200 && status < 300,
     status,
     arrayBuffer: async () => new ArrayBuffer(0),
+    text: async () => '',
     json: async () => ({}),
   })
 
@@ -499,5 +505,31 @@ describe('blobTransport — HEAD throw is non-fatal (native HEAD choke)', () => 
     // And it's a real, decryptable round-trip.
     const out = await downloadBlob(hash, depsFor(server))
     expect([...out]).toEqual([...plaintext])
+  })
+})
+
+// ── Server error bodies surface in the thrown error (diagnosability) ──────────
+// A bare "failed: 400" hides WHY the server rejected the request. The transport
+// now appends the server's response body so a native failure names the actual
+// cause (missing/invalid field, wrong shape) instead of just a status code.
+describe('blobTransport — server error detail surfaces in the thrown error', () => {
+  it('appends the response body when initiate (POST /blobs/uploads) returns 400', async () => {
+    const fetchImpl = async (url, init) => {
+      // Dedup HEAD says "absent" so the upload proceeds to initiate.
+      if (init.method === 'HEAD') {
+        return { ok: false, status: 404, text: async () => '', json: async () => ({}) }
+      }
+      // Initiate is rejected with a descriptive body — this is what we want surfaced.
+      if (init.method === 'POST' && url.includes('/blobs/uploads')) {
+        return { ok: false, status: 400, text: async () => '{"error":"size_required"}', json: async () => ({ error: 'size_required' }) }
+      }
+      throw new Error(`unexpected ${init.method} ${url}`)
+    }
+    const deps = {
+      connection: { vaultUrl: VAULT_URL, vaultToken: TOKEN, accountId: ACCOUNT },
+      fetchImpl,
+      getRootKey: provideKey,
+    }
+    await expect(uploadBlob(enc('x'), deps)).rejects.toThrow(/initiate upload failed: 400 — .*size_required/)
   })
 })

--- a/src/blobs/blobTransport.test.js
+++ b/src/blobs/blobTransport.test.js
@@ -134,32 +134,37 @@ function makeVaultServer({ token = TOKEN, accountId = ACCOUNT } = {}) {
       return binRes(200, rec.bytes)
     }
 
-    // POST /blobs/uploads  (initiate, idempotent on hash; accountId in body)
+    // POST /blobs/uploads  (initiate; accountId + blobHash + size in body).
+    // Mirrors the real server: the hash field is `blobHash`, `partSize` is NOT
+    // read (the client splits locally), success is 201 { uploadId, received:[] }
+    // for a new session or 200 { exists:true } when the bytes are already stored.
     if (method === 'POST' && path === '/blobs/uploads') {
       calls.initiate++
       if (jsonBody.accountId !== accountId) return jsonRes(400, { error: 'accountId required' })
-      let uploadId = hashToUpload.get(jsonBody.hash)
+      if (typeof jsonBody.blobHash !== 'string' || !/^[0-9a-f]{64}$/.test(jsonBody.blobHash)) {
+        return jsonRes(400, { error: 'blobHash must be a 64-character hex sha256' })
+      }
+      if (!Number.isInteger(jsonBody.size) || jsonBody.size < 0) {
+        return jsonRes(400, { error: 'size must be a non-negative integer' })
+      }
+      if (blobs.has(jsonBody.blobHash)) return jsonRes(200, { exists: true, blobHash: jsonBody.blobHash })
+      let uploadId = hashToUpload.get(jsonBody.blobHash)
       if (!uploadId) {
         uploadId = `up-${nextId++}`
-        sessions.set(uploadId, {
-          hash: jsonBody.hash,
-          size: jsonBody.size,
-          partSize: jsonBody.partSize,
-          parts: new Map(),
-        })
-        hashToUpload.set(jsonBody.hash, uploadId)
+        sessions.set(uploadId, { hash: jsonBody.blobHash, size: jsonBody.size, parts: new Map() })
+        hashToUpload.set(jsonBody.blobHash, uploadId)
       }
-      return jsonRes(200, { uploadId })
+      return jsonRes(201, { uploadId, blobHash: jsonBody.blobHash, received: [] })
     }
 
-    // GET /blobs/uploads/:id  (resume point)
+    // GET /blobs/uploads/:id  (resume point; received parts as { index, size } objects)
     if (method === 'GET' && (m = path.match(/^\/blobs\/uploads\/([^/]+)$/))) {
       calls.resume++
       const s = sessions.get(decodeURIComponent(m[1]))
       if (!s) return jsonRes(404, { error: 'no_session' })
+      const indices = [...s.parts.keys()].sort((a, b) => a - b)
       return jsonRes(200, {
-        received: [...s.parts.keys()].sort((a, b) => a - b),
-        partSize: s.partSize,
+        received: indices.map((i) => ({ index: i, size: s.parts.get(i).length })),
         size: s.size,
       })
     }
@@ -177,7 +182,7 @@ function makeVaultServer({ token = TOKEN, accountId = ACCOUNT } = {}) {
       }
       s.parts.set(i, new Uint8Array(init.body)) // store a copy of the part bytes
       partPuts.push(i)
-      return jsonRes(200, { received: i })
+      return jsonRes(200, { index: i, size: s.parts.get(i).length })
     }
 
     // POST /blobs/uploads/:id/finalize  (reassemble + VERIFY hash + store)
@@ -196,13 +201,21 @@ function makeVaultServer({ token = TOKEN, accountId = ACCOUNT } = {}) {
         reassembled.set(p, off)
         off += p.length
       }
-      // VERIFY: server's hash of reassembled bytes == client's declared hash.
+      // VERIFY: server's hash of reassembled bytes == the SESSION's declared hash
+      // (captured at initiate — the finalize body does not carry a hash). On a
+      // mismatch the real server returns 400 with a sentence + declared/computed.
       const serverHash = await sha256Hex(reassembled)
-      if (serverHash !== jsonBody.hash) return jsonRes(409, { error: 'hash_mismatch' })
+      if (serverHash !== s.hash) {
+        return jsonRes(400, {
+          error: 'hash mismatch: reassembled bytes do not match declared blobHash',
+          declared: s.hash,
+          computed: serverHash,
+        })
+      }
       blobs.set(serverHash, { bytes: reassembled, refs: 0 })
       sessions.delete(decodeURIComponent(m[1]))
       hashToUpload.delete(serverHash)
-      return jsonRes(200, { hash: serverHash, stored: true })
+      return jsonRes(200, { blobHash: serverHash, stored: true })
     }
 
     // POST /blobs/:hash/ref-add | ref-release
@@ -505,6 +518,25 @@ describe('blobTransport — HEAD throw is non-fatal (native HEAD choke)', () => 
     // And it's a real, decryptable round-trip.
     const out = await downloadBlob(hash, depsFor(server))
     expect([...out]).toEqual([...plaintext])
+  })
+
+  it('dedups at initiate ({exists:true}) when HEAD is skipped but the blob is stored', async () => {
+    const server = makeVaultServer()
+    const plaintext = enc('already up there')
+
+    // Store it once (normal path).
+    const hash = await uploadBlob(plaintext, depsFor(server))
+    const after = { ...server.calls }
+
+    // Re-upload with a throwing HEAD (native): the HEAD dedup is skipped, so the
+    // client initiates — and the server reports {exists:true}, short-circuiting
+    // before any parts/finalize.
+    const hash2 = await uploadBlob(plaintext, depsFor(server, { fetchImpl: headThrows(server) }))
+    expect(hash2).toBe(hash)
+    expect(server.calls.head).toBe(after.head) // HEAD never reached the server (threw)
+    expect(server.calls.initiate).toBe(after.initiate + 1) // initiate DID run and dedup
+    expect(server.calls.part).toBe(after.part) // no parts re-sent
+    expect(server.calls.finalize).toBe(after.finalize) // no finalize
   })
 })
 


### PR DESCRIPTION
Follow-up to #215/#216 (both merged). Those fixed the native binary transport and the HEAD-dedup choke; this lands the two commits that get a native blob upload the rest of the way through — pushed to the branch after #216 merged, so they need their own PR.

## Why native upload still 400'd after #216

With #216 the upload got past the `HEAD` dedup and reached `POST /blobs/uploads`, which returned a real server **400**. An investigation of the `glance-vault` handlers pinned the cause and several downstream shape mismatches.

## Fixes

**1. Surface the server's response body in transport errors** (`8b30a5b`). A bare `failed: 400` hid the reason. Every non-OK error now appends a short snippet of the server's body (best-effort, never throws from the read), so a native failure names the actual cause.

**2. Align the client to the real server contract** (`517130e`):

| Step | Server contract | Client was doing | Now |
|------|----------------|-------------------|-----|
| initiate body | `blobHash`, `accountId`, `size` | sent `hash` + dead `partSize` → **the 400** | sends `blobHash`, `size`; drops `partSize` |
| initiate success | `201 {uploadId}` or `200 {exists:true}` | only handled `{uploadId}` → threw on a dedup hit | short-circuits on `exists:true` |
| resume point | `received: [{index,size}]` | treated elements as ints → Set of objects → re-sent every part | maps to `.index` |
| finalize | body `{accountId}`; mismatch = `400` `"hash mismatch…"` + declared/computed | sent ignored `hash`; matched only token `hash_mismatch` | sends `{accountId}`; recognizes the real signal |

The `exists:true` handling matters specifically on native: since the HEAD probe is non-fatally skipped there (#216), initiate becomes the real dedup point.

## Tests

The in-process contract mock is updated to the **real** server contract (`blobHash`, 201/`exists` shapes, `received[].index`, the real finalize mismatch body), so the suite validates against what the server actually does — plus tests for the error-body surfacing and the initiate-level dedup short-circuit. Full suite **226 passing**; blobs lint clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_