### PR TITLE
Apply a changed sync folder immediately, without a page reload (#206)

### DIFF
--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getSyncEngine } from '../../sync/engine'
+import { getSyncEngine, reinitSyncEngine } from '../../sync/engine'
 import { isSyncing, syncErrorText, SYNC_ERROR_I18N_KEYS } from '../../sync/status'
 import { verifyVaultCredentials, runVaultSetup, disableVault, VAULT_OUTCOME } from '../../sync/vaultSetup'
 import { resolveWebdavBase } from '../../sync/webdav'
@@ -161,6 +161,12 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
       const dirUrl = `${webdavBase}/${folder}/`
       await mkdirp(dirUrl, username, password)
 
+      // The engine captures the sync folder (appFolderName) only at construction,
+      // so a changed folder doesn't take effect until the engine is rebuilt. Save
+      // the config first (setConfig persists it), then reconstruct so the very next
+      // upload targets the new folder instead of needing a page reload (issue #206).
+      const folderChanged = folder !== (existingConfig?.folder ?? 'GLANCE/lifeglance')
+
       if (encrypt) {
         const cryptoConfig = { cryptoDBName: 'lifeglance-crypto' }
         if (passphrase) {
@@ -178,12 +184,14 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
         // Merge over the live config so the coexisting vault fields are preserved
         // (both tiers share the lifeglance-cloud-sync-config object).
         engine?.setConfig({ ...(engine.getConfig() ?? {}), ...baseConfig, encryptionEnabled: true })
-        await engine?.upload()
+        const activeEngine = folderChanged ? reinitSyncEngine() : engine
+        await activeEngine?.upload()
       } else {
         const { clearEncryptionKey } = await import('@glance-apps/sync')
         await clearEncryptionKey({ cryptoDBName: 'lifeglance-crypto' })
         engine?.setConfig({ ...(engine.getConfig() ?? {}), ...baseConfig, encryptionEnabled: false })
-        engine?.upload().catch(console.error)
+        const activeEngine = folderChanged ? reinitSyncEngine() : engine
+        activeEngine?.upload().catch(console.error)
       }
       onClose()
     } catch (err) {

--- a/src/sync/engine.js
+++ b/src/sync/engine.js
@@ -3,8 +3,12 @@ import { buildPayload, buildBackupPayload, mergePayloads, makeApplyPayload } fro
 import { isNativePlatform, nativeWebdavFetch } from './nativeHttp.js';
 
 let engine = null;
+// The construction params (ref/setter closures) from App.jsx, kept so the
+// engine can be rebuilt in place when a setting that's only read at
+// construction time changes. See reinitSyncEngine.
+let savedInitParams = null;
 
-export const initSyncEngine = ({ milestonesRef, chaptersRef, setMilestones, setChapters,
+const buildEngine = ({ milestonesRef, chaptersRef, setMilestones, setChapters,
   setSyncStatus, setSyncError, setSyncHalted, setLastSynced, setShowPassphraseModal,
   setVaultSkipped }) => {
 
@@ -21,7 +25,7 @@ export const initSyncEngine = ({ milestonesRef, chaptersRef, setMilestones, setC
     localStorage.setItem(KEY_LAST_SYNCED, new Date(Date.now() - 60_000).toISOString())
   }
 
-  engine = createSyncEngine({
+  return createSyncEngine({
     storageKeyPrefix: 'lifeglance',
     cryptoDBName: 'lifeglance-crypto',
     autoBackupDBName: 'lifeglance-auto-backups',
@@ -80,7 +84,23 @@ export const initSyncEngine = ({ milestonesRef, chaptersRef, setMilestones, setC
     onLastSyncedChange: setLastSynced,
     onPassphraseRequired: () => setShowPassphraseModal(true),
   });
+};
 
+export const initSyncEngine = (params) => {
+  savedInitParams = params;
+  engine = buildEngine(params);
+  return engine;
+};
+
+// Rebuild the engine in place, re-reading construction-only config from
+// localStorage. The sync folder (appFolderName) is captured when the engine is
+// built and never re-read afterwards, so a folder change saved via setConfig has
+// no effect until the engine is reconstructed. Calling this right after saving a
+// new folder makes it take effect immediately, instead of only after a page
+// reload (issue #206). No-op until initSyncEngine has run once.
+export const reinitSyncEngine = () => {
+  if (!savedInitParams) return engine;
+  engine = buildEngine(savedInitParams);
   return engine;
 };
 

--- a/src/sync/engineReinit.test.js
+++ b/src/sync/engineReinit.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Capture the config every createSyncEngine call receives so we can assert which
+// appFolderName the engine was built with. Everything else the package exports is
+// stubbed to a no-op so engine.js (and adapter.js's static imports) load cleanly.
+const built = []
+vi.mock('@glance-apps/sync', () => ({
+  createSyncEngine: (cfg) => { built.push(cfg); return { id: built.length, cfg } },
+  // Named exports statically imported by adapter.js; unused here, just present.
+  mergeArrayById: () => [],
+  pruneTombstones: () => [],
+}))
+
+// The test env is 'node' (no DOM). engine.js only needs a get/set/clear store.
+const store = new Map()
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+  clear: () => store.clear(),
+}
+
+const CONFIG_KEY = 'lifeglance-cloud-sync-config'
+const noopParams = {
+  milestonesRef: { current: [] }, chaptersRef: { current: [] },
+  setMilestones: () => {}, setChapters: () => {}, setSyncStatus: () => {},
+  setSyncError: () => {}, setSyncHalted: () => {}, setLastSynced: () => {},
+  setShowPassphraseModal: () => {}, setVaultSkipped: () => {},
+}
+
+describe('reinitSyncEngine', () => {
+  beforeEach(() => {
+    built.length = 0
+    localStorage.clear()
+  })
+
+  it('rebuilds the engine with the sync folder saved since construction', async () => {
+    const { initSyncEngine, reinitSyncEngine, getSyncEngine } = await import('./engine.js')
+
+    // First build: no saved folder → the default appFolderName.
+    initSyncEngine(noopParams)
+    expect(built.at(-1).appFolderName).toBe('GLANCE/lifeglance')
+    const first = getSyncEngine()
+
+    // The user saves a new sync folder (persisted the way setConfig persists it).
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ folder: 'photo/GLANCE/lifeglance' }))
+
+    // Reinit rebuilds a fresh engine that re-reads the folder from localStorage.
+    const rebuilt = reinitSyncEngine()
+    expect(built.at(-1).appFolderName).toBe('photo/GLANCE/lifeglance')
+    expect(rebuilt).not.toBe(first)
+    expect(getSyncEngine()).toBe(rebuilt)
+  })
+
+  it('is a no-op before initSyncEngine has ever run', async () => {
+    vi.resetModules()
+    const { reinitSyncEngine } = await import('./engine.js')
+    expect(reinitSyncEngine()).toBe(null)
+    expect(built).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the "must refresh the page after changing sync settings" papercut reported in #206.

The sync engine captures the WebDAV sync folder (`appFolderName`) only when it is constructed at app load. The underlying `@glance-apps/sync` engine never re-reads it afterwards: `setConfig` persists the config but rebuilds nothing, and the `folder` field it stores is not read for the upload path (the folder segment comes solely from the construction-time `appFolderName`). So after a user changed the sync folder in settings, the engine kept targeting the old/default folder until the page was reloaded.

On a second device this surfaced as the folder reverting to the default `GLANCE/lifeglance` (missing the shared-folder prefix, e.g. `photo/`) until a manual refresh.

## Changes

- **`src/sync/engine.js`** — extract engine construction into `buildEngine`, retain the init params (the ref/setter closures from `App.jsx`), and add `reinitSyncEngine()` to rebuild the engine in place, re-reading the sync folder from `localStorage`. No-op until `initSyncEngine` has run once.
- **`src/components/sync/CloudSyncModal.jsx`** — on save, detect whether the folder actually changed; if so, reconstruct the engine (after `setConfig` persists the new config) and upload through the fresh engine, so the new folder takes effect on the very next sync. Unchanged folders keep using the existing engine.
- **`src/sync/engineReinit.test.js`** — new tests: the rebuild picks up a newly-saved folder, and `reinitSyncEngine()` is a no-op before init.

## Testing

- Full sync suite: 67 pass (9 files).
- Lint clean; production build succeeds.

## Notes / follow-up

This addresses only the folder-staleness half of #206. The other half — generic-WebDAV auto-backups being written to the server root instead of inside the sync folder (which 405s on Synology/fnOS) — lives in the `@glance-apps/sync` package, not this repo, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_