### PR TITLE
Add pinch-to-zoom on touch devices for the timeline

### DIFF
--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -3,7 +3,7 @@ import React, {
   useImperativeHandle, forwardRef,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { dateToX, getTimeRangeForView, getTickMarks, assignLanes, getMsPerPx } from '../../utils/timeline'
+import { dateToX, getTimeRangeForView, getTickMarks, assignLanes, getMsPerPx, computePinchZoom } from '../../utils/timeline'
 import { relativeLabel, formatDateDisplay, ageAtDate, formatDuration } from '../../utils/dates'
 import { dbGetMedia, dbGetPhoto } from '../../data/db'
 import { isRealBlobHash, fetchThumbnailBytes, fetchFullResBytes } from '../../blobs/milestoneMedia.js'
@@ -63,7 +63,7 @@ function wrapTitle(text, maxChars) {
 }
 
 const Timeline = forwardRef(function Timeline(
-  { milestones, chapters = [], zoom, textSize = 'normal', onMilestoneClick, onChapterClick, onChapterDoubleClick, customHalfMs = 0, highlightedIds, highlightScale = 1.06, panMs, onPanMs, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
+  { milestones, chapters = [], zoom, textSize = 'normal', onMilestoneClick, onChapterClick, onChapterDoubleClick, customHalfMs = 0, highlightedIds, highlightScale = 1.06, panMs, onPanMs, onPinch, viewMode = 'all', onClusterClick, clustering = true, birthday = '', newlyAddedId = null, ultraCompact = false },
   ref
 ) {
   const { t, i18n } = useTranslation('timeline')
@@ -304,25 +304,95 @@ const Timeline = forwardRef(function Timeline(
   const endDrag = useCallback(() => { drag.current.active = false }, [])
   const touchId = useRef(null)
 
+  // ── Pinch-to-zoom ─────────────────────────────────────────────────────────
+  // Two-finger pinch drives the 'custom' zoom via onPinch(halfMs, panMs). All
+  // the zoom math is reused from computePinchZoom; here we only translate finger
+  // geometry (distance + midpoint) into its inputs. Values captured at gesture
+  // start live in pinch.current so each move computes an absolute result (no
+  // drift accumulation). startHalfMs is the effective half-span derived from the
+  // live msPerPx, so a pinch can begin from any named zoom level.
+  const pinch = useRef({ active: false, startDist: 1, startMidX: 0, startHalfMs: 0, startPan: 0 })
+
+  const touchGeometry = (touches) => {
+    const rect = wrapRef.current?.getBoundingClientRect()
+    const left = rect ? rect.left : 0
+    const [a, b] = touches
+    return {
+      dist: Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY),
+      midX: (a.clientX + b.clientX) / 2 - left,
+    }
+  }
+
+  const startPinch = (touches) => {
+    if (animRef.current) cancelAnimationFrame(animRef.current)
+    drag.current.active = false // cancel any single-finger pan in progress
+    const { dist, midX } = touchGeometry(touches)
+    pinch.current = {
+      active: true,
+      startDist: dist || 1,
+      startMidX: midX,
+      startHalfMs: (msPerPx * w) / 2,
+      startPan: panMsRef.current,
+    }
+  }
+
+  const movePinch = (touches) => {
+    if (!pinch.current.active || !onPinch) return
+    const { dist, midX } = touchGeometry(touches)
+    const { halfMs, panMs: newPan } = computePinchZoom({
+      startHalfMs: pinch.current.startHalfMs,
+      startPanMs:  pinch.current.startPan,
+      viewMode, width: w,
+      startMidX:   pinch.current.startMidX,
+      midX,
+      distRatio:   dist / pinch.current.startDist,
+    })
+    panMsRef.current = newPan
+    onPinch(halfMs, newPan)
+  }
+
   return (
     <div
       ref={wrapRef}
       className="timeline-svg-wrap"
-      style={{ flex: 1 }}
+      style={{ flex: 1, touchAction: 'none' }}
       onMouseDown={e => startDrag(e.clientX)}
       onMouseMove={e => moveDrag(e.clientX)}
       onMouseUp={endDrag}
       onMouseLeave={endDrag}
       onTouchStart={e => {
-        const t = e.touches[0]
-        touchId.current = t.identifier
-        startDrag(t.clientX)
+        if (e.touches.length >= 2) {
+          startPinch(e.touches)
+        } else {
+          const t = e.touches[0]
+          touchId.current = t.identifier
+          startDrag(t.clientX)
+        }
       }}
       onTouchMove={e => {
-        const t = [...e.touches].find(x => x.identifier === touchId.current)
-        if (t) moveDrag(t.clientX)
+        if (pinch.current.active && e.touches.length >= 2) {
+          movePinch(e.touches)
+        } else if (!pinch.current.active) {
+          const t = [...e.touches].find(x => x.identifier === touchId.current)
+          if (t) moveDrag(t.clientX)
+        }
       }}
-      onTouchEnd={endDrag}
+      onTouchEnd={e => {
+        if (pinch.current.active) {
+          if (e.touches.length < 2) {
+            pinch.current.active = false
+            // Hand off to single-finger pan if one finger remains, re-anchoring
+            // the drag origin so releasing one finger doesn't jump the view.
+            if (e.touches.length === 1) {
+              const t = e.touches[0]
+              touchId.current = t.identifier
+              startDrag(t.clientX)
+            }
+          }
+        } else {
+          endDrag()
+        }
+      }}
     >
       <svg
         width={w} height={h}

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -379,6 +379,15 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     return () => el.removeEventListener('wheel', onWheel)
   }, [])
 
+  // Pinch-to-zoom: the timeline reports an absolute half-span (ms) and pan
+  // offset per gesture frame. Drive the continuous 'custom' zoom directly (no
+  // stepped animation), the same path drill-to-chapter uses to enter custom.
+  const handlePinch = useCallback((halfMs, newPanMs) => {
+    setZoom('custom')
+    setCustomYears(halfMs / (365.25 * 24 * 3600 * 1000))
+    setPanMs(newPanMs)
+  }, [])
+
   // ── Visibility precomputation ─────────────────────────────────────────────────
   // Precompute endpoint data once per chapters change. This is O(chapters × members)
   // and avoids re-scanning chapters for every milestone on every render.
@@ -1940,6 +1949,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
             onChapterDoubleClick={openChapterEdit}
             panMs={panMs}
             onPanMs={setPanMs}
+            onPinch={handlePinch}
             viewMode={viewMode}
             onClusterClick={handleClusterClick}
             clustering={clustering}

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -43,6 +43,30 @@ export function getMsPerPx(zoom, width, customHalfMs = 0) {
   return (half * 2) / width
 }
 
+// Pinch-to-zoom bounds, expressed as half-span in ms: ~1 month visible at max
+// zoom-in, ~300 years visible at max zoom-out.
+export const PINCH_MIN_HALF_MS = 14  * 24 * 3600 * 1000
+export const PINCH_MAX_HALF_MS = 150 * 365.25 * 24 * 3600 * 1000
+
+// Given the view state captured at the start of a pinch gesture and the live
+// finger geometry, compute the new half-span and pan offset. `distRatio` is the
+// current finger distance over the distance at gesture start (>1 = fingers
+// spreading = zoom in). The timestamp under the starting midpoint is kept under
+// the current midpoint, so content follows the fingers (two-finger pan + zoom
+// combined). `nowMs` cancels out, so this is pure and unit-testable.
+export function computePinchZoom({
+  startHalfMs, startPanMs, viewMode = 'all', width,
+  startMidX, midX, distRatio,
+  minHalfMs = PINCH_MIN_HALF_MS, maxHalfMs = PINCH_MAX_HALF_MS,
+}) {
+  const fraction = VIEW_ANCHOR[viewMode] ?? 0.5
+  const half     = Math.max(minHalfMs, Math.min(maxHalfMs, startHalfMs / distRatio))
+  const kStart   = startMidX / width - fraction
+  const kCur     = midX / width - fraction
+  const panMs    = startPanMs + startHalfMs * 2 * kStart - half * 2 * kCur
+  return { halfMs: half, panMs }
+}
+
 // Pick the best tick-mark visual style for a given span
 function autoStyle(startMs, endMs) {
   const spanYears = (endMs - startMs) / (365.25 * 24 * 3600 * 1000)

--- a/src/utils/timeline.test.js
+++ b/src/utils/timeline.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyRecurFilter } from './timeline'
+import { applyRecurFilter, computePinchZoom, PINCH_MIN_HALF_MS, PINCH_MAX_HALF_MS } from './timeline'
 
 // Helper to build a minimal milestone-like object
 function ms(id, dateStr, recurrence_id = null) {
@@ -86,5 +86,60 @@ describe('applyRecurFilter', () => {
     const plain = [n1, n2]
     const result = applyRecurFilter(plain, 'all')
     expect(result).toEqual(plain)
+  })
+})
+
+describe('computePinchZoom', () => {
+  // Mirror of how the timeline maps a screen x to a timestamp, used to assert
+  // the point under the pinch midpoint stays fixed.
+  const timeUnderMid = (panMs, halfMs, midX, width, fraction = 0.5) =>
+    panMs + (halfMs * 2) * (midX / width - fraction)
+
+  // Geometry tests use a wide-open clamp so the finger math is exercised without
+  // the real min/max flooring the small synthetic spans.
+  const NOCLAMP = { minHalfMs: 0, maxHalfMs: Infinity }
+  const base = { startHalfMs: 1000, startPanMs: 0, width: 1000, startMidX: 500, midX: 500, ...NOCLAMP }
+
+  it('halves the span when fingers spread 2×; a centered pinch keeps pan', () => {
+    const r = computePinchZoom({ ...base, distRatio: 2 })
+    expect(r.halfMs).toBe(500)
+    expect(r.panMs).toBe(0)
+  })
+
+  it('doubles the span when fingers pinch to half distance', () => {
+    const r = computePinchZoom({ ...base, distRatio: 0.5 })
+    expect(r.halfMs).toBe(2000)
+  })
+
+  it('clamps zoom-in to the min half-span', () => {
+    const r = computePinchZoom({ startHalfMs: PINCH_MIN_HALF_MS, startPanMs: 0, width: 1000, startMidX: 500, midX: 500, distRatio: 1000 })
+    expect(r.halfMs).toBe(PINCH_MIN_HALF_MS)
+  })
+
+  it('clamps zoom-out to the max half-span', () => {
+    const r = computePinchZoom({ startHalfMs: PINCH_MAX_HALF_MS, startPanMs: 0, width: 1000, startMidX: 500, midX: 500, distRatio: 0.001 })
+    expect(r.halfMs).toBe(PINCH_MAX_HALF_MS)
+  })
+
+  it('keeps the timestamp under an off-center pinch midpoint fixed', () => {
+    const args = { ...base, startMidX: 750, midX: 750, distRatio: 2 }
+    const before = timeUnderMid(args.startPanMs, args.startHalfMs, args.startMidX, args.width)
+    const r = computePinchZoom(args)
+    const after = timeUnderMid(r.panMs, r.halfMs, args.midX, args.width)
+    expect(after).toBeCloseTo(before, 3)
+  })
+
+  it('pans when the two-finger midpoint translates without changing distance', () => {
+    const r = computePinchZoom({ ...base, midX: 600, distRatio: 1 })
+    expect(r.halfMs).toBe(1000)   // distance unchanged → no zoom
+    expect(r.panMs).not.toBe(0)   // midpoint moved → view pans
+  })
+
+  it('honors a non-default view anchor (past) when preserving the midpoint', () => {
+    const args = { startHalfMs: 1000, startPanMs: 12345, viewMode: 'past', width: 1000, startMidX: 300, midX: 300, distRatio: 1.5, ...NOCLAMP }
+    const before = timeUnderMid(args.startPanMs, args.startHalfMs, args.startMidX, args.width, 0.88)
+    const r = computePinchZoom(args)
+    const after = timeUnderMid(r.panMs, r.halfMs, args.midX, args.width, 0.88)
+    expect(after).toBeCloseTo(before, 3)
   })
 })


### PR DESCRIPTION
Adds two-finger pinch-to-zoom on the timeline for touch devices.

## How it works
Pinch drives the timeline's existing continuous `custom` zoom mode (the same one drill-to-chapter and the custom-years input already use), so all the span/tick math is reuse:
- Finger-distance ratio maps to the visible half-span (spread = zoom in, pinch = zoom out).
- The gesture is anchored so the timestamp under the pinch midpoint stays put, and moving the midpoint pans, so it's pan + zoom in a single gesture.
- Clamped to roughly 1 month visible (max zoom-in) up to ~300 years visible (max zoom-out).

## Changes
- **`utils/timeline.js`** — `computePinchZoom()`, a pure helper mapping finger geometry to `{ halfMs, panMs }`, plus `PINCH_MIN_HALF_MS` / `PINCH_MAX_HALF_MS` bounds.
- **`components/timeline/Timeline.jsx`** — two-touch detection folded into the existing touch handlers; single-finger pan is suppressed during a pinch and re-anchored when a finger lifts mid-gesture. Sets `touch-action: none` so the browser doesn't hijack the gesture with native page zoom.
- **`components/timeline/TimelineView.jsx`** — `handlePinch` enters `custom` zoom directly (no stepped animation), mirroring drill-to-chapter.
- **`utils/timeline.test.js`** — 7 tests for the pinch math (zoom in/out, min/max clamping, midpoint anchor-invariance, two-finger pan, and the non-default `past` view anchor).

No data-model, sync, or CSS-file changes.

## Verification
- Drove a headless Chromium session with synthetic multi-touch: single-finger pan still works (ticks shifted years), and a two-finger spread switches the timeline into custom zoom, with no runtime errors.
- Full suite: 263 tests pass (256 + 7 new); 0 ESLint errors; clean production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_