### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.4.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.5.0-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.3.8",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.3.8",
+      "version": "2.5.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor version bump to **2.5.0**, covering the recent additive features (pinch-to-zoom, hidden-milestone access, edit-all-yearly-instances, repeatable annual data) plus the accompanying fixes.

## Changes
- `package.json`: `2.4.0` to `2.5.0`.
- `README.md`: version badge updated to `2.5.0`.
- `package-lock.json`: regenerated via `npm install`. The lockfile version had drifted to `2.3.8`; it is now realigned to `2.5.0`. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UXRbtEozGNiBAsMxhyJdH)_