### PR TITLE
webdav-proxy: opt-in to accept a self-signed upstream TLS cert (fixes #206 HTTPS 502)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,9 @@ services:
     ports:
       - "6868:80"
     restart: unless-stopped
+    # Uncomment if your WebDAV server (e.g. a Synology/fnOS NAS on HTTPS) uses a
+    # self-signed certificate and syncing fails with a 502 Bad Gateway. This makes
+    # the bundled WebDAV proxy accept the untrusted upstream cert. Only use it on a
+    # trusted LAN with your own NAS — it disables cert verification for that hop.
+    # environment:
+    #   - WEBDAV_PROXY_INSECURE_TLS=1

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -6,6 +6,19 @@ const PORT = 3001
 const PRIVATE_IP = /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|::1$|localhost)/i
 const BLOCK_PRIVATE = !!process.env.VERCEL
 
+// Opt-in: accept a self-signed / untrusted TLS cert on the upstream HTTPS WebDAV
+// server. Many self-hosted NAS WebDAV servers (e.g. Synology on :5006) ship a
+// self-signed cert, which Node's https.request rejects by default — the upstream
+// request then errors and the proxy returns 502 before any request reaches the
+// NAS. Enabling this sets rejectUnauthorized:false on the upstream request ONLY.
+// Trust trade-off: only enable on a trusted LAN talking to your own NAS; it
+// disables cert verification for the proxied WebDAV hop. Off by default.
+const INSECURE_TLS = process.env.WEBDAV_PROXY_INSECURE_TLS === '1' ||
+  process.env.WEBDAV_PROXY_INSECURE_TLS === 'true'
+if (INSECURE_TLS) {
+  console.warn('[webdav-proxy] WEBDAV_PROXY_INSECURE_TLS enabled — upstream HTTPS cert verification is OFF')
+}
+
 const FORWARD_REQ_HEADERS = [
   'authorization', 'x-webdav-auth', 'content-type',
   'if-match', 'depth', 'destination',
@@ -49,9 +62,13 @@ http.createServer(async (req, res) => {
   const body = chunks.length ? Buffer.concat(chunks) : null
 
   const lib = url.protocol === 'https:' ? https : http
+  const reqOptions = { method: req.method, headers }
+  // Accept a self-signed upstream cert only when explicitly opted in, and only for
+  // the HTTPS hop (no effect on plain HTTP).
+  if (url.protocol === 'https:' && INSECURE_TLS) reqOptions.rejectUnauthorized = false
   const upstreamReq = lib.request(
     target,
-    { method: req.method, headers },
+    reqOptions,
     (upstreamRes) => {
       const resHeaders = {}
       for (const h of FORWARD_RES_HEADERS) {


### PR DESCRIPTION
## Problem (issue #206)
A self-hoster on a Synology NAS reported WebDAV sync failing even though the connection test passed. Their diagnostics isolated it cleanly:
- The same URL + credentials work from a normal WebDAV client (FolderSync) → NAS + credentials are fine.
- **HTTPS (port 5006) → `502 Bad Gateway`** from `/api/webdav-proxy`.
- **HTTP (port 5005) → `404`** (got past transport to a real app-layer status).

The HTTPS-502-vs-HTTP-404 split is the tell: the bundled proxy's `upstreamReq.on('error')` returns exactly `502 {"error":"Upstream error"}`, and `https.request` is called with **no `rejectUnauthorized` override**. Synology's WebDAV HTTPS ships a **self-signed cert**, which Node rejects → the upstream request errors → 502 before anything reaches the NAS.

## Fix
Add an **opt-in** `WEBDAV_PROXY_INSECURE_TLS` env flag. When set (`1`/`true`), the proxy passes `rejectUnauthorized: false` on the **HTTPS upstream request only**. Off by default; plain HTTP is unaffected. Documented in `docker-compose.yml` as trusted-LAN / own-NAS only (it disables cert verification for that proxied hop).

## Verification
End-to-end against a self-signed HTTPS upstream through the proxy:
- without the flag → **502** (reproduces the report)
- with the flag → **200**

The clean alternative for users is a trusted cert (Synology Let's Encrypt) or a reverse proxy; this flag is the pragmatic self-host escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD9eUjuoEWhsbGgGEBGBHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD9eUjuoEWhsbGgGEBGBHJ)_