### PR TITLE
Categorize chapters + show/hide by tag (closes #213)

### DIFF
--- a/src/components/chapter/ChapterSheet.jsx
+++ b/src/components/chapter/ChapterSheet.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 import { buildDateFromParts, dateFieldOrder, monthNames } from '../../utils/dates'
+import { DEFAULT_CATEGORIES } from '../../utils/colors'
 
 const CHAPTER_COLORS = [
   { hex: 'var(--amber)', label: 'amber'   },
@@ -37,7 +38,7 @@ function parseIso(iso) {
   }
 }
 
-export default function ChapterSheet({ onSave, onClose, onDelete, existing, milestones = [] }) {
+export default function ChapterSheet({ onSave, onClose, onDelete, existing, milestones = [], categories = DEFAULT_CATEGORIES }) {
   const { t } = useTranslation('chapter')
   const { t: tc } = useTranslation('common')
   const { i18n } = useTranslation()
@@ -111,6 +112,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
   const [endYear,        setEndYear]        = useState(initEnd.year)
   const [endPrecision,   setEndPrecision]   = useState('month')
   const [color,          setColor]          = useState(existing?.color ?? CHAPTER_COLORS[0].hex)
+  const [category,       setCategory]       = useState(existing?.category ?? null)
   const [desc,           setDesc]           = useState(existing?.description ?? '')
   const [defVis,         setDefVis]         = useState(existing?.defaultMemberVisibility ?? 'shown')
   const [checkedIds,     setCheckedIds]     = useState(() => new Set(existing?.milestoneIds ?? []))
@@ -208,6 +210,7 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
           start:                  startIso,
           end:                    ongoing ? null : endIso,
           color,
+          category,
           description:            desc.trim(),
           defaultMemberVisibility: defVis,
           milestoneIds:           [...checkedIds],
@@ -316,6 +319,31 @@ export default function ChapterSheet({ onSave, onClose, onDelete, existing, mile
                 onClick={() => setColor(c.hex)}
                 title={c.label}
               />
+            ))}
+          </div>
+        </div>
+
+        {/* Category (tag) — same categories as milestones; used for the show/hide
+            filter. Independent of the chapter's color above. */}
+        <div className="sheet-field">
+          <label className="field-label">{t('categoryLabel')}</label>
+          <div className="category-grid">
+            <div
+              className={`category-chip ${category == null ? 'selected' : ''}`}
+              onClick={() => setCategory(null)}
+            >
+              <div className="category-chip-dot" style={{ background: 'var(--text-muted)' }} />
+              {t('categoryNone')}
+            </div>
+            {categories.map(cat => (
+              <div
+                key={cat.id}
+                className={`category-chip ${category === cat.id ? 'selected' : ''}`}
+                onClick={() => setCategory(cat.id)}
+              >
+                <div className="category-chip-dot" style={{ background: cat.color }} />
+                {cat.label}
+              </div>
             ))}
           </div>
         </div>

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -18,7 +18,7 @@ import TypewriterText    from '../ui/TypewriterText'
 import { ZOOM_LEVELS, applyRecurFilter } from '../../utils/timeline'
 import { expandAnnualDates } from '../../utils/recurrence'
 import { loadCategories, saveCategories } from '../../utils/colors'
-import { getMilestoneVisibility, precomputeEndpoints } from '../../utils/visibility'
+import { getMilestoneVisibility, precomputeEndpoints, filterChaptersByCategory } from '../../utils/visibility'
 import { addMilestone, updateMilestone, deleteMilestone, restoreMilestones, uid } from '../../data/milestones'
 import { listChapters, restoreChapters, createChapter, updateChapter, deleteChapter } from '../../data/chapters'
 import { writeMilestoneTombstone } from '../../sync/tombstones'
@@ -386,7 +386,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
 
   // ── Filter ───────────────────────────────────────────────────────────────────
   const presentCategories = categories.filter(cat =>
-    milestones.some(m => m.category === cat.id)
+    milestones.some(m => m.category === cat.id) || chapters.some(c => c.category === cat.id)
   )
   const hasRecurring = milestones.some(m => m.recurrence_id)
   const categoryFiltered = filter.size === 0 ? milestones : milestones.filter(m => filter.has(m.category))
@@ -1092,6 +1092,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
           start:                  startIso,
           end:                    endIso,
           color:                  data.color,
+          category:               data.category ?? null,
           description:            data.description,
           defaultMemberVisibility: data.defaultMemberVisibility,
           milestoneIds:           data.milestoneIds,
@@ -1107,6 +1108,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         start:                  data.start,
         end:                    data.end,   // null for ongoing
         color:                  data.color,
+        category:               data.category ?? null,
         description:            data.description,
         defaultMemberVisibility: data.defaultMemberVisibility,
       })
@@ -1501,7 +1503,10 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   const drillMilestones = drilledChapter
     ? milestones.filter(m => drilledChapter.milestoneIds.includes(m.id))
     : filteredMilestones
-  const drillChapters   = drilledChapter ? [drilledChapter] : chapters
+  // Chapter bands on the main timeline honor the category filter (a drilled-in
+  // chapter is shown as-is). Milestone visibility still uses the FULL chapters
+  // list above, so hiding a chapter band never changes milestone cascade.
+  const drillChapters   = drilledChapter ? [drilledChapter] : filterChaptersByCategory(chapters, filter)
   const drillHighlighted = highlightedIds
 
   function fmtChapterDate(iso) {
@@ -2105,6 +2110,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
           onDelete={handleChapterDelete}
           existing={editChapter}
           milestones={milestones}
+          categories={categories}
         />
       )}
       {detail && (

--- a/src/data/chapters.js
+++ b/src/data/chapters.js
@@ -12,6 +12,7 @@ export function buildChapter({
   start,
   end = null,
   color,
+  category                  = null,   // tag id (same set as milestone categories); null = untagged
   description               = '',
   defaultMemberVisibility   = 'shown',
   parentChapterId           = null,
@@ -23,6 +24,7 @@ export function buildChapter({
     start:                  start instanceof Date ? start.toISOString() : new Date(start).toISOString(),
     end:                    end === null ? null : (end instanceof Date ? end.toISOString() : new Date(end).toISOString()),
     color,
+    category,
     description,
     defaultMemberVisibility,
     parentChapterId,

--- a/src/locales/en/chapter.json
+++ b/src/locales/en/chapter.json
@@ -22,6 +22,8 @@
   "errorEndDayRange": "end day must be between 1 and {{max}} for the selected month",
   "errorEndAfterStart": "end date must be after start date",
   "colorLabel": "color",
+  "categoryLabel": "category (tag)",
+  "categoryNone": "none",
   "deleteConfirmTitle": "delete <strong>{{title}}</strong>?",
   "endpointTooltip": "endpoint — always shown on main timeline",
   "endpointDimTooltip": "matches chapter boundary — add to make it an endpoint",

--- a/src/sync/losslessness.test.js
+++ b/src/sync/losslessness.test.js
@@ -138,7 +138,7 @@ function typeOf(v) {
 function makeFixture() {
   const parentChapter = buildChapter({
     title: 'The Twenties', start: new Date('2010-01-01'), end: new Date('2019-12-31'),
-    color: '#9370DB', description: 'A whole decade', defaultMemberVisibility: 'shown',
+    color: '#9370DB', category: 'personal', description: 'A whole decade', defaultMemberVisibility: 'shown',
   })
   const childChapter = buildChapter({
     title: 'University Years', start: new Date('2010-09-01'), end: new Date('2014-06-30'),
@@ -265,6 +265,9 @@ describe('GLANCEvault sync — Stage 1 losslessness', () => {
     expect(rc[child.id].parentChapterId).toBe(child.parentChapterId)
     // milestoneIds membership arrays survive verbatim and in order.
     for (const c of oc) expect(rc[c.id].milestoneIds).toEqual(c.milestoneIds)
+    // The chapter category tag (issue #213) rides the chapter row and round-trips.
+    for (const c of oc) expect(rc[c.id].category).toBe(c.category ?? null)
+    expect(oc.find((c) => c.category === 'personal')).toBeTruthy() // fixture actually exercises it
   })
 
   it('preserves every singleton bundle (tombstone maps, birthday, categories) with paired timestamps', async () => {

--- a/src/utils/visibility.js
+++ b/src/utils/visibility.js
@@ -12,6 +12,24 @@
  */
 
 /**
+ * Chapters honor the same category filter as milestones. `filter` is the Set of
+ * selected category ids (empty = no filter, show everything). When a filter is
+ * active, a chapter shows only if its `category` tag is one of the selected ids;
+ * an untagged chapter (category null/undefined) is hidden under an active filter
+ * and shown when the filter is cleared — matching milestone filter behavior.
+ *
+ * Pure and side-effect-free so it's directly unit-testable.
+ *
+ * @param {Array} chapters
+ * @param {Set<string>} filter  selected category ids
+ * @returns {Array} the chapters that pass the filter
+ */
+export function filterChaptersByCategory(chapters, filter) {
+  if (!filter || filter.size === 0) return chapters
+  return chapters.filter(c => c.category != null && filter.has(c.category))
+}
+
+/**
  * Precomputes a Set of milestone IDs that are endpoints of any chapter.
  * Also returns a Map from milestoneId → array of chapter names it anchors.
  *

--- a/src/utils/visibility.test.js
+++ b/src/utils/visibility.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { filterChaptersByCategory } from './visibility.js'
+
+// Chapter category tags + show/hide filter (issue #213).
+const ch = (id, category) => ({ id, category, milestoneIds: [] })
+
+describe('filterChaptersByCategory', () => {
+  const chapters = [ch('a', 'career'), ch('b', 'travel'), ch('c', null), ch('d', 'career'), ch('e', undefined)]
+
+  it('returns everything when no filter is active (empty set or null)', () => {
+    expect(filterChaptersByCategory(chapters, new Set())).toBe(chapters)
+    expect(filterChaptersByCategory(chapters, null)).toBe(chapters)
+  })
+
+  it('keeps only chapters whose tag is in the active filter', () => {
+    expect(filterChaptersByCategory(chapters, new Set(['career'])).map(c => c.id)).toEqual(['a', 'd'])
+  })
+
+  it('supports multiple selected tags', () => {
+    expect(filterChaptersByCategory(chapters, new Set(['career', 'travel'])).map(c => c.id)).toEqual(['a', 'b', 'd'])
+  })
+
+  it('hides untagged chapters (null or undefined category) under an active filter', () => {
+    const out = filterChaptersByCategory(chapters, new Set(['travel']))
+    expect(out.map(c => c.id)).toEqual(['b'])
+    expect(out.some(c => c.category == null)).toBe(false)
+  })
+})


### PR DESCRIPTION
Implements issue #213: chapters can be **tagged with the same categories as milestones** and are **shown/hidden by the selected tag** via the existing timeline filter.

## Design decision (per repo owner)
The category is a **separate, optional tag** — the chapter's existing color palette is **unchanged**. Category is used only for the show/hide filter, so existing chapters look exactly as they do now.

## Changes
- **`data/chapters.js`** — `buildChapter` gains a `category` field (`null` = untagged); `updateChapter`/`restoreChapters` already carry it through.
- **`ChapterSheet`** — a category picker (same chip UI as the milestone sheet) with a **"none"** option; saves `category` alongside `color`.
- **`TimelineView`** — threads `category` on chapter create/update; passes the categories list to the sheet; `presentCategories` now also surfaces a category used **only** by chapters (so it shows as a filter option); the main timeline's chapter bands run through `filterChaptersByCategory`, so a tag filter hides non-matching chapters. A drilled-in chapter is shown as-is, and **milestone visibility still uses the full chapter list** (hiding a band never affects milestone cascade).
- **`utils/visibility.js`** — `filterChaptersByCategory`, a pure helper: empty filter → all; active filter → only chapters whose tag is selected; untagged chapters (null/undefined) hide under an active filter and return when it's cleared — matching milestone behavior.

## Sync
No sync changes needed — the new `category` scalar rides the existing chapter LWW row (`mergeChapters` spreads the whole chapter). The losslessness test now tags a fixture chapter and asserts the tag survives shred→reassemble. Existing untagged chapters need no migration (null/undefined handled throughout).

## Tests
- `visibility.test.js` — the filter (empty / active / multi-select / untagged hidden).
- `losslessness.test.js` — chapter `category` round-trips.
- Full suite **249 pass**; `npm run build` + ESLint clean (0 errors).

## Notes
- Filter semantics match milestones exactly: under an active filter, untagged chapters hide (they're not in any selected tag) and reappear on "All". Since all existing chapters start untagged, they'll show under "All" and can be tagged to appear under specific filters.
- Independent of the open housekeeping (#225) and backfill (#224) PRs — separate files (the two shared files are touched on different lines), so it merges in any order.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_