### PR TITLE
Prompt for the passphrase when the vault intents key can't be derived

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,7 +81,14 @@ export default function App() {
         // GLANCEvault database-sync engine, constructed ALONGSIDE the WebDAV
         // engine above. Returns null (fully inert) unless the vault is enabled in
         // the cloud-sync config — vault sync is opt-in and never replaces WebDAV.
-        initDbSyncEngine({ setMilestones, setChapters })
+        initDbSyncEngine({
+          setMilestones,
+          setChapters,
+          // Vault intents/blob key can't be derived without the passphrase. When
+          // it's missing and vault intents are in use, prompt for it (same modal
+          // the WebDAV engine uses); onUnlocked re-runs the DB sync to derive it.
+          onPassphraseRequired: () => setShowPassphraseModal(true),
+        })
 
         // Restore encryption session key from IDB so the passphrase prompt
         // only appears when the key genuinely isn't stored (first setup or
@@ -243,6 +250,10 @@ export default function App() {
           onUnlocked={() => {
             setShowPassphraseModal(false)
             getSyncEngine()?.sync()
+            // Now that the passphrase is in session, run the DB sync too so the
+            // vault intents/blob key derives (bootstrapIntentsRootKey) and held
+            // intents flush.
+            getDbSyncEngine()?.sync()
           }}
         />
       )}

--- a/src/sync/blobKeyBootstrap.test.js
+++ b/src/sync/blobKeyBootstrap.test.js
@@ -153,3 +153,70 @@ describe('fresh-household blob/intents key late-bootstrap', () => {
     expect(await m.loadVaultIntentsRootKey()).not.toBeNull()
   })
 })
+
+// The upgrade case: vault DB sync runs from a cached DB key, so the passphrase is
+// often absent this session and the vault intents/blob key (new in 2.6.0) never
+// gets derived. When the user has actually selected vault intents, prompt for the
+// passphrase (once) so the key can be derived rather than failing silently with
+// KeyUnavailableError. We seed a cached DB root key (setupDbRootKey → hasDbRootKey
+// true) so the engine's own sync does NOT itself demand the passphrase — exactly
+// the state of an already-syncing device that just upgraded.
+describe('vault intents key — passphrase prompt when it cannot be derived', () => {
+  const INTENTS_VAULT_ACTIVE = JSON.stringify({ enabled: true, transport: 'vault', webdavUrl: '' })
+
+  // Seed a cached DB root key so ensureRootKey is satisfied without a session
+  // passphrase, then clear the passphrase — the "sync works from cache, but the
+  // passphrase isn't in this session" upgrade state.
+  async function seedCachedDbKeyNoPassphrase(m) {
+    const { setupDbRootKey } = await import('@glance-apps/sync')
+    await setupDbRootKey('pw', new Uint8Array(16).fill(7), { cryptoDBName: 'lifeglance-crypto' })
+    m.setSyncPassphrase(null)
+  }
+
+  it('prompts once when the key is missing, no passphrase is in session, and vault intents is active', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    localStorage.setItem('lifeglance-intents-config', INTENTS_VAULT_ACTIVE)
+    await seedCachedDbKeyNoPassphrase(m)
+    expect(await m.loadVaultIntentsRootKey()).toBeNull()   // intents key was never derived
+
+    const onPassphraseRequired = vi.fn()
+    const vault = makeMemVault()
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault, onPassphraseRequired })
+
+    await dbSync.sync()   // sync works off the cached DB key; bootstrap hits the no-passphrase branch
+    await dbSync.sync()   // a later cycle must NOT re-open the modal
+
+    expect(onPassphraseRequired).toHaveBeenCalledTimes(1)
+    expect(await m.loadVaultIntentsRootKey()).toBeNull()  // still no key — it needs the passphrase
+  })
+
+  it('does NOT prompt when vault intents is not the selected transport', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    // No intents config → isVaultIntentsActive() is false (vault sync alone must not nag).
+    await seedCachedDbKeyNoPassphrase(m)
+
+    const onPassphraseRequired = vi.fn()
+    const vault = makeMemVault()
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault, onPassphraseRequired })
+    await dbSync.sync()
+
+    expect(onPassphraseRequired).not.toHaveBeenCalled()
+  })
+
+  it('does not prompt when the passphrase is available — it derives the key instead', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    localStorage.setItem('lifeglance-intents-config', INTENTS_VAULT_ACTIVE)
+    m.setSyncPassphrase('pw')
+
+    const onPassphraseRequired = vi.fn()
+    const vault = makeMemVault()
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault, onPassphraseRequired })
+    await dbSync.sync()
+
+    expect(onPassphraseRequired).not.toHaveBeenCalled()
+    expect(await m.loadVaultIntentsRootKey()).not.toBeNull()
+  })
+})

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -21,7 +21,7 @@ import { registerDirtyTarget } from './dirty.js'
 import { dbGetAll, dbGetAllChapters } from '../data/db.js'
 import { loadCategories } from '../utils/colors.js'
 import { loadVaultIntentsRootKey, setupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
-import { flushOutbox } from '../lib/intentsTransport.js'
+import { flushOutbox, isVaultIntentsActive } from '../lib/intentsTransport.js'
 
 const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
 const DEVICE_ID_KEY  = 'lifeglance-db-sync-device-id'
@@ -29,6 +29,10 @@ const SEEDED_KEY     = 'lifeglance-db-sync-seeded'
 
 let _dbEngine = null
 let _pushTimer = null
+// Once-per-session guard so a device that can't derive the vault intents/blob key
+// without the passphrase prompts for it exactly once, rather than re-opening the
+// modal on every sync cycle if the user dismisses it.
+let _promptedForIntentsKey = false
 // Cached init options (the React setters App passes at mount) so the engine can
 // be re-initialised IN PLACE from anywhere — e.g. the settings modal activating
 // vault sync — without a page reload and without re-plumbing the setters.
@@ -157,10 +161,24 @@ export const initDbSyncEngine = (opts = {}) => {
       // runs the one-time migration that re-homes a legacy shared-slot vault key.
       if (await loadVaultIntentsRootKey()) return       // vault key already present — no-op
       const passphrase = getSyncPassphrase()
-      if (!passphrase) return                           // no passphrase → cannot derive (DB key couldn't either)
+      if (!passphrase) {
+        // The vault intents/blob key can only be derived from the passphrase +
+        // vault salt, but vault DB sync runs from a cached DB key so the passphrase
+        // is often absent this session (nothing re-prompts for it). On an upgraded
+        // device the key never gets derived and vault intents fail with
+        // KeyUnavailableError. If the user has actually selected vault intents,
+        // prompt for the passphrase once so the key can derive; onUnlocked re-runs
+        // the DB sync, which lands here again with the passphrase available.
+        if (!_promptedForIntentsKey && isVaultIntentsActive()) {
+          _promptedForIntentsKey = true
+          opts.onPassphraseRequired?.()
+        }
+        return                                          // no passphrase → cannot derive (DB key couldn't either)
+      }
       const salt = await engine.vault.getSalt(vaultConfig.accountId)
       if (!salt || !salt.length) return                 // salt not established yet — try again next cycle
       await setupVaultIntentsRootKey(passphrase, salt)  // derive against the REAL vault salt → vault slot
+      _promptedForIntentsKey = false                    // key is set; allow a fresh prompt if it's ever lost again
       // The vault intents key just appeared — flush any intents the outbox held
       // (vault target 'transient' on key-not-ready) so a freshly-bootstrapped
       // device delivers them promptly rather than waiting for the next UI poll.


### PR DESCRIPTION
## Summary

Fixes the dayGLANCE intents integration silently failing over GLANCEvault after upgrading to 2.6.0 (observed on the PWA; Android happened to have the key established).

## Root cause

Vault intents (new in 2.6.0) need the vault intents/blob key in the `vault-root-key` IndexedDB slot, derived from the sync passphrase plus the vault salt. But vault DB sync runs from a **cached** DB key, so the passphrase is usually not in the session, and nothing re-prompts for it. On a device that upgraded into 2.6.0, the key therefore never gets derived:

- sends hold as `transient`, and
- receives fail with `KeyUnavailableError` (confirmed in the console).

The one-time shared-slot migration doesn't help devices that ever had WebDAV-intents encryption enabled, since it deliberately skips those (the old slot may hold the WebDAV-salt key, which is the wrong key for the vault). So the key is left with no way to appear.

## Fix

Make it self-heal. In `bootstrapIntentsRootKey` (`dbSync.js`), when the vault key is missing **and** there is no session passphrase **and** the user has actually selected vault intents, surface the existing sync passphrase modal via a new `onPassphraseRequired` option on the DB sync engine (mirroring what the WebDAV engine already does). It prompts **once per session** so a dismissed modal doesn't reopen every cycle. On unlock, `App` now also runs the DB sync so the key derives immediately and any held intents flush.

- `src/sync/dbSync.js` — prompt-once branch in the bootstrap; reset the guard after a successful derive.
- `src/App.jsx` — pass `onPassphraseRequired` to `initDbSyncEngine`; run `getDbSyncEngine()?.sync()` on unlock.
- `src/sync/blobKeyBootstrap.test.js` — three cases: prompt-once when key missing + no passphrase + vault intents active; no prompt when vault intents isn't the selected transport; no prompt when the passphrase is present (it derives instead).

## Scope

This restores **future** delivery. Inbound intents already advanced past by the receive drain's give-up-and-advance path are not recovered here; that behavior (dropping recoverable inbound rows on a device-wide missing key) is a separate follow-up you flagged.

## Testing

- Full suite: 337 pass (31 files).
- Build succeeds; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_