### PR TITLE
User-initiated backfill of existing local media to GLANCEvault

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,14 @@ export default function App() {
     return () => mq.removeEventListener('change', handler)
   }, [])
 
+  // Reload milestones from the store on demand — e.g. after the media backfill
+  // writes real-hash slots, so the newly vault-backed media appears immediately.
+  useEffect(() => {
+    const reload = () => { dbGetAll().then(setMilestones).catch(() => {}) }
+    window.addEventListener('lifeglance:milestones-reload', reload)
+    return () => window.removeEventListener('lifeglance:milestones-reload', reload)
+  }, [])
+
   useEffect(() => {
     initDB()
       .then(() => {

--- a/src/blobs/mediaBackfill.js
+++ b/src/blobs/mediaBackfill.js
@@ -1,0 +1,167 @@
+// =============================================================================
+// mediaBackfill — migrate EXISTING local-only milestone media to GLANCEvault
+// (Phase 8 media, step 2). USER-INITIATED, idempotent, resumable, per-item safe.
+// =============================================================================
+//
+// New attachments already blob-round-trip (TimelineView.establishVaultMediaRefs).
+// This migrates the EXISTING library: media that currently lives only in the
+// local IndexedDB media store (photos keyed `${id}-photo`, audio/video keyed
+// `${id}`) with PLACEHOLDER reference slots, so it becomes visible cross-device.
+//
+// It runs the SAME proven single-media path — uploadMilestoneMedia (thumbnail →
+// upload full + thumb with HEAD-dedup → ref-add) → write the REAL-hash slots via
+// updateMilestone (which BUMPS updated_at so the now-non-deterministic hashes
+// propagate by LWW). It does NOT reimplement upload/encrypt/thumbnail, and it
+// NEVER touches the local media store — local stays as the source and fallback.
+//
+// IDEMPOTENT: a real 64-hex slot is skipped (isRealBlobHash); content-addressing
+// + the HEAD existence check inside uploadBlob mean an already-stored blob is not
+// re-uploaded. Safe to run repeatedly.
+//
+// RESUMABLE with NO separate progress state: the real-hash slot written by
+// updateMilestone IS the durable "done" marker. A re-run re-enumerates from the
+// current (persisted) milestone state, so only slots still on placeholders are
+// processed — an interruption resumes from where it left off.
+//
+// PER-ITEM FAILURE TOLERANCE: one bad item (thumbnail generation fails on a
+// corrupt/unsupported source, or an upload error) is recorded with its reason and
+// SKIPPED; the run continues to the next item. Failed items stay local-only
+// (unchanged placeholders) and are retried on a later run.
+
+import { loadMilestones as _loadMilestones, updateMilestone as _updateMilestone } from '../data/milestones.js'
+import { dbGetPhoto as _dbGetPhoto, dbGetMedia as _dbGetMedia } from '../data/db.js'
+import { uploadMilestoneMedia as _uploadMilestoneMedia, isRealBlobHash } from './milestoneMedia.js'
+import { deriveBlobKey as _deriveBlobKey } from './blobCrypto.js'
+
+// A slot needs backfill when the milestone flags media present but the reference
+// slot is still a local-only placeholder (the milestone id / `${id}-photo`),
+// never a real 64-hex content hash.
+function photoNeedsBackfill(m) { return !!m.has_photo && !isRealBlobHash(m.photo_id) }
+function mediaNeedsBackfill(m) { return !!m.media_type && !isRealBlobHash(m.media_id) }
+
+function reasonOf(err) {
+  const name = err?.name || 'Error'
+  const message = err?.message || String(err)
+  return `${name}: ${message}`
+}
+
+/**
+ * Enumerate the milestones with local media not yet on the vault. A slot is a
+ * target only when (a) its placeholder flags it un-migrated AND (b) its bytes
+ * actually exist in the LOCAL store on this device — a placeholder slot with no
+ * local copy is media held on another device (that device must migrate it), so
+ * it's excluded to keep the progress total honest.
+ *
+ * @returns {Promise<Array<{ id, milestone, photo: boolean, media: boolean }>>}
+ */
+export async function enumerateBackfillTargets(deps = {}) {
+  const loadMilestones = deps.loadMilestones ?? _loadMilestones
+  const dbGetPhoto = deps.dbGetPhoto ?? _dbGetPhoto
+  const dbGetMedia = deps.dbGetMedia ?? _dbGetMedia
+
+  const milestones = await loadMilestones()
+  const targets = []
+  for (const m of milestones) {
+    const wantPhoto = photoNeedsBackfill(m)
+    const wantMedia = mediaNeedsBackfill(m)
+    if (!wantPhoto && !wantMedia) continue
+    const photo = wantPhoto && !!(await dbGetPhoto(m.id))
+    const media = wantMedia && !!(await dbGetMedia(m.id))
+    if (photo || media) targets.push({ id: m.id, milestone: m, photo, media })
+  }
+  return targets
+}
+
+// Migrate ONE slot: read local bytes → run the proven upload path → write the
+// real-hash slot(s). Returns a per-slot result; never throws (the caller relies
+// on that for skip-and-continue).
+async function backfillSlot(milestone, slot, deps) {
+  const dbGetPhoto = deps.dbGetPhoto ?? _dbGetPhoto
+  const dbGetMedia = deps.dbGetMedia ?? _dbGetMedia
+  const uploadMilestoneMedia = deps.uploadMilestoneMedia ?? _uploadMilestoneMedia
+  const updateMilestone = deps.updateMilestone ?? _updateMilestone
+  try {
+    const rec = slot === 'photo' ? await dbGetPhoto(milestone.id) : await dbGetMedia(milestone.id)
+    if (!rec || !rec.blob) return { slot, status: 'skipped', reason: 'no local media on this device' }
+    const bytes = new Uint8Array(await rec.blob.arrayBuffer())
+    const { fullHash, thumbHash } = await uploadMilestoneMedia({ bytes, mimeType: rec.mimeType })
+    const updates = slot === 'photo' ? { photo_id: fullHash } : { media_id: fullHash }
+    if (thumbHash) updates.thumbnail_id = thumbHash
+    const updated = await updateMilestone(milestone.id, updates, milestone)
+    return { slot, status: 'migrated', milestone: updated }
+  } catch (err) {
+    return { slot, status: 'failed', reason: reasonOf(err) }
+  }
+}
+
+// Process a single milestone's flagged slots. Photo then media, threading the
+// updated milestone so the media write builds on the photo write (no slot
+// clobber) — identical to the live backgroundEstablishMedia chaining. Re-checks
+// slot state against the CURRENT object so a resumed run never re-uploads a slot
+// that has already become a real hash.
+async function backfillTarget(target, deps) {
+  let current = target.milestone
+  const results = []
+  if (target.photo && photoNeedsBackfill(current)) {
+    const r = await backfillSlot(current, 'photo', deps)
+    results.push(r)
+    if (r.milestone) current = r.milestone
+  }
+  if (target.media && mediaNeedsBackfill(current)) {
+    const r = await backfillSlot(current, 'media', deps)
+    results.push(r)
+    if (r.milestone) current = r.milestone
+  }
+  return { milestone: current, results, changed: current !== target.milestone }
+}
+
+/**
+ * Run the backfill over all un-migrated local media, one item at a time.
+ *
+ * @param {object} deps
+ *   - onProgress({ done, total })   progress callback (milestone-grained)
+ *   - onMilestoneUpdated(milestone) called after a milestone's slots are written
+ *   - shouldStop() => boolean       cooperative cancel checked at each item boundary
+ *   (plus injectable loadMilestones/dbGetPhoto/dbGetMedia/uploadMilestoneMedia/
+ *    updateMilestone/deriveBlobKey for tests)
+ * @returns summary {
+ *   keyUnavailable, total, migrated, failed, skipped, stopped, failures:[{id,title,slot,reason}]
+ * }
+ *   Counts are SLOT-grained (a milestone with a photo + a video is two units);
+ *   `total`/progress are milestone-grained.
+ */
+export async function runMediaBackfill(deps = {}) {
+  const deriveBlobKey = deps.deriveBlobKey ?? _deriveBlobKey
+  const onProgress = deps.onProgress ?? (() => {})
+  const onMilestoneUpdated = deps.onMilestoneUpdated ?? (() => {})
+  const shouldStop = deps.shouldStop ?? (() => false)
+
+  const summary = { keyUnavailable: false, total: 0, migrated: 0, failed: 0, skipped: 0, stopped: false, failures: [] }
+
+  // Pre-flight: the blob key must be derivable, or EVERY item would throw
+  // BlobKeyUnavailableError. Bail with a clear signal instead of churning the
+  // whole library. (On a device where new attachments already blob-round-trip,
+  // the key is present — this guards the fresh-household / key-not-ready case.)
+  const key = await deriveBlobKey()
+  if (!key) { summary.keyUnavailable = true; return summary }
+
+  const targets = await enumerateBackfillTargets(deps)
+  summary.total = targets.length
+  onProgress({ done: 0, total: summary.total })
+
+  for (let i = 0; i < targets.length; i++) {
+    if (shouldStop()) { summary.stopped = true; break }
+    const { milestone, results, changed } = await backfillTarget(targets[i], deps)
+    for (const r of results) {
+      if (r.status === 'migrated') summary.migrated++
+      else if (r.status === 'skipped') summary.skipped++
+      else {
+        summary.failed++
+        summary.failures.push({ id: targets[i].id, title: targets[i].milestone.title, slot: r.slot, reason: r.reason })
+      }
+    }
+    if (changed) onMilestoneUpdated(milestone)
+    onProgress({ done: i + 1, total: summary.total })
+  }
+  return summary
+}

--- a/src/blobs/mediaBackfill.test.js
+++ b/src/blobs/mediaBackfill.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import { enumerateBackfillTargets, runMediaBackfill } from './mediaBackfill.js'
+import { isRealBlobHash } from './milestoneMedia.js'
+
+// The upload/encrypt/thumbnail path is faked here (proven live + covered by the
+// blobTransport / milestoneMedia suites). These tests exercise the backfill's
+// OWN logic: enumeration of un-migrated local media, the idempotent/resumable
+// run keyed off slot state, per-item failure tolerance, and the summary.
+
+const REAL = (c) => c.repeat(64) // a stand-in 64-hex content hash
+const HASH_FULL = REAL('a')
+const HASH_THUMB = REAL('b')
+const fakeBlob = (n = 4) => ({ arrayBuffer: async () => new Uint8Array(n).buffer })
+
+// Build an in-memory milestone store + injectable deps. `photo`/`media` map a
+// milestone id → the mimeType of its LOCAL bytes (absent = no local copy).
+// uploadMilestoneMedia is faked: it throws for mimeType 'image/fail' (thumbnail
+// failure) and for the first `failNextUpload` calls (flaky/resume), else returns
+// real-looking hashes; updateMilestone mutates the store and bumps updated_at.
+function harness(milestones, { photo = {}, media = {} } = {}) {
+  const store = new Map(milestones.map((m) => [m.id, { ...m }]))
+  const calls = { upload: [], update: [] }
+  let failNextUpload = 0
+  const deps = {
+    deriveBlobKey: async () => ({ aesKey: 1, hmacKey: 1 }),
+    loadMilestones: async () => [...store.values()].map((m) => ({ ...m })),
+    dbGetPhoto: async (id) => (photo[id] ? { blob: fakeBlob(), mimeType: photo[id] } : null),
+    dbGetMedia: async (id) => (media[id] ? { blob: fakeBlob(), mimeType: media[id] } : null),
+    uploadMilestoneMedia: async ({ mimeType }) => {
+      calls.upload.push(mimeType)
+      if (failNextUpload > 0) {
+        failNextUpload--
+        const e = new Error('upload error'); e.name = 'BlobTransportError'; throw e
+      }
+      if (mimeType === 'image/fail') {
+        const e = new Error('bad source'); e.name = 'ThumbnailGenerationError'; throw e
+      }
+      const visual = mimeType.startsWith('image/') || mimeType.startsWith('video/')
+      return { fullHash: HASH_FULL, thumbHash: visual ? HASH_THUMB : null }
+    },
+    updateMilestone: async (id, updates, existing) => {
+      const next = { ...existing, ...updates, updated_at: 'BUMPED' }
+      store.set(id, next)
+      calls.update.push({ id, updates, existingPhotoId: existing.photo_id })
+      return next
+    },
+  }
+  return { deps, store, calls, setFailNextUpload: (n) => { failNextUpload = n } }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+const mPhoto = { id: 'm-photo', title: 'Photo', has_photo: true, photo_id: 'm-photo-photo' }
+const mAudio = { id: 'm-audio', title: 'Audio', media_type: 'audio', media_id: 'm-audio' }
+const mDone = { id: 'm-done', title: 'Done', has_photo: true, photo_id: REAL('c') } // already real
+const mRemote = { id: 'm-remote', title: 'Remote', has_photo: true, photo_id: 'm-remote-photo' } // no local
+const mBad = { id: 'm-bad', title: 'Bad', has_photo: true, photo_id: 'm-bad-photo' }
+const mBoth = { id: 'm-both', title: 'Both', has_photo: true, photo_id: 'm-both-photo', media_type: 'video', media_id: 'm-both' }
+
+describe('mediaBackfill — enumeration', () => {
+  it('targets only un-migrated slots whose LOCAL bytes exist on this device', async () => {
+    const { deps } = harness(
+      [mPhoto, mAudio, mDone, mRemote],
+      { photo: { 'm-photo': 'image/jpeg', 'm-done': 'image/jpeg' }, media: { 'm-audio': 'audio/mpeg' } },
+    )
+    const targets = await enumerateBackfillTargets(deps)
+    // m-photo (placeholder + local) and m-audio (placeholder + local). m-done is a
+    // real hash already; m-remote is a placeholder with no local copy (held on
+    // another device) — both excluded.
+    expect(targets.map((t) => t.id).sort()).toEqual(['m-audio', 'm-photo'])
+    expect(targets.find((t) => t.id === 'm-photo').photo).toBe(true)
+    expect(targets.find((t) => t.id === 'm-audio').media).toBe(true)
+  })
+})
+
+describe('mediaBackfill — a successful item migrates', () => {
+  it('writes real-hash slots (photo + thumbnail) and bumps updated_at', async () => {
+    const { deps, store } = harness([mPhoto], { photo: { 'm-photo': 'image/jpeg' } })
+    const s = await runMediaBackfill(deps)
+    expect(s).toMatchObject({ total: 1, migrated: 1, failed: 0, skipped: 0 })
+    const m = store.get('m-photo')
+    expect(isRealBlobHash(m.photo_id)).toBe(true)
+    expect(isRealBlobHash(m.thumbnail_id)).toBe(true)
+    expect(m.updated_at).toBe('BUMPED')
+  })
+
+  it('audio migrates a full-res hash with NO thumbnail slot', async () => {
+    const { deps, store } = harness([mAudio], { media: { 'm-audio': 'audio/mpeg' } })
+    const s = await runMediaBackfill(deps)
+    expect(s.migrated).toBe(1)
+    const m = store.get('m-audio')
+    expect(isRealBlobHash(m.media_id)).toBe(true)
+    expect(m.thumbnail_id).toBeUndefined()
+  })
+
+  it('a milestone with BOTH photo and video migrates both slots, media built on the photo write', async () => {
+    const { deps, store, calls } = harness([mBoth], { photo: { 'm-both': 'image/jpeg' }, media: { 'm-both': 'video/mp4' } })
+    await runMediaBackfill(deps)
+    const m = store.get('m-both')
+    expect(isRealBlobHash(m.photo_id)).toBe(true)
+    expect(isRealBlobHash(m.media_id)).toBe(true)
+    // Two writes for the same milestone; the media write's `existing` already
+    // carries the real photo_id (threaded — no slot clobber).
+    const bothUpdates = calls.update.filter((c) => c.id === 'm-both')
+    expect(bothUpdates).toHaveLength(2)
+    expect(isRealBlobHash(bothUpdates[1].existingPhotoId)).toBe(true)
+  })
+})
+
+describe('mediaBackfill — idempotent skip', () => {
+  it('an already-migrated (real-hash) item is not enumerated and never uploaded', async () => {
+    const { deps, calls } = harness([mDone], { photo: { 'm-done': 'image/jpeg' } })
+    const s = await runMediaBackfill(deps)
+    expect(s.total).toBe(0)
+    expect(s.migrated).toBe(0)
+    expect(calls.upload).toHaveLength(0)
+  })
+})
+
+describe('mediaBackfill — per-item failure tolerance', () => {
+  it('a failing item is recorded and SKIPPED; the run continues to later items', async () => {
+    // Failing item enumerated FIRST to prove it does not halt the run.
+    const { deps, store, calls } = harness(
+      [mBad, mPhoto],
+      { photo: { 'm-bad': 'image/fail', 'm-photo': 'image/jpeg' } },
+    )
+    const s = await runMediaBackfill(deps)
+    expect(s.failed).toBe(1)
+    expect(s.migrated).toBe(1)
+    expect(s.failures[0]).toMatchObject({ id: 'm-bad', slot: 'photo', title: 'Bad' })
+    expect(s.failures[0].reason).toMatch(/ThumbnailGenerationError/)
+    // The later item still processed; the failed item stays a local-only placeholder.
+    expect(isRealBlobHash(store.get('m-photo').photo_id)).toBe(true)
+    expect(isRealBlobHash(store.get('m-bad').photo_id)).toBe(false)
+    expect(calls.upload).toHaveLength(2) // both attempted
+  })
+})
+
+describe('mediaBackfill — resumable', () => {
+  it('re-running after a partial run processes ONLY the remainder', async () => {
+    const { deps, store, setFailNextUpload } = harness(
+      [mPhoto, mAudio],
+      { photo: { 'm-photo': 'image/jpeg' }, media: { 'm-audio': 'audio/mpeg' } },
+    )
+    setFailNextUpload(1) // fail the first upload (m-photo); m-audio still succeeds
+    const s1 = await runMediaBackfill(deps)
+    expect(s1.migrated).toBe(1) // audio done
+    expect(s1.failed).toBe(1) // photo failed
+    expect(isRealBlobHash(store.get('m-photo').photo_id)).toBe(false)
+    expect(isRealBlobHash(store.get('m-audio').media_id)).toBe(true)
+
+    // Re-run: audio is now a real hash (excluded); only the photo remains.
+    const s2 = await runMediaBackfill(deps)
+    expect(s2.total).toBe(1)
+    expect(s2.migrated).toBe(1)
+    expect(isRealBlobHash(store.get('m-photo').photo_id)).toBe(true)
+  })
+})
+
+describe('mediaBackfill — progress, cancel, and key pre-flight', () => {
+  it('reports progress from 0 to total', async () => {
+    const progress = []
+    const { deps } = harness(
+      [mPhoto, mAudio],
+      { photo: { 'm-photo': 'image/jpeg' }, media: { 'm-audio': 'audio/mpeg' } },
+    )
+    await runMediaBackfill({ ...deps, onProgress: (p) => progress.push(p) })
+    expect(progress[0]).toEqual({ done: 0, total: 2 })
+    expect(progress[progress.length - 1]).toEqual({ done: 2, total: 2 })
+  })
+
+  it('stops cooperatively at an item boundary (resumable) when shouldStop() turns true', async () => {
+    const { deps, store } = harness(
+      [mPhoto, mAudio],
+      { photo: { 'm-photo': 'image/jpeg' }, media: { 'm-audio': 'audio/mpeg' } },
+    )
+    let checks = 0
+    const s = await runMediaBackfill({ ...deps, shouldStop: () => checks++ >= 1 }) // allow item 0, stop before item 1
+    expect(s.stopped).toBe(true)
+    expect(s.migrated).toBe(1)
+    expect(isRealBlobHash(store.get('m-audio').media_id)).toBe(false) // never reached
+  })
+
+  it('bails immediately with keyUnavailable when the blob key cannot be derived', async () => {
+    const { deps, calls } = harness([mPhoto], { photo: { 'm-photo': 'image/jpeg' } })
+    const s = await runMediaBackfill({ ...deps, deriveBlobKey: async () => null })
+    expect(s.keyUnavailable).toBe(true)
+    expect(s.total).toBe(0)
+    expect(calls.upload).toHaveLength(0)
+  })
+
+  it('calls onMilestoneUpdated only for milestones whose slots changed', async () => {
+    const updated = []
+    const { deps } = harness([mPhoto], { photo: { 'm-photo': 'image/jpeg' } })
+    await runMediaBackfill({ ...deps, onMilestoneUpdated: (m) => updated.push(m.id) })
+    expect(updated).toEqual(['m-photo'])
+  })
+})

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getSyncEngine } from '../../sync/engine'
 import { isSyncing, syncErrorText, SYNC_ERROR_I18N_KEYS } from '../../sync/status'
 import { verifyVaultCredentials, runVaultSetup, disableVault, VAULT_OUTCOME } from '../../sync/vaultSetup'
+import { runMediaBackfill } from '../../blobs/mediaBackfill'
 
 // Maps a vault verify/setup outcome kind to its distinct, translatable message.
 const VAULT_MSG_KEY = {
@@ -94,6 +95,15 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
   const [vaultSaving,     setVaultSaving]     = useState(false)
   const [vaultResult,     setVaultResult]     = useState(null)
   const vaultConfigured = !!existingConfig?.vaultEnabled
+
+  // ── Backfill: upload existing local-only media to GLANCEvault (user-initiated) ─
+  const [backfillRunning,  setBackfillRunning]  = useState(false)
+  const [backfillProgress, setBackfillProgress] = useState({ done: 0, total: 0 })
+  const [backfillMsg,      setBackfillMsg]      = useState(null) // { ok, message }
+  const backfillStopRef = useRef(false)
+  // If the modal closes mid-run, signal a cooperative stop so the run halts at the
+  // next item boundary. Already-written slots are durable, so a later run resumes.
+  useEffect(() => () => { backfillStopRef.current = true }, [])
 
   const isExisting = !!existingConfig
 
@@ -239,6 +249,37 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
     disableVault()
     setVaultEnabled(false)
     setVaultResult(null)
+  }
+
+  function backfillSummaryMsg(s) {
+    if (s.keyUnavailable) return { ok: false, message: t('backfillKeyUnavailable') }
+    if (s.stopped)        return { ok: true,  message: t('backfillStopped', { migrated: s.migrated }) }
+    if (s.total === 0)    return { ok: true,  message: t('backfillNothing') }
+    if (s.failed > 0)     return { ok: true,  message: t('backfillDoneWithFailures', { migrated: s.migrated, failed: s.failed }) }
+    return { ok: true, message: t('backfillDone', { migrated: s.migrated }) }
+  }
+
+  async function handleBackfill() {
+    setBackfillRunning(true)
+    setBackfillMsg(null)
+    setBackfillProgress({ done: 0, total: 0 })
+    backfillStopRef.current = false
+    try {
+      const summary = await runMediaBackfill({
+        onProgress: (p) => setBackfillProgress(p),
+        shouldStop: () => backfillStopRef.current,
+      })
+      // Any newly-written real-hash slots need the timeline to reload so the media
+      // becomes visible immediately (and its updated_at bump has already queued the
+      // push to other devices).
+      if (summary.migrated > 0) window.dispatchEvent(new Event('lifeglance:milestones-reload'))
+      if (summary.failures?.length) console.warn('[media backfill] failed items:', summary.failures)
+      setBackfillMsg(backfillSummaryMsg(summary))
+    } catch (err) {
+      setBackfillMsg({ ok: false, message: t('backfillError', { message: err?.message || String(err) }) })
+    } finally {
+      setBackfillRunning(false)
+    }
   }
 
   return (
@@ -481,6 +522,39 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
                   </button>
                 )}
               </div>
+
+              {/* One-time catch-up: upload existing local-only media to the vault. */}
+              {vaultConfigured && (
+                <div style={{ marginTop: '0.85rem', borderTop: '1px solid var(--border-soft, rgba(128,128,128,0.25))', paddingTop: '0.7rem' }}>
+                  <div className="settings-label">{t('backfillTitle')}</div>
+                  <p className="settings-note" style={{ marginTop: '0.15rem', marginBottom: '0.5rem' }}>{t('backfillNote')}</p>
+                  <button className="btn" style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+                    onClick={handleBackfill} disabled={backfillRunning}>
+                    {backfillRunning
+                      ? (backfillProgress.total > 0 ? t('backfillRunning', backfillProgress) : t('backfillScanning'))
+                      : t('backfillStart')}
+                  </button>
+                  {backfillRunning && backfillProgress.total > 0 && (
+                    <div style={{ marginTop: '0.5rem', height: '6px', borderRadius: '3px', background: 'rgba(128,128,128,0.2)', overflow: 'hidden' }}>
+                      <div style={{
+                        height: '100%',
+                        width: `${Math.round((100 * backfillProgress.done) / backfillProgress.total)}%`,
+                        background: 'var(--amber-bright)', transition: 'width 0.2s',
+                      }} />
+                    </div>
+                  )}
+                  {backfillMsg && (
+                    <div style={{
+                      padding: '0.6rem 1rem', borderRadius: '6px', marginTop: '0.5rem', fontSize: '0.82rem',
+                      background: backfillMsg.ok ? 'var(--success-bg)' : 'var(--danger-bg)',
+                      color: backfillMsg.ok ? 'var(--success)' : 'var(--rose)',
+                      border: `1px solid ${backfillMsg.ok ? 'rgba(var(--success-rgb), 0.267)' : 'rgba(var(--rose-rgb), 0.267)'}`,
+                    }}>
+                      {backfillMsg.message}
+                    </div>
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/locales/en/sync.json
+++ b/src/locales/en/sync.json
@@ -85,5 +85,16 @@
   "vaultForbidden": "Account ID not found or not permitted for this token.",
   "vaultNetwork": "Could not reach the vault at this URL.",
   "vaultUnsupported": "This vault server is too old — it doesn't support credential verification.",
-  "vaultPassphraseRequired": "Enter your sync passphrase to enable database sync."
+  "vaultPassphraseRequired": "Enter your sync passphrase to enable database sync.",
+  "backfillTitle": "Existing media",
+  "backfillNote": "Upload photos and audio/video already on this device to GLANCEvault so they appear on your other devices. New attachments upload automatically; this is a one-time catch-up for older items. Safe to run repeatedly — already-uploaded items are skipped.",
+  "backfillStart": "Upload existing media to GLANCEvault",
+  "backfillRunning": "Uploading media… {{done}} of {{total}}",
+  "backfillScanning": "Checking for media to upload…",
+  "backfillNothing": "Nothing to upload — all media on this device is already on GLANCEvault.",
+  "backfillKeyUnavailable": "Vault key isn't ready yet. Let sync finish once, then try again.",
+  "backfillDone": "Uploaded {{migrated}} item(s) to GLANCEvault.",
+  "backfillDoneWithFailures": "Uploaded {{migrated}} item(s); {{failed}} could not be uploaded and stay on this device (you can try again later).",
+  "backfillStopped": "Stopped after {{migrated}} item(s). Run again to finish the rest.",
+  "backfillError": "Upload failed: {{message}}"
 }


### PR DESCRIPTION
Migrates the EXISTING media library — photos/audio/video that live only in the local IndexedDB media store with placeholder reference slots — up to the vault, so older items become visible cross-device (new attachments already do this on save). Rebased onto the latest `main` now that the media round-trip is proven.

## What it does
- **`src/blobs/mediaBackfill.js`** — `enumerateBackfillTargets` finds milestones whose slot is still a placeholder (`isRealBlobHash === false`) **and** whose bytes exist locally on this device (a placeholder with no local copy is media held on another device — excluded). `runMediaBackfill` runs the **proven** `uploadMilestoneMedia` path per item, then writes the real-hash slots via `updateMilestone` (bumps `updated_at` → LWW propagation).
  - **Idempotent**: real-hash slots skipped; content-addressing + HEAD dedup skip already-stored blobs. Safe to run repeatedly.
  - **Resumable** with no separate state: the real-hash slot IS the durable "done" marker, so a re-run processes only the remainder.
  - **Per-item failure tolerance**: a bad item (thumbnail/upload failure) is recorded and skipped; the run continues. (Note: with the merged poster fix, a video whose poster can't be generated now uploads anyway — it won't be a backfill failure.)
  - **Key pre-flight**: if the blob key can't be derived, it bails with `keyUnavailable` instead of failing every item.
- **UI (`CloudSyncModal`)** — "Upload existing media to GLANCEvault", shown only when vault sync is active, with live "Uploading media… N of M", a progress bar, and a final summary (migrated / failed / nothing / key-not-ready / stopped). Closing the modal cooperatively stops at an item boundary (resumable).
- **`App.jsx`** — reloads milestones on `lifeglance:milestones-reload` (dispatched after a run) so migrated media appears immediately.

## Tests
`mediaBackfill.test.js` (faked upload path): enumerates only un-migrated local items; a success writes real-hash slots + bumps `updated_at`; audio gets no thumbnail slot; a photo+video milestone threads both writes; already-migrated is skipped; a failing item is recorded and does NOT halt the run; re-running resumes only the remainder; progress 0→total; cooperative stop; key-unavailable pre-flight. Full suite passes (245); ESLint clean (0 errors); `npm run build` succeeds.

## On-device note
The real at-scale thumbnail generation over your actual library and the bulk upload are only exercisable on-device — which is why a single bad item records-and-continues rather than aborting the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_