### PR TITLE
Bootstrap the blob/intents key on the fresh-household first-sync

### DIFF
--- a/src/sync/blobKeyBootstrap.test.js
+++ b/src/sync/blobKeyBootstrap.test.js
@@ -1,0 +1,155 @@
+// Fresh-household blob/intents key late-bootstrap (dbSync.js).
+//
+// The DB-sync root key gets a late bootstrap inside the engine: on first
+// sync/push, ensureRootKey establishes the per-account salt and derives the DB
+// key from the session passphrase. A device that first set up on the
+// UNINITIALIZED path (fresh household, no salt yet) never ran vaultSetup's
+// SUCCESS-path setupIntentsEncryption, so WITHOUT this fix its blob/intents key
+// — which shares the same passphrase + salt foundation — would stay null
+// forever and blob encryption would fail on that device.
+//
+// These tests drive the REAL createDbSyncEngine through initDbSyncEngine over an
+// in-memory vault and assert:
+//   • fresh-household (uninitialized) setup + first-sync salt-establishment
+//     leaves a NON-NULL blob/intents key (so encryptBlob would succeed);
+//   • an already-initialized (SUCCESS-path) device is unaffected — its key is
+//     neither re-derived nor clobbered;
+//   • the bootstrap is idempotent across repeated first-syncs.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+
+// Minimal localStorage for the node test environment.
+if (typeof globalThis.localStorage === 'undefined') {
+  const m = new Map()
+  globalThis.localStorage = {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  }
+}
+
+// One shared in-memory vault. Starts with NO salt (a fresh household); the
+// engine's ensureRootKey registers one on first use via putSalt (first-write-wins).
+function makeMemVault() {
+  const rows = new Map()
+  let seq = 0
+  const salts = new Map()
+  return {
+    async batch(app, { rows: upserts }) {
+      for (const r of upserts) { seq += 1; rows.set(r.entityId, { entityId: r.entityId, envelope: r.envelope, deleted: false, seq }) }
+      return { written: upserts.length, maxSeq: seq }
+    },
+    async deleteRow(app, entityId) {
+      seq += 1; const prev = rows.get(entityId)
+      rows.set(entityId, { entityId, envelope: prev?.envelope, deleted: true, seq })
+      return { seq }
+    },
+    async list(app, { since }) {
+      const out = [...rows.values()].filter(r => r.seq > since).sort((a, b) => a.seq - b.seq)
+      return { rows: out, hasMore: false }
+    },
+    async getRow(app, entityId) { return rows.get(entityId) ?? null },
+    async device() { return { updated: true } },
+    async getSalt(accountId) { return salts.get(accountId) ?? null },
+    async putSalt(accountId, salt) { if (!salts.has(accountId)) salts.set(accountId, salt); return salts.get(accountId) },
+    _salts: salts,
+  }
+}
+
+const VAULT_CFG = { vaultEnabled: true, vaultUrl: 'http://vault.test', vaultToken: 'tok', accountId: 'acct-1' }
+
+async function freshModules() {
+  vi.resetModules()
+  global.indexedDB = new IDBFactory()
+  localStorage.clear()
+  const db = await import('../data/db.js')
+  await db.initDB()
+  const { initDbSyncEngine } = await import('./dbSync.js')
+  const { loadIntentsRootKey, setupIntentsEncryption } = await import('../lib/intentsKeyStore.js')
+  const { deriveBlobKey } = await import('../blobs/blobCrypto.js')
+  const { setSyncPassphrase, clearDbRootKey } = await import('@glance-apps/sync')
+  // @glance-apps/sync is externalized (native ESM), so vi.resetModules does NOT
+  // reset its in-memory DB root key. Clear it so each test starts as a genuine
+  // fresh device (hasDbRootKey false → ensureRootKey establishes the salt).
+  clearDbRootKey()
+  return { db, initDbSyncEngine, loadIntentsRootKey, setupIntentsEncryption, deriveBlobKey, setSyncPassphrase }
+}
+
+describe('fresh-household blob/intents key late-bootstrap', () => {
+  beforeEach(() => { localStorage.clear() })
+
+  it('uninitialized setup + first sync → non-null blob/intents key (encryptBlob would succeed)', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    // Fresh household: passphrase is set (as vaultSetup does on the UNINITIALIZED
+    // path) but NO salt exists yet and NO key has been derived — the SUCCESS-path
+    // setupIntentsEncryption never ran.
+    m.setSyncPassphrase('pw')
+    expect(await m.loadIntentsRootKey()).toBeNull()   // no blob/intents key yet
+    expect(vault._salts.size).toBe(0)                 // no salt established yet
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await dbSync.sync()   // ensureRootKey establishes the salt + DB key; bootstrap derives the blob/intents key
+
+    // The salt is now established AND the blob/intents key exists…
+    expect(vault._salts.has('acct-1')).toBe(true)
+    const rootKey = await m.loadIntentsRootKey()
+    expect(rootKey).not.toBeNull()
+    // …so the blob key derives — encryptBlob would succeed on this device.
+    expect(await m.deriveBlobKey()).not.toBeNull()
+  })
+
+  it('already-initialized (SUCCESS-path) device: key present, not re-derived or clobbered', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    // Emulate the SUCCESS path having already derived the blob/intents key
+    // (against the vault-fetched salt) before the engine ever syncs.
+    await m.setupIntentsEncryption('pw', new Uint8Array(16).fill(9))
+    const keyBefore = await m.loadIntentsRootKey()
+    expect(keyBefore).not.toBeNull()
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await dbSync.sync()
+
+    // The pre-existing key is preserved verbatim — idempotent no-op, no clobber.
+    expect(await m.loadIntentsRootKey()).toBe(keyBefore)
+  })
+
+  it('idempotent across repeated first-syncs (never re-derives once established)', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await dbSync.sync()
+    const key1 = await m.loadIntentsRootKey()
+    expect(key1).not.toBeNull()
+
+    await dbSync.sync()   // repeated sync must NOT re-derive/clobber
+    const key2 = await m.loadIntentsRootKey()
+    expect(key2).toBe(key1)
+  })
+
+  it('push-on-write also bootstraps the key when it establishes the salt first', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    // A real push-on-write carries a dirty row — pushDirtyRows early-returns
+    // (before ensureRootKey) when nothing is dirty, so seed a local write.
+    const milestones = await import('../data/milestones.js')
+    await milestones.addMilestone({ title: 'Backgrounded write', date: new Date('2020-01-01') })
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await dbSync.pushNow()   // push-on-write path also runs ensureRootKey → establishes salt
+
+    expect(vault._salts.has('acct-1')).toBe(true)
+    expect(await m.loadIntentsRootKey()).not.toBeNull()
+  })
+})

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -14,12 +14,13 @@
 // React); the refresh reloads React state so the UI reflects merged rows. That
 // is a state bridge, not a cursor bridge.
 
-import { createDbSyncEngine } from '@glance-apps/sync'
+import { createDbSyncEngine, getSyncPassphrase } from '@glance-apps/sync'
 import { makeDbAdapter } from './dbAdapter.js'
 import { makeRealStore } from './dbStore.js'
 import { registerDirtyTarget } from './dirty.js'
 import { dbGetAll, dbGetAllChapters } from '../data/db.js'
 import { loadCategories } from '../utils/colors.js'
+import { loadIntentsRootKey, setupIntentsEncryption } from '../lib/intentsKeyStore.js'
 
 const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
 const DEVICE_ID_KEY  = 'lifeglance-db-sync-device-id'
@@ -130,6 +131,37 @@ export const initDbSyncEngine = (opts = {}) => {
     localStorage.setItem(SEEDED_KEY, '1')
   }
 
+  // Blob/intents key late-bootstrap — the missing twin of the DB key's bootstrap.
+  //
+  // The DB-sync root key gets a late bootstrap inside the engine: on first
+  // sync/push, ensureRootKey establishes the per-account salt (getSalt, or
+  // register a fresh one via putSalt) and derives the DB key from the session
+  // passphrase + that salt. A device that first set up on the UNINITIALIZED
+  // path (fresh household, no salt yet) never ran vaultSetup's SUCCESS-path
+  // derivation, so its blob/intents key — which shares the same passphrase +
+  // salt foundation — would otherwise stay null forever, and blob encryption
+  // (and, once wired, intents) would fail on that device.
+  //
+  // This gives the blob/intents key the SAME late bootstrap at the SAME moment:
+  // once the engine cycle has established the salt, derive it against the REAL
+  // vault salt (never an invented one) using the same session passphrase the DB
+  // key derivation used. Idempotent — a no-op once the key exists (the SUCCESS
+  // path already ran, or a previous first-sync already bootstrapped it), so it
+  // never re-derives or clobbers. Non-fatal: a failure here (e.g. a transient
+  // getSalt) is retried on the next cycle and never breaks a succeeded sync.
+  const bootstrapIntentsRootKey = async () => {
+    try {
+      if (await loadIntentsRootKey()) return          // already set up — no-op
+      const passphrase = getSyncPassphrase()
+      if (!passphrase) return                          // no passphrase → cannot derive (DB key couldn't either)
+      const salt = await engine.vault.getSalt(vaultConfig.accountId)
+      if (!salt || !salt.length) return                // salt not established yet — try again next cycle
+      await setupIntentsEncryption(passphrase, salt)   // derive against the REAL established salt
+    } catch (err) {
+      console.warn('[dbsync] blob/intents key bootstrap deferred', err)
+    }
+  }
+
   // Post-cycle React refresh (the state bridge described above).
   const refresh = async () => {
     const [ms, ch] = await Promise.all([dbGetAll(), dbGetAllChapters()])
@@ -150,15 +182,21 @@ export const initDbSyncEngine = (opts = {}) => {
   const sync = async () => {
     await seedSnapshot()
     const r = await engine.sync()
+    await bootstrapIntentsRootKey()   // salt is now established — give the blob/intents key its late bootstrap
     await refresh()
     return r
   }
 
   // Vault-only push (no pull), used by the debounced push-on-write so a local
-  // edit reaches the vault promptly even on a backgrounded device.
+  // edit reaches the vault promptly even on a backgrounded device. This also
+  // runs ensureRootKey (salt establishment), so bootstrap the blob/intents key
+  // here too — a backgrounded first write can establish the salt before any
+  // full sync does.
   const pushNow = async () => {
     await seedSnapshot()
-    return engine.pushDirtyRows()
+    const r = await engine.pushDirtyRows()
+    await bootstrapIntentsRootKey()
+    return r
   }
   const pushDebounced = (ms = 4000) => {
     clearTimeout(_pushTimer)


### PR DESCRIPTION
## Problem

A device that first set up vault sync on the **UNINITIALIZED** path (a fresh household with no salt yet) skipped `vaultSetup`'s SUCCESS-path `setupIntentsEncryption`, so its blob/intents root key stayed **null forever** — even after the salt was later established on first sync.

The DB-sync key *does* get a late bootstrap: inside `@glance-apps/sync`, `ensureRootKey` establishes the per-account salt on first sync/push (`getSalt`, or register a fresh one via `putSalt`) and derives the DB key from the session passphrase + that salt. But nothing gave the **blob/intents key** — which shares the same passphrase + salt foundation — the same treatment. Result: on such a device sync worked, but blob encryption (and, once wired, intents) would fail with `BlobKeyUnavailableError`.

The two existing `setupIntentsEncryption` call sites both miss this transition:
- `vaultSetup.js` — SUCCESS path only, explicitly skipped on UNINITIALIZED (no salt to derive against, and we never invent one).
- `intentsTransport.js` (`enableIntentsEncryption`) — a separate, manual WebDAV-integration action with its own salt.

The media-backfill pre-flight `deriveBlobKey()` guard only papered over the symptom.

## Fix

Give the blob/intents key the **same late bootstrap at the same moment**. A new `bootstrapIntentsRootKey` helper in `src/sync/dbSync.js` runs right after the engine cycle (in both `sync` and `pushNow`, since either can be the first to establish the salt) and:

- **Idempotent** — no-op once the key exists, so the SUCCESS path and repeated first-syncs never re-derive or clobber.
- **Real salt only** — derives against `engine.vault.getSalt(accountId)` (the salt the engine just established/registered), never an invented one — same discipline as the SUCCESS path.
- **Reuses the passphrase** — `getSyncPassphrase()`, the same one the DB key derivation used; skips cleanly (no invented workaround) if it is somehow absent.
- **Non-fatal** — a transient failure (e.g. a `getSalt` blip) is logged and retried on the next cycle; a succeeded sync is never broken.

This fixes both blobs **and** intents on fresh-household devices (shared key store). The backfill guard is deliberately left in place as a belt-and-suspenders check — it should now rarely/never trigger. The SUCCESS-path derivation, the DB-key bootstrap, merge logic, and `@glance-apps/*` are untouched.

## Tests

New `src/sync/blobKeyBootstrap.test.js` drives the real `createDbSyncEngine` through `initDbSyncEngine` over an in-memory vault:

- fresh-household (uninitialized) setup + first-sync salt-establishment → **non-null** blob/intents key, and `deriveBlobKey()` succeeds (so `encryptBlob` would work);
- an already-initialized (SUCCESS-path) device is unaffected — key preserved by reference, not re-derived or clobbered;
- idempotent across repeated first-syncs;
- the push-on-write path bootstraps too when it establishes the salt first.

Full suite passes (275 pass; the 2 `src/utils/dates.test.js` failures are pre-existing and unrelated — a container locale/ICU issue, verified by stashing). Production build passes; lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8sbnd4UM8GGgJJ2czNsH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8sbnd4UM8GGgJJ2czNsH6)_