### PR TITLE
Show synced-in (blob-backed) media everywhere it was missing

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -5,7 +5,8 @@ import React, {
 import { useTranslation } from 'react-i18next'
 import { dateToX, getTimeRangeForView, getTickMarks, assignLanes, getMsPerPx } from '../../utils/timeline'
 import { relativeLabel, formatDateDisplay, ageAtDate, formatDuration } from '../../utils/dates'
-import { dbGetMedia } from '../../data/db'
+import { dbGetMedia, dbGetPhoto } from '../../data/db'
+import { isRealBlobHash, fetchThumbnailBytes } from '../../blobs/milestoneMedia.js'
 
 // Map text-size labels → root px value (must match TimelineView TEXT_SIZES)
 const REM_PX = { small: 19, normal: 22, big: 26, bigger: 30 }
@@ -90,6 +91,34 @@ const Timeline = forwardRef(function Timeline(
   const [chapterTip,  setChapterTip]  = useState(null) // { chapter, x, y } | null
   const [playingId,   setPlayingId]   = useState(null)
   const audioElRef = useRef(null)
+  // Hover-preview of a card's photo. The image is loaded on demand: a synced-in
+  // photo lives only as a vault blob (photo_id is a real blob hash), so fetch +
+  // decrypt a thumbnail; a locally authored one reads the local store. The object
+  // URL is tracked so the preview never leaks, and a hovered-id guard drops a load
+  // that resolves after the pointer already left.
+  const photoTipUrlRef = useRef(null)
+  const hoveredPhotoRef = useRef(null)
+  const hidePhotoTip = useCallback(() => {
+    hoveredPhotoRef.current = null
+    if (photoTipUrlRef.current) { URL.revokeObjectURL(photoTipUrlRef.current); photoTipUrlRef.current = null }
+    setPhotoTip(null)
+  }, [])
+  const showPhotoTip = useCallback((m, x, y) => {
+    hoveredPhotoRef.current = m.id
+    const set = (blob) => {
+      if (!blob || hoveredPhotoRef.current !== m.id) return
+      if (photoTipUrlRef.current) URL.revokeObjectURL(photoTipUrlRef.current)
+      const url = URL.createObjectURL(blob)
+      photoTipUrlRef.current = url
+      setPhotoTip({ uri: url, x, y })
+    }
+    if (isRealBlobHash(m.photo_id)) {
+      fetchThumbnailBytes(m.photo_id).then(b => set(b && new Blob([b]))).catch(() => {})
+    } else {
+      dbGetPhoto(m.id).then(res => set(res?.blob)).catch(() => {})
+    }
+  }, [])
+  useEffect(() => () => { if (photoTipUrlRef.current) URL.revokeObjectURL(photoTipUrlRef.current) }, [])
   // Track which IDs have already played their fly-in so we don't re-animate on re-renders
   const [flyDoneIds,  setFlyDoneIds]  = useState(() => new Set())
   // panMsRef always tracks the latest value for animation calculations
@@ -670,7 +699,7 @@ const Timeline = forwardRef(function Timeline(
               {(() => {
                 const icons = []
                 if (m.dayglance_linked) icons.push('dayglance')
-                if (m.photo_uri)  icons.push('camera')
+                if (m.has_photo)  icons.push('camera')
                 if (m.media_type === 'audio') icons.push('audio')
                 if (m.media_type === 'video') icons.push('video')
                 if (m.url)        icons.push('link')
@@ -690,8 +719,8 @@ const Timeline = forwardRef(function Timeline(
                   if (type === 'camera') return (
                     <g key="camera" transform={`translate(${ix},${iy})`}
                        opacity={op} style={{ cursor: 'zoom-in' }}
-                       onMouseEnter={e => setPhotoTip({ uri: m.photo_uri, x: e.clientX, y: e.clientY })}
-                       onMouseLeave={() => setPhotoTip(null)}>
+                       onMouseEnter={e => showPhotoTip(m, e.clientX, e.clientY)}
+                       onMouseLeave={hidePhotoTip}>
                       <rect x={-2} y={-1} width={18} height={13} fill="transparent" />
                       <rect x={0} y={2.5} width={14} height={8} rx={1.3}
                         fill="none" stroke={m.color} strokeWidth={0.85} />

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { dateToX, getTimeRangeForView, getTickMarks, assignLanes, getMsPerPx } from '../../utils/timeline'
 import { relativeLabel, formatDateDisplay, ageAtDate, formatDuration } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
-import { isRealBlobHash, fetchThumbnailBytes } from '../../blobs/milestoneMedia.js'
+import { isRealBlobHash, fetchThumbnailBytes, fetchFullResBytes } from '../../blobs/milestoneMedia.js'
 
 // Map text-size labels → root px value (must match TimelineView TEXT_SIZES)
 const REM_PX = { small: 19, normal: 22, big: 26, bigger: 30 }
@@ -187,10 +187,13 @@ const Timeline = forwardRef(function Timeline(
       audioElRef.current = null
       if (playingId === m.id) { setPlayingId(null); return }
     }
-    // Fetch blob lazily and play via a transient object URL
-    dbGetMedia(m.id).then(result => {
-      if (!result) return
-      const url = URL.createObjectURL(result.blob)
+    // Fetch blob lazily and play via a transient object URL. A synced-in audio
+    // lives only as a vault blob (media_id is a real blob hash, no local copy), so
+    // fetch + decrypt it (mirroring MilestoneDetail); a locally authored one reads
+    // the local media store.
+    const play = (blob) => {
+      if (!blob) return
+      const url = URL.createObjectURL(blob)
       const a = new Audio(url)
       a._objectUrl = url
       audioElRef.current = a
@@ -201,7 +204,12 @@ const Timeline = forwardRef(function Timeline(
         audioElRef.current = null
         setPlayingId(null)
       }
-    })
+    }
+    if (isRealBlobHash(m.media_id)) {
+      fetchFullResBytes(m.media_id).then(b => play(b && new Blob([b], { type: 'audio/mpeg' }))).catch(() => {})
+    } else {
+      dbGetMedia(m.id).then(result => play(result?.blob)).catch(() => {})
+    }
   }
 
   // Measure container

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -25,7 +25,7 @@ import { writeMilestoneTombstone } from '../../sync/tombstones'
 import { getSyncEngine } from '../../sync/engine'
 import { dirtyBirthday } from '../../sync/dirty'
 import { readVaultConfig } from '../../sync/dbSync'
-import { uploadMilestoneMedia, releaseMilestoneMedia } from '../../blobs/milestoneMedia.js'
+import { uploadMilestoneMedia, releaseMilestoneMedia, isRealBlobHash, fetchFullResBytes, fetchThumbnailBytes } from '../../blobs/milestoneMedia.js'
 import ChapterSheet from '../chapter/ChapterSheet'
 import CloudSyncModal from '../sync/CloudSyncModal'
 import SyncPassphraseModal from '../sync/SyncPassphraseModal'
@@ -44,6 +44,22 @@ import { isSyncing, SYNC_ERROR_I18N_KEYS } from '../../sync/status.js'
 import { appendActivityEntry } from '../../lib/intentsActivityLog.js'
 import ActivityLogModal from '../dayglance/ActivityLogModal.jsx'
 import { EVENTS } from '@glance-apps/intents'
+
+// A blob-backed photo slot carries no stored mime type (the encrypted bytes are
+// opaque). For a backup data-URI the declared mime matters — restore reads it
+// back from the header — so sniff the image type from the magic bytes rather than
+// mislabel it. Falls back to JPEG (the capture default) for anything unrecognized.
+function sniffImageMime(bytes) {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg'
+  if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return 'image/png'
+  if (bytes.length >= 6 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) return 'image/gif'
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+  ) return 'image/webp'
+  return 'image/jpeg'
+}
 
 const ZOOM_RANK = { decades: 5, '30yr': 4, years: 3, months: 2, weeks: 1, custom: 3.5 }
 
@@ -1286,16 +1302,25 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
 
   // ── Backup ───────────────────────────────────────────────────────────────────
   async function handleSaveBackup() {
-    // Collect photos as base64 data-URIs keyed by milestone id
+    // Collect photos as base64 data-URIs keyed by milestone id. A photo synced
+    // from another device lives only as a vault blob (photo_id is a real blob
+    // hash, no local copy), so fetch+decrypt those too — otherwise a backup made
+    // on the receiving device would silently omit every synced-in photo.
     const photos = {}
     for (const m of milestones) {
       if (!m.has_photo) continue
       try {
-        const result = await dbGetPhoto(m.id)
-        if (!result) continue
-        const buf = await result.blob.arrayBuffer()
-        const b64 = btoa([...new Uint8Array(buf)].map(b => String.fromCharCode(b)).join(''))
-        photos[m.id] = `data:${result.mimeType};base64,${b64}`
+        let bytes, mimeType
+        if (isRealBlobHash(m.photo_id)) {
+          const b = await fetchFullResBytes(m.photo_id)
+          if (b) { bytes = b; mimeType = sniffImageMime(b) }
+        } else {
+          const result = await dbGetPhoto(m.id)
+          if (result) { bytes = new Uint8Array(await result.blob.arrayBuffer()); mimeType = result.mimeType }
+        }
+        if (!bytes) continue
+        const b64 = btoa([...bytes].map(b => String.fromCharCode(b)).join(''))
+        photos[m.id] = `data:${mimeType};base64,${b64}`
       } catch { /* skip unreadable photo */ }
     }
 
@@ -1630,20 +1655,31 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     return () => document.removeEventListener('click', close)
   }, [watchMenuOpen])
 
-  // Load the current event's photo (if any) for the watch-mode backdrop.
+  // Load the current event's photo (if any) for the watch-mode backdrop. A photo
+  // synced from another device lives only as a vault blob (photo_id is a real blob
+  // hash, no local copy), so fetch+decrypt it — mirroring MilestoneDetail — instead
+  // of only reading the local store (which returned nothing, so no backdrop showed).
+  // Thumbnail-first keeps a tour from pulling full-res on every hop.
   const [idlePhotoUrl, setIdlePhotoUrl] = useState(null)
   const idleEventId = idle.currentEvent?.id
   const idleHasPhoto = !!idle.currentEvent?.has_photo
+  const idlePhotoId = idle.currentEvent?.photo_id
   useEffect(() => {
     if (!idle.active || !idleHasPhoto || !idleEventId) { setIdlePhotoUrl(null); return }
     let url, cancelled = false
-    dbGetPhoto(idleEventId).then(res => {
-      if (cancelled || !res) return
-      url = URL.createObjectURL(res.blob)
+    const show = (blob) => {
+      if (cancelled || !blob) return
+      url = URL.createObjectURL(blob)
       setIdlePhotoUrl(url)
-    }).catch(() => {})
+    }
+    if (isRealBlobHash(idlePhotoId)) {
+      // Untyped image blob — <img> content-sniffs it (same as MilestoneDetail).
+      fetchThumbnailBytes(idlePhotoId).then(b => show(b && new Blob([b]))).catch(() => {})
+    } else {
+      dbGetPhoto(idleEventId).then(res => show(res?.blob)).catch(() => {})
+    }
     return () => { cancelled = true; if (url) URL.revokeObjectURL(url) }
-  }, [idle.active, idleEventId, idleHasPhoto])
+  }, [idle.active, idleEventId, idleHasPhoto, idlePhotoId])
 
   // While watching, spotlight the current event's card (built-in glow + scale).
   const timelineHighlighted = idle.active


### PR DESCRIPTION
Follow-up to the native blob-media work (#215–#217). Those made cross-device photo/audio/video sync work; this fixes the remaining spots that still read only the **local** media store and so silently missed media that lives only as a vault blob (a milestone synced from another device carries `photo_id`/`media_id` = a real blob hash with no local copy). The primary viewer (`MilestoneDetail`) already handled this; these consumers didn't.

## Fixes

**1. Watch-mode Ken Burns backdrop** (`TimelineView.jsx`)
Only read `dbGetPhoto(eventId)`, which returns nothing for a blob-backed photo, so no backdrop rendered on the receiving device. Now mirrors `MilestoneDetail` — `isRealBlobHash(photo_id)` → `fetchThumbnailBytes` (thumbnail-first, so a tour doesn't pull full-res on every hop), else the local store.

**2. Save Backup** (`TimelineView.jsx`)
Iterated milestones reading only `dbGetPhoto(m.id)`, so a backup made on the receiving device **silently omitted every synced-in photo** (silent data loss in an export). Now fetches full-res blob bytes for blob-backed slots. Since a blob slot carries no stored mime and restore reads the mime back from the data-URI header, the image type is sniffed from the magic bytes (JPEG/PNG/GIF/WebP) rather than mislabeled.

**3. Card camera icon** (`Timeline.jsx`)
The icon and its hover preview keyed off `m.photo_uri` — a field migrated away in the db v3 upgrade (base64 → media blob store) and stripped by the milestones layer — so the icon never rendered on current milestones at all. Now gates on `m.has_photo`, and the hover preview loads the real image on demand (blob thumbnail or local), with the object URL tracked/revoked and a hovered-id guard against a load resolving after the pointer leaves.

**4. Card audio playback** (`Timeline.jsx`)
While auditing the other icons after the camera fix: audio/video/link/recurrence/dayGLANCE icons all gate on current synced fields (`media_type`, `url`, `recurrence`, `dayglance_linked`) — no dead-field bug, so they display correctly. But the inline audio player read only `dbGetMedia(m.id)` (local), so a synced-in audio played nothing on the receiving device. Now mirrors `MilestoneDetail`: `isRealBlobHash(media_id)` → `fetchFullResBytes`, else local. (Video already delegates to `MilestoneDetail`, which handles the fallback; link/recurrence/dayGLANCE need no media.)

## Verification

- Full suite **226 passing**; `npm run build` succeeds; ESLint clean (only pre-existing warnings).
- The blob-fallback pattern is the same one `MilestoneDetail` already uses and that the `blobTransport`/`milestoneMedia` suites cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_