### PR TITLE
TEMP diagnostic DIAG3: fresh-build proof + visible media upload path

### DIFF
--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -63,9 +63,16 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
     const real = isRealBlobHash(m.media_id)
     const parts = [`type=${m.media_type}`, real ? `id=real:${String(m.media_id).slice(0, 10)}` : 'id=placeholder']
     const mb = (n) => `${(n / 1048576).toFixed(1)}MB`
+    // Set SYNCHRONOUSLY so the line renders immediately — its presence proves this
+    // (DIAG3) build is actually running (vs a stale cached bundle); its absence
+    // means the app is serving old code.
+    setMediaDiag(`DIAG3 · ${parts.join(' · ')} · probing local…`)
+    // Bound the local read so a stall shows up instead of leaving the line stuck.
+    const withTimeout = (p, ms, label) =>
+      Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} timeout ${ms}ms`)), ms))])
     // Always probe the local store (even for a real id) so we know whether a local
     // copy exists on this device.
-    dbGetMedia(m.id).then(result => {
+    withTimeout(dbGetMedia(m.id), 8000, 'dbGetMedia').then(result => {
       if (cancelled) return
       parts.push(result?.blob ? `local=${mb(result.blob.size)}` : 'local=NONE')
       if (real) {
@@ -74,13 +81,13 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
           if (cancelled) return
           if (b) { parts.push(`fetch=${mb(b.length)}`); show(new Blob([b], { type })) }
           else parts.push('fetch=null')
-          setMediaDiag(parts.join(' · '))
-        }).catch(e => { if (!cancelled) { parts.push(`fetch!=${e?.name || 'err'}:${String(e?.message || '').slice(0, 40)}`); setMediaDiag(parts.join(' · ')) } })
+          setMediaDiag('DIAG3 · ' + parts.join(' · '))
+        }).catch(e => { if (!cancelled) { parts.push(`fetch!=${e?.name || 'err'}:${String(e?.message || '').slice(0, 40)}`); setMediaDiag('DIAG3 · ' + parts.join(' · ')) } })
       } else {
         show(result?.blob)
-        setMediaDiag(parts.join(' · '))
+        setMediaDiag('DIAG3 · ' + parts.join(' · '))
       }
-    }).catch(e => { if (!cancelled) { parts.push(`local!=${String(e?.message || e).slice(0, 40)}`); setMediaDiag(parts.join(' · ')) } })
+    }).catch(e => { if (!cancelled) { parts.push(`local!=${String(e?.message || e).slice(0, 40)}`); setMediaDiag('DIAG3 · ' + parts.join(' · ')) } })
     return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl) }
   }, [m.id, m.media_type, m.media_id])
 

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -827,20 +827,27 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   async function establishVaultMediaRefs(milestone, file, slot) {
     if (!file || !readVaultConfig()) return milestone
     try {
+      // TEMP DIAGNOSTIC (DIAG3): make the whole media upload path visible on-device.
+      // A start toast proves this fresh build ran establish for the media slot; a
+      // success/timeout/error toast reveals what happened (the audio clue says the
+      // upload silently never completes for media, which no poster is involved in).
+      const sizeMB = (file.size / 1048576).toFixed(1)
+      showToast(`DIAG3 · uploading ${slot} ${sizeMB}MB ${file.type || '?'}…`)
       const bytes = new Uint8Array(await file.arrayBuffer())
-      const { fullHash, thumbHash } = await uploadMilestoneMedia({ bytes, mimeType: file.type })
+      const withTimeout = (p, ms) =>
+        Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error(`upload timed out after ${Math.round(ms / 1000)}s`)), ms))])
+      const { fullHash, thumbHash } = await withTimeout(uploadMilestoneMedia({ bytes, mimeType: file.type }), 120000)
       const updates = slot === 'photo' ? { photo_id: fullHash } : { media_id: fullHash }
       if (thumbHash) updates.thumbnail_id = thumbHash
-      return await updateMilestone(milestone.id, updates, milestone)
+      const updated = await updateMilestone(milestone.id, updates, milestone)
+      showToast(`DIAG3 · ${slot} uploaded ✓ id=${String(fullHash).slice(0, 8)} thumb=${thumbHash ? 'yes' : 'no'}`)
+      return updated
     } catch (err) {
       // Behavior unchanged (kept local, retriable, slots left as placeholders).
-      // TEMPORARY DIAGNOSTIC: surface the real error name+message on-screen so a
-      // non-debuggable release build reveals WHY the blob upload failed
-      // (BlobKeyUnavailableError / ThumbnailGenerationError / VaultError / …).
       console.error('[media] vault blob sync deferred (kept local, retriable):', err)
       const name = err?.name || 'Error'
       const message = err?.message || String(err)
-      showToast(`Media sync deferred: ${name}: ${message}`, 'error')
+      showToast(`DIAG3 · ${slot} sync FAILED: ${name}: ${message}`, 'error')
       return milestone
     }
   }


### PR DESCRIPTION
## ⚠️ Temporary — to be reverted (with the other DIAG commits)

Follow-up triage. The #220 diagnostic line did **not** appear on-device under the video placeholder. That line is set inside `dbGetMedia(...).then/.catch`, so its total absence means the local-store read **never settled** (hung) — or old code was running. This makes both symptoms explainable by one cause: a large **video** blob read from IndexedDB stalling (audio, smaller, reads fine and plays locally).

### Changes
- **`MilestoneDetail`** — the media-state line is now set **synchronously** with a literal `DIAG3` tag, so its presence proves this exact build is running, and its content shows even if the local read stalls. The `dbGetMedia` read is bounded by an 8s timeout (`local!=dbGetMedia timeout` on stall) so a hang is visible.
- **`establishVaultMediaRefs`** (TimelineView) — the media **upload** path now toasts on start (`DIAG3 · uploading media <size> <type>…`), success (`uploaded ✓ id=… thumb=…`), and failure/timeout, and bounds `uploadMilestoneMedia` with a 120s timeout. Audio saves+plays locally but never syncs with no toast → the upload silently doesn't complete (no poster involved); these toasts show whether establish runs for the media slot and where it stalls.

### What one test now tells us
Attach a video (and an audio) on phone 1, watch the toasts, then open each milestone's detail sheet:
- **Toasts** reveal the upload path: does `DIAG3 · uploading media…` fire? Then `uploaded ✓` / `FAILED: <reason>` / a 120s timeout?
- **Detail line** reveals local state: `id=placeholder|real · local=NONE|<size>|dbGetMedia timeout · fetch=…`.

If you see **no `DIAG3` text at all**, the build genuinely isn't running the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_