### PR TITLE
Fix video upload hanging on poster-frame generation (poster is best-effort)

### DIFF
--- a/src/blobs/milestoneMedia.js
+++ b/src/blobs/milestoneMedia.js
@@ -16,8 +16,16 @@
 //  • BLOBS-BEFORE-REFERENCE: the full-res blob AND its thumbnail are uploaded and
 //    confirmed stored BEFORE the caller writes any reference slot. uploadBlob is
 //    idempotent (HEAD-dedup), so a retry after a partial failure is safe.
-//  • NO REFERENCE TO A THUMBNAIL THAT WASN'T MADE: thumbnail generation runs
-//    FIRST; if it throws, we abort before any upload or ref — nothing is written.
+//  • THUMBNAIL POLICY DIFFERS BY KIND:
+//     – IMAGE: the thumbnail IS the display surface, so it runs FIRST and a
+//       failure ABORTS before any upload or ref — a photo with no image is
+//       nothing (unchanged).
+//     – VIDEO: the poster is BEST-EFFORT. The video blob is the payload, so a
+//       poster failure/timeout does NOT abort — it drops the poster and uploads
+//       the video anyway, writing a real media_id (visible cross-device without a
+//       poster). Poster generation is time-bounded in thumbnail.js, so it can
+//       never hang the upload.
+//     – AUDIO: no thumbnail step.
 //  • The CALLER writes the returned slot hashes via updateMilestone(), which
 //    bumps updated_at — real hashes are not device-derivable, so the change must
 //    propagate via LWW (unlike the old deterministic backfill, which did not bump).
@@ -44,10 +52,13 @@ export function isRealBlobHash(value) {
  * for audio, which has no visual thumbnail). The caller writes these to the slots
  * ONLY after this resolves.
  *
- * Ordering: generate thumbnail → upload full → upload thumb → ref-add both. A
- * throw at any step leaves NOTHING referenced (uploads are idempotent on retry).
+ * Ordering: (poster/thumbnail) → upload full → upload thumb → ref-add. For IMAGE
+ * a thumbnail failure aborts before any upload; for VIDEO a poster failure is
+ * swallowed and the video uploads anyway (thumbHash null). Uploads are idempotent
+ * on retry.
  *
- * @throws {import('./thumbnail.js').ThumbnailGenerationError} bad/corrupt source — before any upload.
+ * @throws {import('./thumbnail.js').ThumbnailGenerationError} bad/corrupt IMAGE source — before any upload.
+ *         (A VIDEO poster failure/timeout is NOT thrown — the video uploads without a poster.)
  * @throws {import('./blobCrypto.js').BlobKeyUnavailableError} no vault key yet — before any network write.
  * @throws on any upload / ref failure (caller treats as "reference not established yet", retriable).
  */
@@ -57,13 +68,31 @@ export async function uploadMilestoneMedia({ bytes, mimeType }, deps = {}) {
   const addBlobRef = deps.addBlobRef ?? _addBlobRef
 
   const kind = sourceKind(mimeType)
-  const wantsThumb = kind === 'image' || kind === 'video'
 
-  // 1. Thumbnail FIRST — if it can't be made, abort before any upload/reference.
+  // 1. Thumbnail / poster.
+  //   • IMAGE: the thumbnail IS the display surface — a failure ABORTS here,
+  //     before any upload or reference (a photo with no image is nothing).
+  //   • VIDEO: the poster is BEST-EFFORT. The video blob is the payload, so a
+  //     poster failure/timeout must not block it — drop the poster, log, and
+  //     proceed to upload the video with no thumbnail slot. (Poster generation is
+  //     time-bounded in thumbnail.js, so this can never hang.)
+  //   • AUDIO (kind === null): no thumbnail step.
   let thumb = null
-  if (wantsThumb) thumb = await generateThumbnail(bytes, mimeType)
+  if (kind === 'image') {
+    thumb = await generateThumbnail(bytes, mimeType)
+  } else if (kind === 'video') {
+    try {
+      thumb = await generateThumbnail(bytes, mimeType)
+    } catch (err) {
+      thumb = null
+      try {
+        console.warn('[media] video poster generation failed — uploading video without a poster:', err?.message || err)
+      } catch { /* ignore logging failure */ }
+    }
+  }
 
-  // 2. Upload both blobs, confirm stored, BEFORE the caller writes any slot.
+  // 2. Upload the full-res blob (ALWAYS), then the poster if we made one. Confirm
+  //    stored BEFORE the caller writes any slot (uploadBlob is idempotent).
   const fullHash = await uploadBlob(bytes)
   const thumbHash = thumb ? await uploadBlob(thumb.bytes) : null
 

--- a/src/blobs/milestoneMedia.test.js
+++ b/src/blobs/milestoneMedia.test.js
@@ -62,6 +62,20 @@ describe('uploadMilestoneMedia — ordering + clean-fail', () => {
     expect(d.calls).toEqual(['upload:1', 'ref:A']) // no 'thumb'
   })
 
+  it('video: a poster FAILURE/timeout does NOT abort — uploads the video with no poster (thumbHash null)', async () => {
+    const d = recorder({ generateThumbnail: async () => { throw new Error('video poster timed out at step: loadedmetadata') } })
+    const out = await uploadMilestoneMedia({ bytes, mimeType: 'video/mp4' }, d)
+    // The video WAS uploaded + referenced; poster was dropped (no thumb upload/ref).
+    expect(out).toEqual({ fullHash: HASH_A, thumbHash: null })
+    expect(d.calls).toEqual(['upload:1', 'ref:A'])
+  })
+
+  it('image: a thumbnail failure STILL aborts (the image IS the display surface) — contrast with video', async () => {
+    const d = recorder({ generateThumbnail: async () => { throw new Error('corrupt source') } })
+    await expect(uploadMilestoneMedia({ bytes, mimeType: 'image/png' }, d)).rejects.toThrow('corrupt source')
+    expect(d.calls).toEqual([]) // nothing uploaded, nothing referenced
+  })
+
   it('thumbnail-generation failure aborts BEFORE any upload or ref (no reference to a thumbnail that was never made)', async () => {
     const err = new Error('corrupt source')
     const d = recorder({ generateThumbnail: async () => { throw err } })

--- a/src/blobs/thumbnail.js
+++ b/src/blobs/thumbnail.js
@@ -45,6 +45,14 @@ export const DEFAULT_QUALITY = 0.8
 export const POSTER_FRAME_TIME_SECONDS = 1
 
 /**
+ * Hard bound (ms) on EACH await in video poster generation. A native WebView can
+ * silently never fire `loadedmetadata` / `seeked` (a detached <video>, or a codec
+ * it can't decode without emitting `error`), which would otherwise hang the whole
+ * media upload forever. Each step is raced against this so it can never block.
+ */
+export const VIDEO_POSTER_TIMEOUT_MS = 10000
+
+/**
  * Thrown when a thumbnail cannot be produced (corrupt/unsupported source, or any
  * decode/encode failure). A clean, typed failure with NO partial output — the
  * caller treats it as a failed upload and publishes nothing referencing a
@@ -122,7 +130,15 @@ export async function generateThumbnail(sourceBytes, mimeType, opts = {}) {
   try {
     decoded =
       kind === 'video'
-        ? await processor.decodeVideoFrame(sourceBytes, mimeType, posterTime)
+        // Overall bound on video decode, on TOP of the per-step timeouts inside
+        // the browser processor: no processor (real or injected) can make this
+        // await forever. The inner per-step timeout normally fires first and names
+        // the stalling step; this is the backstop (and the seam tests exercise).
+        ? await withTimeout(
+            processor.decodeVideoFrame(sourceBytes, mimeType, posterTime),
+            opts.videoPosterTimeoutMs ?? (VIDEO_POSTER_TIMEOUT_MS + 2000),
+            'decodeVideoFrame',
+          )
         : await processor.decodeImage(sourceBytes, mimeType)
   } catch (err) {
     throw new ThumbnailGenerationError(`failed to decode ${kind} source`, { cause: err })
@@ -183,18 +199,28 @@ export const browserImageProcessor = {
     video.muted = true
     video.preload = 'auto'
     video.playsInline = true
+    // Lightweight step logging so an on-device run reveals WHERE the WebView
+    // stalls (which await never completed) rather than failing opaquely.
+    const step = (msg) => { try { console.warn(`[thumbnail:video] ${msg}`) } catch { /* ignore */ } }
     try {
       video.src = url
-      await onceEvent(video, 'loadedmetadata')
+      step('loading metadata…')
+      await withTimeout(onceEvent(video, 'loadedmetadata'), VIDEO_POSTER_TIMEOUT_MS, 'loadedmetadata')
+      step(`metadata loaded (duration=${video.duration}, ${video.videoWidth}x${video.videoHeight}); seeking…`)
       const duration = Number.isFinite(video.duration) ? video.duration : atSeconds
       const seekTo = Math.min(atSeconds, Math.max(0, duration))
-      await seekVideo(video, Number.isFinite(seekTo) ? seekTo : 0)
-      const frame = await createImageBitmap(video)
+      await withTimeout(seekVideo(video, Number.isFinite(seekTo) ? seekTo : 0), VIDEO_POSTER_TIMEOUT_MS, 'seeked')
+      step('seek complete; grabbing frame (createImageBitmap)…')
+      const frame = await withTimeout(createImageBitmap(video), VIDEO_POSTER_TIMEOUT_MS, 'createImageBitmap(video)')
+      step('frame grabbed OK')
       return {
         width: frame.width || video.videoWidth,
         height: frame.height || video.videoHeight,
         source: frame,
       }
+    } catch (err) {
+      step(`FAILED: ${err?.message || err}`)
+      throw err
     } finally {
       URLg.revokeObjectURL(url)
     }
@@ -209,6 +235,18 @@ export const browserImageProcessor = {
     const blob = await canvas.convertToBlob({ type: mimeType, quality })
     return new Uint8Array(await blob.arrayBuffer())
   },
+}
+
+// Race a promise against a timeout so a media-element await can NEVER block
+// forever. On timeout, rejects with a clear label naming the step that stalled.
+// The underlying promise is abandoned (the caller cleans up the <video>/object
+// URL in its finally), which is the whole point: we stop waiting on the WebView.
+function withTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`video poster timed out after ${ms}ms at step: ${label}`)), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
 }
 
 function onceEvent(target, name) {

--- a/src/blobs/thumbnail.test.js
+++ b/src/blobs/thumbnail.test.js
@@ -81,6 +81,9 @@ function makeFakeProcessor(behavior = {}) {
       calls.decodeVideoFrame++
       calls.lastPosterTime = atSeconds
       if (behavior.decodeThrows) throw new Error('fake video decode failure')
+      // Simulate the Android-WebView stall: a decode that never settles. The
+      // timeout in generateThumbnail must turn this into a rejection, not a hang.
+      if (behavior.decodeHangs) return new Promise(() => {})
       return { ...readDims(bytes), source: { kind: 'video-frame' } }
     },
     async encode(image, targetWidth, targetHeight, mimeType, quality) {
@@ -191,6 +194,18 @@ describe('thumbnail — video source (poster frame)', () => {
       posterTimeSeconds: 3.5,
     })
     expect(calls.lastPosterTime).toBe(3.5)
+  })
+
+  it('bounds a hanging video decode with a timeout → ThumbnailGenerationError (never blocks forever)', async () => {
+    const { processor, calls } = makeFakeProcessor({ decodeHangs: true })
+    const err = await generateThumbnail(fakeSource(1920, 1080), 'video/mp4', {
+      processor,
+      videoPosterTimeoutMs: 20, // short bound so the never-settling decode times out fast
+    }).then(() => null, (e) => e)
+    expect(err).toBeInstanceOf(ThumbnailGenerationError)
+    expect(err.cause?.message).toMatch(/timed out/i) // the timeout, surfaced as the cause
+    expect(calls.decodeVideoFrame).toBe(1) // it was invoked, then bounded
+    expect(calls.encode).toBe(0) // no partial output — never reached encode
   })
 })
 


### PR DESCRIPTION
## Problem

Attaching a **video** with vault sync on silently never uploaded: the milestone kept the "stored on originating device" placeholder on both devices, with **no error toast**. Root cause (confirmed by investigation): `uploadMilestoneMedia` generated the thumbnail **first**, and for video that ran `decodeVideoFrame` — a detached `<video>` awaiting `loadedmetadata` / `seeked` / `createImageBitmap` with **no timeout**. In the Android WebView those events can never fire, so it hung forever: the video was never uploaded, nothing threw, no toast.

## Changes

**1. Timeout on video poster generation** (`thumbnail.js`)
`VIDEO_POSTER_TIMEOUT_MS` (10s) bounds **each** await inside `decodeVideoFrame` (`loadedmetadata`, `seeked`, `createImageBitmap`) via a `withTimeout` race, and `generateThumbnail` wraps the whole video decode in an outer backstop bound. No step can await unboundedly; a stall rejects with a clear message naming the step instead of hanging.

**2. Step logging** (`thumbnail.js`)
`decodeVideoFrame` logs each step reached (`loading metadata → metadata loaded → seeking → seek complete → grabbing frame → frame grabbed / FAILED`), so an on-device run reveals exactly where the WebView stalls.

**3. Poster is non-blocking for VIDEO** (`milestoneMedia.js` — the design fix)
For a video, a poster failure/timeout no longer aborts the upload: it logs, drops the poster (`thumbnail = null`), and proceeds to upload the video full-res blob so a real `media_id` is written (video visible cross-device, just without a poster). **IMAGE is unchanged** — its thumbnail *is* the display surface, so an image thumbnail failure still aborts. **AUDIO** is unaffected (no thumbnail step — `sourceKind('audio/*')` is null).

## Display side
A video with a real `media_id` + null `thumbnail_id` already renders/streams: `MilestoneDetail` plays from `media_id` via `fetchFullResBytes`; `thumbnail_id` is only written when a poster exists and read only by `releaseMilestoneMedia` (filtered by `isRealBlobHash`). No display path requires it.

## Tests
Processor faked — real WebView video decode is on-device only.
- Hanging video decode → times out into `ThumbnailGenerationError` (never blocks).
- Video poster failure/timeout → **video still uploads**, `thumbHash: null`.
- Poster success → both written (unchanged).
- Image thumbnail failure → still aborts before any upload (unchanged).
- Audio → no-thumbnail upload path (unchanged).

Full suite **229 passing**; ESLint clean; `npm run build` succeeds.

## On-device verification
The real fix is confirmable on-device: rebuild, attach a video, watch the `[thumbnail:video]` logs — either the poster succeeds, or you see which step stalls and the video uploads anyway (real `media_id`, no poster) within ~10s instead of hanging forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_