### PR TITLE
Give the vault intents/blob key its own key slot (fix shared-slot collision)

### DIFF
--- a/src/blobs/blobCrypto.js
+++ b/src/blobs/blobCrypto.js
@@ -68,7 +68,7 @@
 // -----------------------------------------------------------------------------
 // KEY DERIVATION — on the record, domain-separated (quote for §deriveBlobKey)
 // -----------------------------------------------------------------------------
-//   Root key source: loadIntentsRootKey() — the same per-account vault root key
+//   Root key source: loadVaultIntentsRootKey() — the same per-account vault root key
 //     the sync/intents path uses (PBKDF2(syncPassphrase, /salt/:accountId) →
 //     HKDF base CryptoKey, non-extractable, usages ["deriveKey"]). We reach it
 //     through that existing cached/IDB-backed store; we never re-derive it here.
@@ -82,7 +82,7 @@
 //
 // =============================================================================
 
-import { loadIntentsRootKey } from '../lib/intentsKeyStore.js'
+import { loadVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
 
 /** AES-GCM nonce length, in bytes. The stored blob is [nonce || ciphertext]. */
 export const NONCE_LENGTH = 12
@@ -122,7 +122,7 @@ function toBytes(data) {
  *                    Injectable so this module stays decoupled and testable.
  * @returns the BlobKey ({ aesKey, hmacKey }), or `null` if the root key is not available.
  */
-export async function deriveBlobKey(getRootKey = loadIntentsRootKey) {
+export async function deriveBlobKey(getRootKey = loadVaultIntentsRootKey) {
   const rootKey = await getRootKey()
   if (!rootKey) return null
 
@@ -168,7 +168,7 @@ async function sha256Hex(bytes) {
  * @throws  {BlobKeyUnavailableError} if the root key is unavailable. NEVER falls
  *          back to plaintext.
  */
-export async function encryptBlob(plaintext, getRootKey = loadIntentsRootKey) {
+export async function encryptBlob(plaintext, getRootKey = loadVaultIntentsRootKey) {
   const blobKey = await deriveBlobKey(getRootKey)
   if (!blobKey) throw new BlobKeyUnavailableError()
 
@@ -203,7 +203,7 @@ export async function encryptBlob(plaintext, getRootKey = loadIntentsRootKey) {
  * @throws  if the blob has been tampered with (AES-GCM tag verification fails)
  *          or is malformed.
  */
-export async function decryptBlob(stored, getRootKey = loadIntentsRootKey) {
+export async function decryptBlob(stored, getRootKey = loadVaultIntentsRootKey) {
   const blobKey = await deriveBlobKey(getRootKey)
   if (!blobKey) throw new BlobKeyUnavailableError()
 

--- a/src/lib/intentsKeyStore.js
+++ b/src/lib/intentsKeyStore.js
@@ -1,13 +1,32 @@
-// IndexedDB-backed store for the lifeGLANCE intents root key.
-// Mirrors dayGLANCE's intentsKeyStore — separate from cloud sync's crypto DB.
+// IndexedDB-backed store for lifeGLANCE's intents/blob root keys.
+//
+// TWO DISTINCT KEY SLOTS live in one IDB store, and they must NEVER be confused —
+// they hold different key material derived from different salts:
+//
+//   • 'intents-root-key'  — the WebDAV FILE-TIER intents key, derived from the
+//     WebDAV shared salt (intents-encryption-salt.json). Written by
+//     enableIntentsEncryption(); read by the WebDAV intents deliverer/poller.
+//
+//   • 'vault-root-key'    — the GLANCEvault intents + BLOB key, derived from the
+//     server-owned vault salt (/salt/:accountId). Written by the vault setup /
+//     first-sync bootstrap; read by the vault intents transport and blobCrypto.
+//
+// They were ONE slot originally, which collided: a device with WebDAV-intents
+// encryption on AND vault sync on wrote both a WebDAV-salt key and a vault-salt
+// key into the same record (last-writer-wins), breaking blob and/or vault-intents
+// decryption. Separating the slots makes that collision structurally impossible.
+// Mirrors dayGLANCE's model (vault-root-key vs root-key); see the reference doc §4.2.
 
 import { deriveIntentsRootKey, deriveEnvelopeKey } from '@glance-apps/intents'
 
-const DB_NAME    = 'lifeglance-intents-crypto'
-const STORE_NAME = 'keys'
-const KEY_ID     = 'intents-root-key'
+const DB_NAME       = 'lifeglance-intents-crypto'
+const STORE_NAME    = 'keys'
+const KEY_ID        = 'intents-root-key'   // WebDAV file-tier intents key (WebDAV salt)
+const VAULT_KEY_ID  = 'vault-root-key'     // vault intents + blob key (vault salt)
+const INTENTS_CONFIG_KEY = 'lifeglance-intents-config'
 
-let _rootKey = null   // module-level cache; survives re-renders, not page reload
+let _rootKey      = null   // WebDAV-slot cache; survives re-renders, not page reload
+let _vaultRootKey = null   // vault-slot cache; distinct from the WebDAV slot
 
 function openDB() {
   return new Promise((resolve, reject) => {
@@ -18,42 +37,96 @@ function openDB() {
   })
 }
 
-async function loadFromIDB() {
+// Load one record (by its slot id) from the store.
+async function loadFromIDB(recordKey) {
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx  = db.transaction(STORE_NAME, 'readonly')
-    const req = tx.objectStore(STORE_NAME).get(KEY_ID)
+    const req = tx.objectStore(STORE_NAME).get(recordKey)
     req.onsuccess = e => resolve(e.target.result ?? null)
     req.onerror   = e => reject(e.target.error)
   })
 }
 
-async function saveToIDB(key) {
+// Persist one record (by its slot id) into the store.
+async function saveToIDB(key, recordKey) {
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx  = db.transaction(STORE_NAME, 'readwrite')
-    const req = tx.objectStore(STORE_NAME).put(key, KEY_ID)
+    const req = tx.objectStore(STORE_NAME).put(key, recordKey)
     req.onsuccess = () => resolve()
     req.onerror   = e => reject(e.target.error)
   })
 }
 
-// Returns the cached root key, or loads it from IDB on first call.
+// ── WebDAV file-tier intents key ('intents-root-key') ─────────────────────────
+
+// Returns the cached WebDAV intents root key, or loads it from IDB on first call.
 export async function loadIntentsRootKey() {
   if (_rootKey) return _rootKey
-  _rootKey = await loadFromIDB()
+  _rootKey = await loadFromIDB(KEY_ID)
   return _rootKey
 }
 
-// Derives and persists the root key from the passphrase + shared salt bytes.
+// Derives and persists the WebDAV intents root key from the passphrase + the
+// WebDAV shared salt bytes. (WebDAV path — unchanged; do not point vault callers here.)
 export async function setupIntentsEncryption(passphrase, sharedRootSalt) {
   const key = await deriveIntentsRootKey(passphrase, sharedRootSalt)
-  await saveToIDB(key)
+  await saveToIDB(key, KEY_ID)
   _rootKey = key
   return key
 }
 
-// Returns a deriveKey function bound to the current root key, or null if no key.
+// ── GLANCEvault intents + blob key ('vault-root-key') ─────────────────────────
+
+// Did this device ever turn on WebDAV-intents encryption? Read directly from
+// localStorage to avoid importing intentsTransport (which imports this module).
+function webdavIntentsEncryptionEnabled() {
+  try {
+    const raw = localStorage.getItem(INTENTS_CONFIG_KEY)
+    return !!(raw && JSON.parse(raw)?.encryptionEnabled)
+  } catch {
+    return false
+  }
+}
+
+// One-time migration for devices upgraded from the shared-slot era. Before the
+// split, a vault-only device (WebDAV-intents encryption never enabled) stored its
+// VAULT key in 'intents-root-key'. Adopt that key into the new vault slot so blob
+// and vault-intents access is NOT lost on upgrade — no passphrase needed, we just
+// re-home the existing CryptoKey. Guarded: only when WebDAV-intents encryption was
+// never enabled (else 'intents-root-key' may hold the WebDAV key, which must NOT
+// become the vault key — that device re-derives the vault key on next sync).
+async function migrateVaultKeyFromSharedSlot() {
+  if (webdavIntentsEncryptionEnabled()) return null // shared slot may be the WebDAV key — don't adopt
+  const legacy = await loadFromIDB(KEY_ID)
+  if (!legacy) return null
+  await saveToIDB(legacy, VAULT_KEY_ID) // re-home the vault key into its own slot
+  return legacy
+}
+
+// Returns the cached vault intents/blob root key, loading it from the vault slot
+// on first call. If the vault slot is empty, attempt the one-time migration from
+// the legacy shared slot (see above) so upgraded vault-only devices keep access.
+export async function loadVaultIntentsRootKey() {
+  if (_vaultRootKey) return _vaultRootKey
+  _vaultRootKey = await loadFromIDB(VAULT_KEY_ID)
+  if (!_vaultRootKey) _vaultRootKey = await migrateVaultKeyFromSharedSlot()
+  return _vaultRootKey
+}
+
+// Derives and persists the VAULT intents/blob root key from the passphrase + the
+// server-owned vault salt. Writes ONLY the vault slot — never touches the WebDAV slot.
+export async function setupVaultIntentsRootKey(passphrase, vaultSalt) {
+  const key = await deriveIntentsRootKey(passphrase, vaultSalt)
+  await saveToIDB(key, VAULT_KEY_ID)
+  _vaultRootKey = key
+  return key
+}
+
+// ── Shared helper ─────────────────────────────────────────────────────────────
+
+// Returns a deriveKey function bound to the given root key, or null if no key.
 export function makeDeriveFn(rootKey) {
   if (!rootKey) return null
   return (salt) => deriveEnvelopeKey(rootKey, salt)

--- a/src/lib/intentsKeyStore.test.js
+++ b/src/lib/intentsKeyStore.test.js
@@ -1,0 +1,156 @@
+// Key-slot separation: the WebDAV file-tier intents key ('intents-root-key') and
+// the GLANCEvault intents+blob key ('vault-root-key') live in DISTINCT records so
+// they can never collide, plus the one-time migration that re-homes a legacy
+// shared-slot vault key on upgrade. Runs against fake-indexeddb (real IDB paths).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+import { buildEncryptedEnvelope, parseEncryptedEnvelope, SOURCE_APPS, ACTIONS } from '@glance-apps/intents'
+
+if (typeof globalThis.localStorage === 'undefined') {
+  const m = new Map()
+  globalThis.localStorage = {
+    getItem: k => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: k => m.delete(k),
+    clear: () => m.clear(),
+  }
+}
+
+const INTENTS_CONFIG_KEY = 'lifeglance-intents-config'
+const WEBDAV_SALT = new Uint8Array(32).fill(3)
+const VAULT_SALT  = new Uint8Array(16).fill(9)
+
+// Fresh IDB + fresh module (module-level key caches reset) per test.
+async function fresh() {
+  vi.resetModules()
+  global.indexedDB = new IDBFactory()
+  localStorage.clear()
+  const ks = await import('./intentsKeyStore.js')
+  const blob = await import('../blobs/blobCrypto.js')
+  return { ...ks, deriveBlobKey: blob.deriveBlobKey }
+}
+
+const setWebdavIntentsEncryptionOn = () =>
+  localStorage.setItem(INTENTS_CONFIG_KEY, JSON.stringify({ enabled: true, webdavUrl: 'https://d', encryptionEnabled: true }))
+
+// A NOTIFY envelope built under `deriveFn`, for round-trip / cross-decrypt checks.
+async function encEnvelope(deriveFn) {
+  return buildEncryptedEnvelope(
+    { action: ACTIONS.NOTIFY, emittedBy: SOURCE_APPS.LIFEGLANCE, eventId: '20260101T000000Z-aaaaaa',
+      payload: { event_id: '20260101T000000Z-aaaaaa', source_app: SOURCE_APPS.LIFEGLANCE, source_entity_id: 'm1',
+        entity_type: 'goal', event: 'completed', task_id: 'm1', title: 'T', timestamp: '2026-01-01T00:00:00.000Z' } },
+    deriveFn,
+  )
+}
+
+describe('key-slot separation', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('WebDAV and vault keys occupy DISTINCT slots — neither clobbers the other', async () => {
+    const ks = await fresh()
+    // Both encryption tiers on, on the same device (the old collision scenario).
+    setWebdavIntentsEncryptionOn()
+    const webdavKey = await ks.setupIntentsEncryption('pw', WEBDAV_SALT)   // → intents-root-key
+    const vaultKey  = await ks.setupVaultIntentsRootKey('pw', VAULT_SALT)  // → vault-root-key
+
+    // Each slot returns ITS OWN key, unaffected by the other write.
+    expect(await ks.loadIntentsRootKey()).toBe(webdavKey)
+    expect(await ks.loadVaultIntentsRootKey()).toBe(vaultKey)
+    expect(webdavKey).not.toBe(vaultKey)
+
+    // Both keys are usable AND genuinely different material: a vault-key envelope
+    // round-trips under the vault key but the WebDAV key cannot decrypt it.
+    const env = await encEnvelope(ks.makeDeriveFn(vaultKey))
+    const dec = await parseEncryptedEnvelope(env, ks.makeDeriveFn(vaultKey))
+    expect(dec.payload.event).toBe('completed')
+    await expect(parseEncryptedEnvelope(env, ks.makeDeriveFn(webdavKey))).rejects.toThrow()
+  })
+
+  it('setting up the WebDAV key does NOT populate the vault slot', async () => {
+    const ks = await fresh()
+    setWebdavIntentsEncryptionOn()
+    await ks.setupIntentsEncryption('pw', WEBDAV_SALT)
+    // Vault slot stays empty — migration must NOT adopt the WebDAV key (see below).
+    expect(await ks.loadVaultIntentsRootKey()).toBeNull()
+  })
+})
+
+describe('bootstrap guard checks the vault slot', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('a present WebDAV key does NOT satisfy the vault-key guard (would derive)', async () => {
+    const ks = await fresh()
+    setWebdavIntentsEncryptionOn()
+    await ks.setupIntentsEncryption('pw', WEBDAV_SALT) // WebDAV key present, vault slot empty
+    // The bootstrap guard is `if (await loadVaultIntentsRootKey()) return`.
+    // With WebDAV-intents encryption on, migration is skipped → vault slot null →
+    // the guard is falsy → the bootstrap proceeds to derive the vault key.
+    expect(await ks.loadVaultIntentsRootKey()).toBeNull()
+  })
+})
+
+describe('vault/blob readers read the vault slot', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('deriveBlobKey uses the vault slot (not the WebDAV slot)', async () => {
+    const ks = await fresh()
+    // Only the WebDAV key exists (encryption on) — the blob key must NOT derive
+    // from it; the blob reader looks at the vault slot, which is empty.
+    setWebdavIntentsEncryptionOn()
+    await ks.setupIntentsEncryption('pw', WEBDAV_SALT)
+    expect(await ks.deriveBlobKey()).toBeNull()
+
+    // Once the vault key exists, the blob key derives.
+    await ks.setupVaultIntentsRootKey('pw', VAULT_SALT)
+    expect(await ks.deriveBlobKey()).not.toBeNull()
+  })
+})
+
+describe('migration for existing (shared-slot) devices', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('re-homes a legacy vault key from the shared slot when WebDAV-intents encryption was never enabled', async () => {
+    const ks = await fresh()
+    // Legacy vault-only device: the OLD code wrote the VAULT-salt key into the
+    // shared 'intents-root-key' slot, and WebDAV-intents encryption was never on.
+    const legacy = await ks.setupIntentsEncryption('pw', VAULT_SALT) // simulates the legacy shared-slot write
+    // (no encryptionEnabled flag → vault-only user)
+
+    // First read of the vault slot migrates the key in — no passphrase needed.
+    const migrated = await ks.loadVaultIntentsRootKey()
+    expect(migrated).not.toBeNull()
+    // Same KEY MATERIAL as the legacy key (IDB structured-clones the CryptoKey on
+    // read, so assert functional identity, not reference): a legacy-key envelope
+    // decrypts under the migrated key.
+    const env = await encEnvelope(ks.makeDeriveFn(legacy))
+    const dec = await parseEncryptedEnvelope(env, ks.makeDeriveFn(migrated))
+    expect(dec.payload.event).toBe('completed')
+    // Blob access is preserved on upgrade.
+    expect(await ks.deriveBlobKey()).not.toBeNull()
+  })
+
+  it('does NOT adopt the shared slot when WebDAV-intents encryption is on (may be the WebDAV key)', async () => {
+    const ks = await fresh()
+    setWebdavIntentsEncryptionOn()
+    await ks.setupIntentsEncryption('pw', WEBDAV_SALT) // could be the WebDAV key — unsafe to adopt
+    expect(await ks.loadVaultIntentsRootKey()).toBeNull()
+    expect(await ks.deriveBlobKey()).toBeNull()         // no vault key adopted
+  })
+
+  it('migrated key persists across a fresh module load (survives reload, no passphrase)', async () => {
+    const first = await fresh()
+    const legacy = await first.setupIntentsEncryption('pw', VAULT_SALT)
+    await first.loadVaultIntentsRootKey() // triggers migration → writes vault-root-key
+
+    // Simulate a page reload: reset module caches but keep the SAME IndexedDB.
+    vi.resetModules()
+    const reloaded = await import('./intentsKeyStore.js')
+    const afterReload = await reloaded.loadVaultIntentsRootKey()
+    expect(afterReload).not.toBeNull()                  // read straight from the vault slot
+    // Same underlying material as the legacy key: a legacy-key envelope decrypts.
+    const env = await encEnvelope(first.makeDeriveFn(legacy))
+    const dec = await parseEncryptedEnvelope(env, reloaded.makeDeriveFn(afterReload))
+    expect(dec.payload.event).toBe('completed')
+  })
+})

--- a/src/lib/intentsVaultTransport.js
+++ b/src/lib/intentsVaultTransport.js
@@ -12,9 +12,9 @@
 //      and a uniform bounded-retry model.
 //
 // CROSS-APP CRYPTO CONTRACT: the vault intents key is the SAME per-account root
-// key the blob store uses — loadIntentsRootKey(), derived
-// deriveIntentsRootKey(syncPassphrase, /salt/:accountId) and now reliably
-// bootstrapped on every setup path (dbSync.js). Two GLANCE apps that feed the
+// key the blob store uses — loadVaultIntentsRootKey() (the dedicated 'vault-root-key'
+// slot), derived deriveIntentsRootKey(syncPassphrase, /salt/:accountId) and now
+// reliably bootstrapped on every setup path (dbSync.js). Two GLANCE apps that feed the
 // same passphrase + the same server-owned vault salt derive the byte-identical
 // key and decrypt each other's envelopes. NEVER plaintext on the vault, send or
 // receive. See docs/glance-intents-transport-reference.md §3–§5.
@@ -30,7 +30,7 @@ import {
   NoKeyError,
   SOURCE_APPS,
 } from '@glance-apps/intents'
-import { loadIntentsRootKey, makeDeriveFn } from './intentsKeyStore.js'
+import { loadVaultIntentsRootKey, makeDeriveFn } from './intentsKeyStore.js'
 import { nativeVaultFetchImpl } from '../sync/nativeVaultFetch.js'
 
 const SYNC_CONFIG_KEY = 'lifeglance-cloud-sync-config'
@@ -133,7 +133,7 @@ export async function deliverToVault(intent, deps = {}) {
   const conn = deps.connection ?? readVaultIntentsConnection()
   if (!conn) return 'transient'
 
-  const getRootKey = deps.getRootKey ?? loadIntentsRootKey
+  const getRootKey = deps.getRootKey ?? loadVaultIntentsRootKey
   const rootKey = await getRootKey()
   if (!rootKey) return 'transient' // key not ready — hold/retry, never plaintext
 
@@ -244,7 +244,7 @@ export async function drainVaultIntents(onEnvelope, deps = {}) {
   if (!conn) return // vault not enabled — nothing to drain (WebDAV path is separate)
 
   const doFetch    = resolveFetch(deps)
-  const getRootKey = deps.getRootKey ?? loadIntentsRootKey
+  const getRootKey = deps.getRootKey ?? loadVaultIntentsRootKey
   const limit      = deps.limit ?? PAGE_SIZE
   const store      = deps.cursorStore ?? makeLocalStorageCursorStore()
 

--- a/src/sync/blobKeyBootstrap.test.js
+++ b/src/sync/blobKeyBootstrap.test.js
@@ -67,14 +67,14 @@ async function freshModules() {
   const db = await import('../data/db.js')
   await db.initDB()
   const { initDbSyncEngine } = await import('./dbSync.js')
-  const { loadIntentsRootKey, setupIntentsEncryption } = await import('../lib/intentsKeyStore.js')
+  const { loadVaultIntentsRootKey, setupVaultIntentsRootKey } = await import('../lib/intentsKeyStore.js')
   const { deriveBlobKey } = await import('../blobs/blobCrypto.js')
   const { setSyncPassphrase, clearDbRootKey } = await import('@glance-apps/sync')
   // @glance-apps/sync is externalized (native ESM), so vi.resetModules does NOT
   // reset its in-memory DB root key. Clear it so each test starts as a genuine
   // fresh device (hasDbRootKey false → ensureRootKey establishes the salt).
   clearDbRootKey()
-  return { db, initDbSyncEngine, loadIntentsRootKey, setupIntentsEncryption, deriveBlobKey, setSyncPassphrase }
+  return { db, initDbSyncEngine, loadVaultIntentsRootKey, setupVaultIntentsRootKey, deriveBlobKey, setSyncPassphrase }
 }
 
 describe('fresh-household blob/intents key late-bootstrap', () => {
@@ -86,9 +86,9 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
     const vault = makeMemVault()
     // Fresh household: passphrase is set (as vaultSetup does on the UNINITIALIZED
     // path) but NO salt exists yet and NO key has been derived — the SUCCESS-path
-    // setupIntentsEncryption never ran.
+    // setupVaultIntentsRootKey never ran.
     m.setSyncPassphrase('pw')
-    expect(await m.loadIntentsRootKey()).toBeNull()   // no blob/intents key yet
+    expect(await m.loadVaultIntentsRootKey()).toBeNull()   // no blob/intents key yet
     expect(vault._salts.size).toBe(0)                 // no salt established yet
 
     const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
@@ -96,7 +96,7 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
 
     // The salt is now established AND the blob/intents key exists…
     expect(vault._salts.has('acct-1')).toBe(true)
-    const rootKey = await m.loadIntentsRootKey()
+    const rootKey = await m.loadVaultIntentsRootKey()
     expect(rootKey).not.toBeNull()
     // …so the blob key derives — encryptBlob would succeed on this device.
     expect(await m.deriveBlobKey()).not.toBeNull()
@@ -109,15 +109,15 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
     m.setSyncPassphrase('pw')
     // Emulate the SUCCESS path having already derived the blob/intents key
     // (against the vault-fetched salt) before the engine ever syncs.
-    await m.setupIntentsEncryption('pw', new Uint8Array(16).fill(9))
-    const keyBefore = await m.loadIntentsRootKey()
+    await m.setupVaultIntentsRootKey('pw', new Uint8Array(16).fill(9))
+    const keyBefore = await m.loadVaultIntentsRootKey()
     expect(keyBefore).not.toBeNull()
 
     const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
     await dbSync.sync()
 
     // The pre-existing key is preserved verbatim — idempotent no-op, no clobber.
-    expect(await m.loadIntentsRootKey()).toBe(keyBefore)
+    expect(await m.loadVaultIntentsRootKey()).toBe(keyBefore)
   })
 
   it('idempotent across repeated first-syncs (never re-derives once established)', async () => {
@@ -128,11 +128,11 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
 
     const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
     await dbSync.sync()
-    const key1 = await m.loadIntentsRootKey()
+    const key1 = await m.loadVaultIntentsRootKey()
     expect(key1).not.toBeNull()
 
     await dbSync.sync()   // repeated sync must NOT re-derive/clobber
-    const key2 = await m.loadIntentsRootKey()
+    const key2 = await m.loadVaultIntentsRootKey()
     expect(key2).toBe(key1)
   })
 
@@ -150,6 +150,6 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
     await dbSync.pushNow()   // push-on-write path also runs ensureRootKey → establishes salt
 
     expect(vault._salts.has('acct-1')).toBe(true)
-    expect(await m.loadIntentsRootKey()).not.toBeNull()
+    expect(await m.loadVaultIntentsRootKey()).not.toBeNull()
   })
 })

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -20,7 +20,7 @@ import { makeRealStore } from './dbStore.js'
 import { registerDirtyTarget } from './dirty.js'
 import { dbGetAll, dbGetAllChapters } from '../data/db.js'
 import { loadCategories } from '../utils/colors.js'
-import { loadIntentsRootKey, setupIntentsEncryption } from '../lib/intentsKeyStore.js'
+import { loadVaultIntentsRootKey, setupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
 import { flushOutbox } from '../lib/intentsTransport.js'
 
 const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
@@ -152,12 +152,15 @@ export const initDbSyncEngine = (opts = {}) => {
   // getSalt) is retried on the next cycle and never breaks a succeeded sync.
   const bootstrapIntentsRootKey = async () => {
     try {
-      if (await loadIntentsRootKey()) return          // already set up — no-op
+      // Guard on the VAULT slot (not the WebDAV slot): a present WebDAV-intents key
+      // must NOT make us skip deriving the vault key. loadVaultIntentsRootKey also
+      // runs the one-time migration that re-homes a legacy shared-slot vault key.
+      if (await loadVaultIntentsRootKey()) return       // vault key already present — no-op
       const passphrase = getSyncPassphrase()
-      if (!passphrase) return                          // no passphrase → cannot derive (DB key couldn't either)
+      if (!passphrase) return                           // no passphrase → cannot derive (DB key couldn't either)
       const salt = await engine.vault.getSalt(vaultConfig.accountId)
-      if (!salt || !salt.length) return                // salt not established yet — try again next cycle
-      await setupIntentsEncryption(passphrase, salt)   // derive against the REAL established salt
+      if (!salt || !salt.length) return                 // salt not established yet — try again next cycle
+      await setupVaultIntentsRootKey(passphrase, salt)  // derive against the REAL vault salt → vault slot
       // The vault intents key just appeared — flush any intents the outbox held
       // (vault target 'transient' on key-not-ready) so a freshly-bootstrapped
       // device delivers them promptly rather than waiting for the next UI poll.

--- a/src/sync/vaultSetup.js
+++ b/src/sync/vaultSetup.js
@@ -14,17 +14,18 @@
 // Passphrase/key foundation (shared with blobs + intents): the vault uses the
 // SINGLE sync passphrase, not a vault-specific secret. When the salt already
 // exists we derive BOTH the DB-sync root key (setupDbRootKey) and the intents/
-// blob root key (setupIntentsEncryption) from passphrase + the VAULT-FETCHED salt
-// BEFORE activating, so the key is cached when the engine comes up and lifeGLANCE
-// stays byte-identical-decryptable with the other apps. We never derive against
-// an invented salt.
+// blob root key (setupVaultIntentsRootKey → the dedicated 'vault-root-key' slot)
+// from passphrase + the VAULT-FETCHED salt BEFORE activating, so the key is cached
+// when the engine comes up and lifeGLANCE stays byte-identical-decryptable with the
+// other apps. We never derive against an invented salt. The vault key has its OWN
+// slot, separate from the WebDAV file-tier intents key, so the two never collide.
 
 import {
   createVaultClient as defaultCreateVaultClient,
   setSyncPassphrase as defaultSetSyncPassphrase,
   setupDbRootKey as defaultSetupDbRootKey,
 } from '@glance-apps/sync'
-import { setupIntentsEncryption as defaultSetupIntentsEncryption } from '../lib/intentsKeyStore.js'
+import { setupVaultIntentsRootKey as defaultSetupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
 import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine } from './dbSync.js'
 import { nativeVaultFetchImpl } from './nativeVaultFetch.js'
 
@@ -116,7 +117,7 @@ export async function runVaultSetup({ vaultUrl, vaultToken, accountId, passphras
   ;(deps.setSyncPassphrase ?? defaultSetSyncPassphrase)(passphrase)
   if (outcome.kind === VAULT_OUTCOME.SUCCESS) {
     await (deps.setupDbRootKey ?? defaultSetupDbRootKey)(passphrase, outcome.salt, { cryptoDBName: CRYPTO_DBNAME })
-    await (deps.setupIntentsEncryption ?? defaultSetupIntentsEncryption)(passphrase, outcome.salt)
+    await (deps.setupVaultIntentsRootKey ?? defaultSetupVaultIntentsRootKey)(passphrase, outcome.salt)
   }
 
   // Activate IN PLACE (rebuild the engine from the freshly saved config) and kick

--- a/src/sync/vaultSetup.test.js
+++ b/src/sync/vaultSetup.test.js
@@ -35,7 +35,7 @@ function spyDeps(createVaultClient) {
     createVaultClient,
     setSyncPassphrase: vi.fn(),
     setupDbRootKey: vi.fn(async () => {}),
-    setupIntentsEncryption: vi.fn(async () => {}),
+    setupVaultIntentsRootKey: vi.fn(async () => {}),
     reinit: vi.fn(),
     startSync: vi.fn(),
   }
@@ -87,7 +87,7 @@ describe('runVaultSetup — verify-before-save gate', () => {
     // Keys derived against the FETCHED salt (not invented), before activation.
     expect(deps.setSyncPassphrase).toHaveBeenCalledWith('pw')
     expect(deps.setupDbRootKey).toHaveBeenCalledWith('pw', salt, { cryptoDBName: 'lifeglance-crypto' })
-    expect(deps.setupIntentsEncryption).toHaveBeenCalledWith('pw', salt)
+    expect(deps.setupVaultIntentsRootKey).toHaveBeenCalledWith('pw', salt)
     expect(deps.reinit).toHaveBeenCalledTimes(1)
     expect(deps.startSync).toHaveBeenCalledTimes(1)
   })
@@ -100,7 +100,7 @@ describe('runVaultSetup — verify-before-save gate', () => {
     expect(readVaultConfig()).toEqual(CREDS)            // saved
     expect(deps.setSyncPassphrase).toHaveBeenCalledWith('pw')
     expect(deps.setupDbRootKey).not.toHaveBeenCalled()  // no salt → none invented
-    expect(deps.setupIntentsEncryption).not.toHaveBeenCalled()
+    expect(deps.setupVaultIntentsRootKey).not.toHaveBeenCalled()
     expect(deps.reinit).toHaveBeenCalledTimes(1)        // still activated
   })
 


### PR DESCRIPTION
**Stacked on #237** — this PR shows only the slot-separation diff; it auto-retargets to `main` once #237 merges.

## The problem
The vault intents + blob key (derived from the **vault** salt) and the WebDAV file-tier intents key (derived from the **WebDAV** salt) both wrote the same `intents-root-key` record, unguarded, last-writer-wins. A device running WebDAV-intents encryption **and** vault could store two different-salt keys in one slot, breaking blob and/or vault-intents decryption by write order. (Matches the reference doc §4.2 / dayGLANCE's `vault-root-key` vs `root-key` model.) Derivation is unchanged — only the **storage slot** separates.

## What changed
- **`intentsKeyStore.js`**: dedicated `vault-root-key` record with its own cache + `loadVaultIntentsRootKey` / `setupVaultIntentsRootKey`, alongside the unchanged WebDAV `intents-root-key` functions.
- **Vault writers → vault slot**: `vaultSetup.js` SUCCESS path and the `dbSync.js` first-sync bootstrap. The bootstrap guard now checks the **vault** slot — fixing the silent-wrong-key bug where a present WebDAV key made the bootstrap skip deriving the vault key.
- **Vault/blob readers → vault slot**: `intentsVaultTransport.js` and `blobCrypto.js`.
- **WebDAV path unchanged**: `enableIntentsEncryption` + the WebDAV deliverer/poller keep `intents-root-key`. So the two keys can never share storage.

## Migration for existing devices
`loadVaultIntentsRootKey` runs a one-time, **no-passphrase** re-home: if the vault slot is empty **and** WebDAV-intents encryption was never enabled (so the legacy shared slot holds the vault-salt key), it copies that key into `vault-root-key`. A vault-only device keeps blob/intents access immediately on first vault read, no re-derivation. A device that *did* enable WebDAV-intents encryption (already colliding pre-fix) skips the adopt and re-derives the vault key cleanly on next vault setup/sync.

## Testing
New `intentsKeyStore.test.js`: distinct slots don't clobber and both stay usable; the bootstrap guard checks the vault slot; blob/vault readers read the vault slot; a legacy shared-slot vault key re-homes and survives reload with no loss; a WebDAV key is never adopted as the vault key. `vaultSetup.test.js` / `blobKeyBootstrap.test.js` updated to the vault-slot names. Full suite (324) + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD9eUjuoEWhsbGgGEBGBHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD9eUjuoEWhsbGgGEBGBHJ)_