### PR TITLE
Harden language-tag handling so a POSIX locale can't blank the app

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,6 +1,7 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
+import { sanitizeLanguageTag } from './utils/locale'
 
 import common from './locales/en/common.json'
 import onboarding from './locales/en/onboarding.json'
@@ -111,6 +112,10 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
+    // A detected language can be a POSIX-style value (e.g. "en-US@posix") that
+    // is not a valid BCP-47 tag; normalize it so i18n.language is always safe to
+    // pass to Intl. Applies to every detection source, including cached values.
+    detection: { convertDetectedLanguage: sanitizeLanguageTag },
     defaultNS: 'common',
     ns: [
       'common',

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -5,12 +5,14 @@ import {
   isPast,
 } from 'date-fns'
 import i18n from '../i18n'
+import { safeLocale } from './locale'
 
 // Resolve the locale to use for Intl formatting. Callers may pass an explicit
 // BCP-47 locale; otherwise we follow the APP's selected language (not the
-// browser's), falling back to English.
+// browser's), falling back to English. safeLocale guards against a malformed
+// tag reaching Intl (which would throw and blank the render).
 function resolveLocale(locale) {
-  return locale || i18n.language || 'en'
+  return safeLocale(locale || i18n.language || 'en')
 }
 
 // Returns the age (in whole years) at a given date, or null if birthday not set

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -1,0 +1,38 @@
+// Language-tag hygiene for Intl.
+//
+// Browsers on real devices hand out clean BCP-47 tags (en-US, zh-CN, …), but
+// POSIX/headless environments and some embedded WebViews surface values like
+// "en-US@posix", "en_US.UTF-8", "C", or "POSIX". Those are NOT valid BCP-47
+// tags, and passing them to Intl.DateTimeFormat / toLocaleString throws a
+// RangeError — which, thrown during render, blanks the whole app.
+
+// Normalize a raw language string into a valid BCP-47 tag, or 'en' if nothing
+// usable remains. Strips POSIX modifier (@posix) and charset (.UTF-8) suffixes
+// and converts the POSIX '_' region separator to BCP-47 '-'.
+export function sanitizeLanguageTag(lng) {
+  if (!lng || typeof lng !== 'string') return 'en'
+  const tag = lng.split('@')[0].split('.')[0].trim().replace(/_/g, '-')
+  if (!tag || /^(c|posix)$/i.test(tag)) return 'en' // language-less POSIX locales
+  try {
+    return Intl.getCanonicalLocales(tag)[0] || 'en'
+  } catch {
+    // Structurally invalid even after cleanup — fall back to the primary subtag.
+    try {
+      return Intl.getCanonicalLocales(tag.split('-')[0])[0] || 'en'
+    } catch {
+      return 'en'
+    }
+  }
+}
+
+// Guard a locale immediately before handing it to Intl. Returns the value
+// unchanged when Intl accepts it, otherwise a sanitized tag — so a stale or
+// externally-set bad value can never crash a render.
+export function safeLocale(lng) {
+  try {
+    Intl.getCanonicalLocales(lng) // throws RangeError on an invalid tag
+    return lng
+  } catch {
+    return sanitizeLanguageTag(lng)
+  }
+}

--- a/src/utils/locale.test.js
+++ b/src/utils/locale.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeLanguageTag, safeLocale } from './locale'
+
+describe('sanitizeLanguageTag', () => {
+  it('strips a POSIX @modifier suffix', () => {
+    expect(sanitizeLanguageTag('en-US@posix')).toBe('en-US')
+  })
+
+  it('strips a charset suffix and normalizes the POSIX region separator', () => {
+    expect(sanitizeLanguageTag('en_US.UTF-8')).toBe('en-US')
+  })
+
+  it('maps the language-less C / POSIX locales to en', () => {
+    expect(sanitizeLanguageTag('C')).toBe('en')
+    expect(sanitizeLanguageTag('POSIX')).toBe('en')
+  })
+
+  it('falls back to en for empty, null, or non-string input', () => {
+    expect(sanitizeLanguageTag('')).toBe('en')
+    expect(sanitizeLanguageTag(null)).toBe('en')
+    expect(sanitizeLanguageTag(undefined)).toBe('en')
+    expect(sanitizeLanguageTag(42)).toBe('en')
+  })
+
+  it('passes valid tags through, canonicalizing case', () => {
+    expect(sanitizeLanguageTag('en')).toBe('en')
+    expect(sanitizeLanguageTag('de')).toBe('de')
+    expect(sanitizeLanguageTag('zh-CN')).toBe('zh-CN')
+    expect(sanitizeLanguageTag('zh-hk')).toBe('zh-HK')
+    expect(sanitizeLanguageTag('zh_TW')).toBe('zh-TW')
+  })
+
+  it('recovers the primary subtag when the full tag is unusable', () => {
+    expect(sanitizeLanguageTag('en@@@')).toBe('en')
+  })
+
+  it('always returns a tag Intl accepts', () => {
+    for (const raw of ['en-US@posix', 'en_US.UTF-8', 'C', 'POSIX', '', null, 'zh_TW', 'garble!!']) {
+      const out = sanitizeLanguageTag(raw)
+      expect(() => new Intl.DateTimeFormat(out)).not.toThrow()
+    }
+  })
+})
+
+describe('safeLocale', () => {
+  it('returns a valid tag unchanged', () => {
+    expect(safeLocale('en-US')).toBe('en-US')
+    expect(safeLocale('zh-CN')).toBe('zh-CN')
+  })
+
+  it('sanitizes an invalid tag rather than throwing', () => {
+    expect(safeLocale('en-US@posix')).toBe('en-US')
+    expect(safeLocale('C')).toBe('en')
+  })
+
+  it('never yields a value that makes Intl throw', () => {
+    for (const raw of ['en-US@posix', 'C', '', null, 'de_DE.UTF-8']) {
+      expect(() => new Intl.DateTimeFormat(safeLocale(raw)).format(new Date())).not.toThrow()
+    }
+  })
+})

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -1,3 +1,5 @@
+import { safeLocale } from './locale'
+
 export const ZOOM_LEVELS = ['decades', '30yr', 'years', 'months', 'weeks']
 
 // Half-range in milliseconds for each named zoom level (total range = 2×)
@@ -55,6 +57,8 @@ function autoStyle(startMs, endMs) {
 // Generate tick marks for the current view. `locale` (BCP-47) localizes the
 // short month labels; callers pass the app's selected language.
 export function getTickMarks(zoom, startMs, endMs, width, locale) {
+  // Guard against a malformed tag reaching toLocaleString below (would throw).
+  const loc = safeLocale(locale)
   // 'custom' auto-selects its visual style; '30yr' uses the same style as 'decades'
   const style = zoom === 'custom' ? autoStyle(startMs, endMs)
               : zoom === '30yr'   ? 'decades'
@@ -86,7 +90,7 @@ export function getTickMarks(zoom, startMs, endMs, width, locale) {
         const major = d.getMonth() === 0
         const label = major
           ? String(d.getFullYear())
-          : d.toLocaleString(locale, { month: 'short' })
+          : d.toLocaleString(loc, { month: 'short' })
         ticks.push({ x, label, major })
       }
       d = new Date(d.getFullYear(), d.getMonth() + 1, 1)
@@ -99,7 +103,7 @@ export function getTickMarks(zoom, startMs, endMs, width, locale) {
       if (x >= -2 && x <= width + 2) {
         const isFirst = d.getDate() <= 7
         const label = isFirst
-          ? d.toLocaleString(locale, { month: 'short', year: 'numeric' })
+          ? d.toLocaleString(loc, { month: 'short', year: 'numeric' })
           : ''
         ticks.push({ x, label, major: isFirst })
       }


### PR DESCRIPTION
## Problem
Some environments (POSIX/headless shells, certain embedded WebViews) report a language string like `en-US@posix` or `en_US.UTF-8`. These are **not** valid BCP-47 tags. `i18next-browser-languagedetector` adopts the value verbatim, and when it later reaches `new Intl.DateTimeFormat(lang, …)` / `toLocaleString(lang, …)` (timeline ticks, date formatting), Intl throws `RangeError: Invalid language tag`. Because that throw happens during render, React unwinds and the whole screen goes blank.

This was surfaced while verifying the pinch-to-zoom work in a headless container whose `LANG=en-US@posix`.

## Fix
Two layers:

1. **Root cause** — `i18n.js` now sanitizes every detected language via `detection.convertDetectedLanguage`, so `i18n.language` is always a valid tag (applies to cached/localStorage values too).
2. **Defense-in-depth** — the two `Intl` consumers (`dates.js` `resolveLocale`, `timeline.js` `getTickMarks`) route the locale through `safeLocale()`, so even a stale or externally-set bad value can't crash a render.

New `utils/locale.js`:
- `sanitizeLanguageTag(lng)` — strips `@modifier` / `.charset` suffixes, converts the POSIX `_` region separator to `-`, maps language-less `C` / `POSIX` to `en`, and canonicalizes via `Intl.getCanonicalLocales`. Returns `en` for anything unusable.
- `safeLocale(lng)` — returns the tag unchanged when Intl accepts it, otherwise a sanitized one.

Valid tags (`en`, `de`, `zh-CN`, `zh-HK`, `zh-TW`) pass through unchanged, so there is no behavior change for real devices.

## Verification
- Headless Chromium with `navigator.language` forced to `en-US@posix`: the timeline now renders (no `RangeError`); previously it blanked.
- 10 new unit tests for `sanitizeLanguageTag` / `safeLocale`, including a property that every output is a tag `Intl.DateTimeFormat` accepts.
- Full suite green apart from two pre-existing date "today" boundary flakes that also fail on `main` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_