### PR TITLE
Enter birthday with Year/Month/Day dropdowns instead of a date picker (#243)

### DIFF
--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -3,6 +3,7 @@ import { useTranslation, Trans } from 'react-i18next'
 import { saveCategories } from '../../utils/colors'
 import { isMuted, setMuted } from '../../utils/audio'
 import { THEMES, getTheme, setTheme } from '../../utils/theme'
+import { dateFieldOrder, monthNames } from '../../utils/dates'
 import IntegrationSettings from '../dayglance/IntegrationSettings'
 
 const TEXT_SIZES_ALL = ['small', 'normal', 'big', 'bigger']
@@ -21,6 +22,83 @@ function slugify(str) {
   return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
+// Number of days in a given 1-based month, defaulting to 31 until a month is
+// picked so the day list is never empty.
+function daysInMonth(year, month) {
+  if (!month) return 31
+  return new Date(Number(year) || 2000, Number(month), 0).getDate()
+}
+
+// Birthday entry as three Year / Month / Day dropdowns instead of a native
+// <input type="date">. On phones the native picker opens a calendar that forces
+// tapping back through a month per step to reach a birth year decades ago
+// (issue #243); dropdowns make it a few taps. The stored value keeps the exact
+// same YYYY-MM-DD string the date input produced, so age math and sync are
+// unchanged. Fields are ordered per locale (dateFieldOrder).
+function BirthdayPicker({ value, onChange, language, tc }) {
+  const months = monthNames(language, 'long')
+
+  const parse = (v) => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v || '')
+    return m ? { y: m[1], mo: String(Number(m[2])), d: String(Number(m[3])) } : { y: '', mo: '', d: '' }
+  }
+  const [parts, setParts] = useState(() => parse(value))
+
+  // Re-sync if the birthday changes elsewhere (e.g. restored from a backup or a
+  // GLANCEvault sync) while this modal is open. Adjusting state during render off
+  // the previous prop is React's recommended alternative to a syncing effect.
+  const [lastValue, setLastValue] = useState(value)
+  if (value !== lastValue) {
+    setLastValue(value)
+    setParts(parse(value))
+  }
+
+  const nowYear = new Date().getFullYear()
+  const years = Array.from({ length: nowYear - 1900 + 1 }, (_, i) => String(nowYear - i))
+  const days = Array.from({ length: daysInMonth(parts.y, parts.mo) }, (_, i) => String(i + 1))
+
+  function update(next) {
+    // Keep the day valid for the chosen month/year (e.g. Feb 31 -> Feb 28/29).
+    const max = daysInMonth(next.y, next.mo)
+    if (next.d && Number(next.d) > max) next.d = String(max)
+    setParts(next)
+    // Only emit a complete date; an incomplete selection clears the birthday.
+    onChange(next.y && next.mo && next.d
+      ? `${next.y}-${next.mo.padStart(2, '0')}-${next.d.padStart(2, '0')}`
+      : '')
+  }
+
+  const fields = {
+    year: (
+      <select key="year" className="settings-birthday-input" value={parts.y}
+        onChange={e => update({ ...parts, y: e.target.value })} aria-label={tc('year')}>
+        <option value="">{tc('year')}</option>
+        {years.map(y => <option key={y} value={y}>{y}</option>)}
+      </select>
+    ),
+    month: (
+      <select key="month" className="settings-birthday-input" value={parts.mo}
+        onChange={e => update({ ...parts, mo: e.target.value })} aria-label={tc('month')}>
+        <option value="">{tc('month')}</option>
+        {months.map((m, i) => <option key={i + 1} value={String(i + 1)}>{m}</option>)}
+      </select>
+    ),
+    day: (
+      <select key="day" className="settings-birthday-input" value={parts.d}
+        onChange={e => update({ ...parts, d: e.target.value })} aria-label={tc('day')}>
+        <option value="">{tc('day')}</option>
+        {days.map(d => <option key={d} value={d}>{d}</option>)}
+      </select>
+    ),
+  }
+
+  return (
+    <div className="settings-birthday-fields">
+      {dateFieldOrder(language).map(f => fields[f])}
+    </div>
+  )
+}
+
 export default function SettingsModal({
   textSize, onTextSizeChange,
   categories, onCategoriesChange,
@@ -36,7 +114,7 @@ export default function SettingsModal({
   onClose,
   ultraCompact = false,
 }) {
-  const { t } = useTranslation('settings')
+  const { t, i18n } = useTranslation('settings')
   const { t: tc } = useTranslation('common')
   const [newLabel,   setNewLabel]   = useState('')
   const [newColor,   setNewColor]   = useState(COLOR_PALETTE[0])
@@ -293,12 +371,11 @@ export default function SettingsModal({
           <div className="settings-label">{t('youLabel')}</div>
           <div className="settings-you-row">
             <span className="settings-you-label">{t('birthday')}</span>
-            <input
-              type="date"
-              className="settings-birthday-input"
+            <BirthdayPicker
               value={birthday}
-              max={(() => { const t = new Date(); return `${t.getFullYear()}-${String(t.getMonth()+1).padStart(2,'0')}-${String(t.getDate()).padStart(2,'0')}` })()}
-              onChange={e => onBirthdayChange(e.target.value)}
+              onChange={onBirthdayChange}
+              language={i18n.language}
+              tc={tc}
             />
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1867,6 +1867,11 @@ button, input, select, textarea {
   color: var(--text-muted);
   flex-shrink: 0;
 }
+.settings-birthday-fields {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
 .settings-birthday-input {
   background: transparent;
   border: 1px solid var(--border);
@@ -1876,6 +1881,9 @@ button, input, select, textarea {
   font-size: 0.72rem;
   padding: 0.3rem 0.5rem;
   color-scheme: dark;
+}
+select.settings-birthday-input {
+  cursor: pointer;
 }
 
 .settings-backup-row {


### PR DESCRIPTION
## Summary

Addresses item 1 of #243: on mobile, the birthday field's native `<input type="date">` opens the OS calendar, which forces tapping back one month per step to reach a birth year decades ago ("clicks = age × 12 months"), making it impractical for a birthday.

This replaces it with three **Year / Month / Day** dropdowns, matching the month/year dropdown pattern onboarding already uses for events.

## Changes

- `src/components/settings/SettingsModal.jsx` — new `BirthdayPicker` component:
  - Fields ordered per locale (`dateFieldOrder`), month names localized (`monthNames`).
  - Day list clamped to the chosen month/year, so invalid dates like Feb 31 can't be selected.
  - Stores the **exact same `YYYY-MM-DD` string** the date input produced, so `ageAtDate` and sync are unchanged. An incomplete selection clears the birthday, matching the old empty-date-input behavior.
  - Re-syncs from the prop via render-phase state adjustment (React's recommended alternative to a syncing effect) so a backup/sync restore while the modal is open is reflected.
- `src/index.css` — flex row for the three selects (`.settings-birthday-fields`).

## Testing

- Full test suite: 332 pass (30 files).
- Build succeeds; lint clean.

## Scope note

This is item 1 of #243 only. Item 3 (timeline zoom on web) needs no code — the web already supports zoom via the zoom tabs, mouse-wheel zoom, and cluster-click drill-down. Item 2 (portrait onboarding) is intentionally **not** being done: making onboarding portrait only to then force a rotate into the landscape app is a worse hand-off than one consistent orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_