### PR TITLE
Lint housekeeping: unused imports/vars + one dead export

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Onboarding   from './components/onboarding/Onboarding'
 import TimelineView from './components/timeline/TimelineView'

--- a/src/components/dayglance/IntegrationSettings.jsx
+++ b/src/components/dayglance/IntegrationSettings.jsx
@@ -1,14 +1,12 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { loadIntentsConfig, saveIntentsConfig, enableIntentsEncryption } from '../../lib/intentsTransport.js'
-import { loadIntentsRootKey } from '../../lib/intentsKeyStore.js'
 import { isNativePlatform, nativeWebdavResponse } from '../../sync/nativeHttp.js'
 
 const PROXY_URL = import.meta.env.VITE_WEBDAV_PROXY_URL ?? '/api/webdav-proxy'
 
 export default function IntegrationSettings() {
   const { t } = useTranslation('dayglance')
-  const { t: ts } = useTranslation('sync')
   const [cfg, setCfg] = useState(loadIntentsConfig)
   const [testStatus, setTestStatus] = useState(null)
   const [testMsg,    setTestMsg]    = useState('')

--- a/src/components/onboarding/Step3Future.jsx
+++ b/src/components/onboarding/Step3Future.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import TypewriterText from '../ui/TypewriterText'
 import { buildDateFromParts, dateFieldOrder, monthNames } from '../../utils/dates'
 
-export default function Step3Future({ onSubmit, pastMilestone }) {
+export default function Step3Future({ onSubmit }) {
   const { t } = useTranslation('onboarding')
   const { t: tc } = useTranslation('common')
   const { i18n } = useTranslation()

--- a/src/components/sync/AutoBackupModal.jsx
+++ b/src/components/sync/AutoBackupModal.jsx
@@ -22,7 +22,7 @@ function SettingsTab({ onClose }) {
   const savedBackupConfig = loadBackupConfig()
 
   const [remoteEnabled, setRemoteEnabled] = useState(savedBackupConfig?.remoteEnabled ?? false)
-  const [provider,      setProvider]      = useState(existingConfig?.provider ?? 'nextcloud')
+  const [provider] = useState(existingConfig?.provider ?? 'nextcloud')
   const [url,           setUrl]           = useState(existingConfig?.url ?? '')
   const [username,      setUsername]      = useState(existingConfig?.username ?? '')
   const [password,      setPassword]      = useState(existingConfig?.password ?? '')

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -295,7 +295,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
 
   // Inbound: dayGLANCE notifying of a state change on one of our milestones.
   const handleInboundNotify = useCallback(async (payload) => {
-    const { event, source_entity_id, due, previous_due, completed_at, title } = payload
+    const { event, source_entity_id, due, completed_at, title } = payload
     const current = milestonesRef.current.find(m => m.id === source_entity_id)
     if (!current) return
 

--- a/src/lib/intentsKeyStore.js
+++ b/src/lib/intentsKeyStore.js
@@ -58,7 +58,3 @@ export function makeDeriveFn(rootKey) {
   if (!rootKey) return null
   return (salt) => deriveEnvelopeKey(rootKey, salt)
 }
-
-export function clearIntentsRootKey() {
-  _rootKey = null
-}

--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -52,7 +52,7 @@ export const buildBackupPayload = async () => {
 
 // applyPayload — writes merged data to IDB, then refreshes React state via callbacks
 export const makeApplyPayload = (setMilestones, setChapters) =>
-  async (data, opts) => {
+  async (data, _opts) => {
     const life = data?.lives?.default;
     if (!life) return;
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -56,7 +56,7 @@ export function relativeParts(dateStr) {
   return { key: 'relToday', today: true }
 }
 
-export function relativeLabel(dateStr, precision = 'day') {
+export function relativeLabel(dateStr, _precision = 'day') {
   const { key, count = 0, months = 0 } = relativeParts(dateStr)
   // Strip the <0></0> / <1></1> component tags used by the animated variant.
   return i18n.t(key, { ns: 'common', count, months }).replace(/<\/?\d+>/g, '')

--- a/src/utils/visibility.js
+++ b/src/utils/visibility.js
@@ -22,7 +22,6 @@
  * @returns {{ endpointChapterNames: Map<string, string[]> }}
  */
 export function precomputeEndpoints(chapters) {
-  const endpointIds          = new Set()
   const endpointChapterNames = new Map()
 
   for (const chapter of chapters) {


### PR DESCRIPTION
Zero-behavior-change cleanup. Based on fresh `main`, independent of the backfill PR.

## Removed / fixed (9 of 10 `no-unused-vars`)
- Unused imports: `useCallback` (App.jsx), `loadIntentsRootKey` (IntegrationSettings.jsx)
- Unused locals: `ts` translation binding (IntegrationSettings), `previous_due` destructure (TimelineView), `endpointIds` set (visibility.js), `setProvider` setter (AutoBackupModal)
- Unused prop: `pastMilestone` dropped from `Step3Future`
- Genuinely-ignored args prefixed `_` (no signature change): `opts` → `_opts` (`adapter.makeApplyPayload`), `precision` → `_precision` (`dates.relativeLabel`)

## Dead export removed
- `clearIntentsRootKey` (`intentsKeyStore.js`) — no callers, and it only cleared the in-memory cache (not the persisted IDB key), so it couldn't function as a real key-teardown anyway. Confirmed not a planned logout hook (a real one would need to delete from IDB like `clearEncryptionKey` does).

## Result
`no-unused-vars`: **10 → 1**. Total ESLint warnings: **32 → 23**, still **0 errors**. Full suite passes (245); `npm run build` succeeds.

## Deliberately NOT touched (flagged, not fixed here)
1. **`ultraCompact` (Timeline.jsx:66)** — the one remaining `no-unused-vars`. It's **not dead code**: it's a real user setting (`setUltraCompact` in TimelineView drives layout + button labels) that TimelineView *passes to `<Timeline>`, but `<Timeline>` ignores it* (its layout uses an internal `compactLayout` media-query instead). That's a possible **unwired setting**, not lint noise — left as-is pending a product decision.
2. **`relativeLabel(dateStr, _precision)`** — silenced for lint, but note the underlying behavior: every caller passes `m.date_precision`, yet the body never forwards it to `relativeParts`, so **relative labels aren't precision-aware**. Possibly intentional; flagging in case it's a latent bug. Behavior unchanged in this PR.
3. **The 22 `react-hooks` warnings** — idiomatic in this codebase (the "load in an effect → setState" pattern, ref reads in `useIdleMode`). Not worth the regression risk for a clean report; a separate careful pass if you ever want zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_