### PR TITLE
Pin @glance-apps/sync to 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/core": "^8.4.0",
         "@capacitor/ios": "^8.4.0",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.5.2",
+        "@glance-apps/sync": "1.5.3",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.2.tgz",
-      "integrity": "sha512-S+O/bsGxtkDzcVBPhI8DlTiy89cfOwe9XGFaZoD3G1m2kZzOW9RnKNqHYuPSP2+Auy0RFPBQla+45nhm6WuN+A==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.3.tgz",
+      "integrity": "sha512-wzRVEtGcyfbzH5tMhqeKHhiXsJobU1qvdt5JRGjD1zcxEpqpETUSsOJ8n4UQzQA27ah6AESDx1aYYphJ5TkuDQ==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@capacitor/core": "^8.4.0",
     "@capacitor/ios": "^8.4.0",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.5.2",
+    "@glance-apps/sync": "1.5.3",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
## Summary

Bumps the sync engine to `@glance-apps/sync@1.5.3` (exact pin, matching the existing pinning style). This is the release that fixes the second half of #206: generic-WebDAV auto-backups being written to the server root.

## What 1.5.3 fixes

Per the package changelog:

- The `webdav` backup provider previously built its upload directory as the bare WebDAV root, so backups landed at `<webdavUrl>/<prefix><ts>.json`. On NAS targets whose base URL is the server root (Synology/fnOS), a `PUT` to `/` is rejected with `405 Method Not Allowed`, so auto-backups silently failed (reported in #206).
- 1.5.3 writes backups to `<webdavUrl>/<appFolderName>/backups/` — matching the sync-file path and the `nextcloud` backup provider — and issues an `MKCOL` for the app folder and the `backups/` subdir on `404`/`409` before retrying the `PUT`, so the first backup to a fresh target succeeds. `listBackups` / `downloadBackup` / `deleteBackup` / retention all target the same nested directory. The folder segment comes from `appFolderName`, not the unused `config.folder`.

## Changes

- `package.json`: `@glance-apps/sync` `1.5.2` → `1.5.3`.
- `package-lock.json`: corresponding version + integrity update (only entry changed).

## Testing

- Full test suite: 332 pass (30 files).
- Production build succeeds; lint clean (pre-existing warnings only).

## Notes

Together with #245 (apply a changed sync folder without a page reload), this closes out the actionable bugs from #206. No lifeGLANCE source changes are needed to pick up the backup-path fix — it's entirely inside the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_