### PR TITLE
Bump version to 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.6.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.6.1-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Patch release bump, 2.6.0 to 2.6.1. Updates the version in `package.json`, the lockfile root version (via `npm install`), and the README version badge.

## Why patch

Bug fixes only, no new features or breaking changes:

- Prompt for the sync passphrase when the vault intents/blob key can't be derived, so the dayGLANCE integration stops silently failing after upgrading (#249).
- Classify key-unavailable rows in the intents receive drain as HOLD instead of giving up after retries, so locked-but-valid inbound intents are never dropped (#250).

## Changes

- `package.json`: `2.6.0` to `2.6.1`
- `package-lock.json`: root version updated to match
- `README.md`: version badge updated to `2.6.1`

## Testing

- Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_