### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.5.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.6.0-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Minor release bump, 2.5.0 to 2.6.0. Updates the version in `package.json`, the lockfile root version (via `npm install`), and the README version badge.

## Why minor

Changes since 2.5.0 are additive with no breaking changes:

**New features / enhancements**
- GLANCEvault transport for bidirectional intents
- dayGLANCE intents integration made independent, with an either/or transport
- Cloud Sync modal rework: vault beta-flagged, WebDAV toggle, test button relocated
- WebDAV proxy opt-in self-signed TLS (`WEBDAV_PROXY_INSECURE_TLS`)
- Birthday entry via Year/Month/Day dropdowns

**Bug fixes**
- Vault intents/blob key gets its own key slot, plus bootstrap on fresh-household first sync
- Sync folder change applies without a page reload (#206)
- `@glance-apps/sync` 1.5.3 (WebDAV backups nest under the sync folder)
- Pinch into custom zoom no longer pops the keyboard
- Locale cleanup (hidden-count icon, duplicate zh_CN)

## Changes

- `package.json`: `2.5.0` to `2.6.0`
- `package-lock.json`: root version updated to match
- `README.md`: version badge updated to `2.6.0`

## Testing

- Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_