### PR TITLE
Auto-backup connection Test resolves the WebDAV base like the sync Test (related #206)

### DIFF
--- a/src/components/sync/AutoBackupModal.jsx
+++ b/src/components/sync/AutoBackupModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getSyncEngine } from '../../sync/engine'
+import { buildWebdavConfig } from '../../sync/webdav'
 
 const FREQUENCIES = [
   { value: 'hourly',  label: 'Hourly (keep 24)' },
@@ -41,11 +42,15 @@ function SettingsTab({ onClose }) {
     setTesting(true)
     setResult(null)
     try {
-      const config = { provider, url, username, password }
-      const ok = await engine?.testConnection?.(config)
-      setResult(ok
+      // Build + test the connection the SAME way the Cloud Sync test does
+      // (resolving the provider base), so the two tests agree for one server
+      // instead of the auto-backup test failing while sync passes (issue #206).
+      const config = buildWebdavConfig({ provider, url, username, password, folder: existingConfig?.folder })
+      const r = await engine?.test?.(config)
+      if (!r) throw new Error('Sync engine not initialized.')
+      setResult(r.success
         ? { ok: true, message: t('connectionSuccessful') }
-        : { ok: false, message: t('connectionFailedSimple') })
+        : { ok: false, message: r.error ?? t('connectionFailedSimple') })
     } catch (err) {
       setResult({ ok: false, message: t('error', { message: err.message }) })
     } finally {

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { getSyncEngine } from '../../sync/engine'
 import { isSyncing, syncErrorText, SYNC_ERROR_I18N_KEYS } from '../../sync/status'
 import { verifyVaultCredentials, runVaultSetup, disableVault, VAULT_OUTCOME } from '../../sync/vaultSetup'
+import { resolveWebdavBase } from '../../sync/webdav'
 import { runMediaBackfill } from '../../blobs/mediaBackfill'
 
 // Maps a vault verify/setup outcome kind to its distinct, translatable message.
@@ -29,14 +30,6 @@ async function mkdirp(url, username, password) {
       await fetch(PROXY, { method: 'MKCOL', headers: { ...auth, 'X-WebDAV-Url': url } })
     }
   }
-}
-
-function resolveWebdavBase(provider, url, username) {
-  const base = url.replace(/\/+$/, '')
-  if (provider === 'nextcloud' && !base.includes('/remote.php/dav')) {
-    return `${base}/remote.php/dav/files/${encodeURIComponent(username)}`
-  }
-  return base
 }
 
 const PROVIDERS = [

--- a/src/sync/webdav.js
+++ b/src/sync/webdav.js
@@ -1,0 +1,40 @@
+// Shared WebDAV URL/config helpers for the cloud-sync and auto-backup panels.
+//
+// Both the Cloud Sync "test connection" and the Auto-Backup "test connection"
+// must build the connection the SAME way. Previously the sync Test pre-resolved
+// the provider base (adding Nextcloud's /remote.php/dav/files/<user> path) while
+// the auto-backup Test passed the raw url + provider straight through — so the
+// same server could pass one test and fail the other (issue #206). These helpers
+// are the single source of truth used by both.
+
+/**
+ * Resolve the WebDAV base URL for a provider. Nextcloud exposes files under
+ * /remote.php/dav/files/<username>; every other provider (Koofr, generic WebDAV,
+ * Synology, fnOS, …) uses the URL exactly as entered.
+ */
+export function resolveWebdavBase(provider, url, username) {
+  const base = (url || '').replace(/\/+$/, '')
+  if (provider === 'nextcloud' && !base.includes('/remote.php/dav')) {
+    return `${base}/remote.php/dav/files/${encodeURIComponent(username)}`
+  }
+  return base
+}
+
+/**
+ * Build the connection config the sync engine's test/save expects, with the
+ * provider-resolved WebDAV base. Mirrors exactly what CloudSyncModal's sync Test
+ * builds, so the auto-backup Test exercises the identical endpoint.
+ */
+export function buildWebdavConfig({ provider, url, username, password, folder }) {
+  return {
+    provider,
+    url,
+    username,
+    password,
+    folder,
+    enabled: true,
+    webdavUrl: resolveWebdavBase(provider, url, username),
+    nextcloudUrl: url,
+    appPassword: password,
+  }
+}

--- a/src/sync/webdav.test.js
+++ b/src/sync/webdav.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWebdavBase, buildWebdavConfig } from './webdav.js'
+
+describe('resolveWebdavBase', () => {
+  it('appends the Nextcloud dav path for the nextcloud provider (trailing slash trimmed)', () => {
+    expect(resolveWebdavBase('nextcloud', 'https://nc.example.com/', 'alice'))
+      .toBe('https://nc.example.com/remote.php/dav/files/alice')
+  })
+
+  it('does not double-append when the dav path is already present', () => {
+    const u = 'https://nc.example.com/remote.php/dav/files/alice'
+    expect(resolveWebdavBase('nextcloud', u, 'alice')).toBe(u)
+  })
+
+  it('url-encodes the username', () => {
+    expect(resolveWebdavBase('nextcloud', 'https://nc/', 'a b')).toBe('https://nc/remote.php/dav/files/a%20b')
+  })
+
+  it('uses the URL as-is for generic webdav / Synology (plain http + LAN IP untouched)', () => {
+    expect(resolveWebdavBase('webdav', 'http://192.168.1.9:5005/lifeglance/', 'u'))
+      .toBe('http://192.168.1.9:5005/lifeglance')
+  })
+
+  it('uses the URL as-is for koofr', () => {
+    expect(resolveWebdavBase('koofr', 'https://app.koofr.net/dav/Koofr', 'u')).toBe('https://app.koofr.net/dav/Koofr')
+  })
+})
+
+describe('buildWebdavConfig', () => {
+  it('carries auth + folder and sets the resolved webdavUrl (nextcloud)', () => {
+    const c = buildWebdavConfig({ provider: 'nextcloud', url: 'https://nc/', username: 'al', password: 'pw', folder: 'GLANCE/lifeglance' })
+    expect(c).toMatchObject({
+      provider: 'nextcloud',
+      url: 'https://nc/',
+      username: 'al',
+      password: 'pw',
+      folder: 'GLANCE/lifeglance',
+      enabled: true,
+      webdavUrl: 'https://nc/remote.php/dav/files/al',
+      nextcloudUrl: 'https://nc/',
+      appPassword: 'pw',
+    })
+  })
+
+  it('webdavUrl equals the raw url for a generic provider (Synology/fnOS)', () => {
+    const c = buildWebdavConfig({ provider: 'webdav', url: 'http://nas:5005/lg', username: 'u', password: 'p', folder: 'x' })
+    expect(c.webdavUrl).toBe('http://nas:5005/lg')
+  })
+})


### PR DESCRIPTION
While looking into #206, I found a real inconsistency between the two "test connection" buttons:

- **Cloud Sync** Test pre-resolved the provider WebDAV base — adding Nextcloud's `/remote.php/dav/files/<user>` and passing a `webdavUrl` — then called `engine.test`.
- **Auto-Backup** Test passed the **raw** `url` + `provider` straight to `engine.testConnection`, with no base resolution.

So the same server could **pass the sync test and fail the auto-backup test** (exactly what the #206 reporter saw). It also means a Nextcloud user's auto-backup test would hit the wrong path.

## Fix
- New `src/sync/webdav.js` — single source of truth: `resolveWebdavBase(provider, url, username)` and `buildWebdavConfig(...)`.
- `CloudSyncModal` imports `resolveWebdavBase` instead of keeping a private copy (no behavior change).
- `AutoBackupModal`'s Test now builds the **identical** config via `buildWebdavConfig` and calls the **same** `engine.test` the sync Test uses — so both tests exercise the same resolved endpoint.

## Notes
- Generic WebDAV / Synology / fnOS / Koofr URLs pass through unchanged (plain `http://` and LAN IPs untouched) — only Nextcloud gets the dav path appended.
- This is a consistency fix, **not** necessarily the root cause of #206 (that looks like a `/volume2/...` path in the reporter's config). Keeping the issue open pending their reply.

## Tests
`webdav.test.js` — Nextcloud path resolution (+ no double-append, username encoding) and pass-through for generic/Synology/Koofr. Full suite **256 pass**; ESLint clean (0 errors); `npm run build` succeeds.

Related to #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_