### PR TITLE
#192: move edit-mode recurrence block under the date, matching create…

### DIFF
--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -376,6 +376,22 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
           </div>
         )}
 
+        {/* Recurrence (edit mode) — sits under the date too, matching create mode */}
+        {isEdit && existing?.recurrence === 'annual' && (
+          <div className="sheet-field">
+            <div className="detail-recurrence-warn">
+              {applyToSeries ? t('applyToSeriesWarning') : t('repeatsAnnuallyEditWarning')}
+            </div>
+            <label className="recurrence-toggle-row" style={{ marginTop: '0.5rem' }}>
+              <span className="field-label" style={{ marginBottom: 0 }}>{t('applyToSeries')}</span>
+              <input type="checkbox" className="settings-toggle"
+                checked={applyToSeries}
+                onChange={e => setApplyToSeries(e.target.checked)} />
+            </label>
+            <p className="settings-note" style={{ marginTop: '0.35rem' }}>{t('applyToSeriesNote')}</p>
+          </div>
+        )}
+
         {/* Category */}
         <div className="sheet-field">
           <label className="field-label">{t('category')}</label>
@@ -507,21 +523,6 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
             }}
           />
         </div>
-
-        {isEdit && existing?.recurrence === 'annual' && (
-          <div className="sheet-field">
-            <div className="detail-recurrence-warn">
-              {applyToSeries ? t('applyToSeriesWarning') : t('repeatsAnnuallyEditWarning')}
-            </div>
-            <label className="recurrence-toggle-row" style={{ marginTop: '0.5rem' }}>
-              <span className="field-label" style={{ marginBottom: 0 }}>{t('applyToSeries')}</span>
-              <input type="checkbox" className="settings-toggle"
-                checked={applyToSeries}
-                onChange={e => setApplyToSeries(e.target.checked)} />
-            </label>
-            <p className="settings-note" style={{ marginTop: '0.35rem' }}>{t('applyToSeriesNote')}</p>
-          </div>
-        )}
 
         {/* Visibility (edit mode only) */}
         {isEdit && (


### PR DESCRIPTION
… mode

The create-mode "repeats annually" block was relocated under the date field, but the edit-mode counterpart (the "editing this instance" warning + "apply to all yearly instances" toggle) was left near the bottom of the sheet. Move it up under the date too so recurrence sits in the same place in both modes.


Claude-Session: https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH