### PR TITLE
Video poster: show it on the video and during the "Downloading…" state

### DIFF
--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -123,6 +123,16 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
   function doDelete()       { onDelete(m.id); onClose() }
   function doDeleteSeries() { onDeleteSeries(m.recurrence_id); onClose() }
 
+  // Label for the media-unavailable / downloading state (shared by the plain and
+  // poster-backed renders below).
+  const mediaLabel = mediaLoading
+    ? t('mediaDownloading', {
+        progress: mediaLoading.total
+          ? `${fmtMB(mediaLoading.received)} / ${fmtMB(mediaLoading.total)}`
+          : fmtMB(mediaLoading.received),
+      })
+    : t('mediaSyncedFromDevice')
+
   return (
     <div className="sheet-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
       <div className="sheet">
@@ -200,17 +210,24 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
           </div>
         )}
         {m.media_type && !audioUrl && (
-          <div className="detail-audio-wrap detail-media-unavailable">
-            <span className="detail-media-unavailable-label">
-              {mediaLoading
-                ? t('mediaDownloading', {
-                    progress: mediaLoading.total
-                      ? `${fmtMB(mediaLoading.received)} / ${fmtMB(mediaLoading.total)}`
-                      : fmtMB(mediaLoading.received),
-                  })
-                : t('mediaSyncedFromDevice')}
-            </span>
-          </div>
+          posterUrl && m.media_type === 'video' ? (
+            // Show the poster frame with the status (e.g. "Downloading… X.X MB")
+            // overlaid, so a large video previews immediately while it downloads.
+            <div className="detail-audio-wrap" style={{ position: 'relative', display: 'inline-block', lineHeight: 0 }}>
+              <img src={posterUrl} alt="" className="detail-video" />
+              <div style={{
+                position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: 'rgba(0,0,0,0.4)', color: '#fff', fontSize: '0.85rem', lineHeight: 1.3,
+                textAlign: 'center', padding: '0.5rem', borderRadius: 'inherit',
+              }}>
+                {mediaLabel}
+              </div>
+            </div>
+          ) : (
+            <div className="detail-audio-wrap detail-media-unavailable">
+              <span className="detail-media-unavailable-label">{mediaLabel}</span>
+            </div>
+          )
         )}
 
         {/* Note */}

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Capacitor } from '@capacitor/core'
 import { formatDateDisplay, relativeLabel, ageAtDate } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto, dbPutMedia } from '../../data/db'
-import { isRealBlobHash, fetchFullResBytes, fetchFullResBytesChunked } from '../../blobs/milestoneMedia.js'
+import { isRealBlobHash, fetchFullResBytes, fetchFullResBytesChunked, fetchThumbnailBytes } from '../../blobs/milestoneMedia.js'
 
 // Bytes → "X.X MB" for the download-progress label.
 const fmtMB = (n) => `${(n / 1048576).toFixed(1)} MB`
@@ -27,6 +27,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
   const [audioUrl,  setAudioUrl]  = useState(null)
   const [photoUrl,  setPhotoUrl]  = useState(null)
   const [mediaLoading, setMediaLoading] = useState(null) // { received, total } while downloading a remote clip
+  const [posterUrl, setPosterUrl] = useState(null) // video poster (from the uploaded thumbnail)
   const [confirm,   setConfirm]   = useState(null)
   const [pins,      setPins]      = useState(readPins)
 
@@ -87,6 +88,20 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
     }).catch(() => {})
     return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl) }
   }, [m.id, m.media_type, m.media_id])
+
+  // Video poster: the uploaded thumbnail (thumbnail_id) is a small blob, so fetch +
+  // decrypt it (cached in-memory) and use it as the <video poster>, replacing the
+  // default blank "big play button" with the captured frame.
+  useEffect(() => {
+    if (m.media_type !== 'video' || !isRealBlobHash(m.thumbnail_id)) { setPosterUrl(null); return }
+    let objectUrl, cancelled = false
+    fetchThumbnailBytes(m.thumbnail_id).then(bytes => {
+      if (cancelled || !bytes) return
+      objectUrl = URL.createObjectURL(new Blob([bytes], { type: 'image/jpeg' }))
+      setPosterUrl(objectUrl)
+    }).catch(() => {})
+    return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl) }
+  }, [m.media_type, m.thumbnail_id])
 
   useEffect(() => {
     if (!m.has_photo) return
@@ -180,7 +195,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
         {m.media_type && audioUrl && (
           <div className="detail-audio-wrap">
             {m.media_type === 'video'
-              ? <video controls src={audioUrl} className="detail-video" />
+              ? <video controls poster={posterUrl || undefined} src={audioUrl} className="detail-video" />
               : <audio controls src={audioUrl} className="detail-audio" />}
           </div>
         )}


### PR DESCRIPTION
Follow-up to #222. Videos played, but the poster frame was missing.

**1. Poster on the video.** The detail-sheet `<video>` had no `poster`, so it showed the browser's blank frame + big play button. We already upload a poster frame on video upload (`thumbnail_id`), so this fetches + decrypts that small thumbnail (in-memory cached) and sets it as `<video poster>` — the captured frame with a play overlay instead of a blank box.

**2. Poster during download.** `thumbnail_id` rides along in the synced milestone row and the poster blob is tiny, so it fetches immediately on the receiving device — independently of the large video download. So while a remote video downloads, the sheet now shows the **poster frame with "⬇️ Downloading… X.X MB" overlaid**, instead of a bare text label. Once the video is ready it plays with the same poster.

Falls back to the default UI / plain label when no poster exists (e.g. a video whose poster couldn't be generated).

Two commits over `main`. ESLint clean (0 errors); `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)