### PR TITLE
docker.yml: add a manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   release:
     types: [published]
+  # Manual "Run workflow" button. Pick a tag (e.g. v2.6.1) to rebuild and
+  # republish that release's image (metadata-action derives the version from the
+  # tag), or a branch to refresh `latest`. Useful when a release build wedges and
+  # needs re-running without cancelling or re-publishing the release.
+  workflow_dispatch:
 
 jobs:
   # Runs on every push and PR. Fails on lint errors; warnings are advisory and
@@ -111,10 +116,10 @@ jobs:
           docker rm -f lifeglance webdav || true
           docker network rm test-net || true
 
-  # Runs on release only, gated on test passing.
+  # Runs on a published release, or a manual dispatch, gated on test passing.
   publish-to-ghcr:
     needs: test
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Adds a manual **Run workflow** button to the "Build & Push to GHCR" workflow, so the image can be rebuilt/republished on demand, without cancelling a stuck run or re-publishing a release (exactly the situation the v2.6.1 build hit).

## Changes

- `on:` gains `workflow_dispatch:`.
- The `publish-to-ghcr` job gate becomes `github.event_name == 'release' || github.event_name == 'workflow_dispatch'`. Without this second change the button would run only `lint`/`test` and never publish, since publish was gated on the release event alone.

## How to use it

Actions → **Build & Push to GHCR** → **Run workflow**, then pick the ref:
- a **tag** (e.g. `v2.6.1`) → `docker/metadata-action` derives `{{version}}`/`{{major}}.{{minor}}` from the tag, so it republishes `2.6.1` / `2.6` / `latest`;
- a **branch** (e.g. `main`) → no semver tag applies, so it just refreshes `latest`.

The `lint` and `test` gates still run first, so a manual publish is held to the same checks as a release.

## Notes

No behavior change for existing events: `push`/`pull_request` still run `lint`/`test` only, and `release: published` still publishes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCgp2JJq1rwzQBQoWKBd6)_