### PR TITLE
Confirm cloud restore on new devices (sync-status feedback, #253)

### DIFF
--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -219,6 +219,19 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     return () => window.removeEventListener('lifeglance:sync-applied', onSyncApplied)
   }, [])
 
+  // First-restore confirmation: applyPayload fires 'lifeglance:restored' when a
+  // previously-empty device receives milestones from the cloud. Surface a toast
+  // so the user gets a definite "your timeline is here" signal instead of
+  // watching the green dot and refreshing repeatedly to see if it worked (#253).
+  useEffect(() => {
+    const onRestored = (e) => {
+      const count = e?.detail?.count
+      if (count > 0) showToast(ts('restoredToast', { count }), 'success')
+    }
+    window.addEventListener('lifeglance:restored', onRestored)
+    return () => window.removeEventListener('lifeglance:restored', onRestored)
+  }, [])
+
   // Apply font size globally
   useEffect(() => {
     document.documentElement.style.fontSize = TEXT_SIZES[textSize]
@@ -1944,7 +1957,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
               <button
                 className="action-link sync-status-btn"
                 onClick={onOpenCloudSync}
-                title={syncHalted ? t('syncErrorTitle') : isSyncing(syncStatus) ? t('syncingTitle') : syncError ? (SYNC_ERROR_I18N_KEYS[syncError.code] ? ts(SYNC_ERROR_I18N_KEYS[syncError.code]) : t('syncErrorSimple')) : t('cloudSyncTitle')}
+                title={syncHalted ? t('syncErrorTitle') : isSyncing(syncStatus) ? t('syncingTitle') : syncError ? (SYNC_ERROR_I18N_KEYS[syncError.code] ? ts(SYNC_ERROR_I18N_KEYS[syncError.code]) : t('syncErrorSimple')) : lastSynced ? t('lastSyncedTitle', { time: new Date(lastSynced).toLocaleString(i18n.language) }) : t('cloudSyncTitle')}
               >
                 <span
                   className="sync-dot"

--- a/src/locales/de/sync.json
+++ b/src/locales/de/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "Verlauf",
   "wrongPassphrase": "Falsche Synchronisierungs-Passphrase — sie muss exakt mit der auf deinen anderen Geräten verwendeten übereinstimmen.",
   "vaultSkippedToast": "{{count}} Element(e) konnten nicht gelesen werden — siehe Cloud-Sync-Einstellungen.",
+  "restoredToast": "{{count}} Meilenstein(e) aus der Cloud wiederhergestellt.",
   "vaultSkippedNote": "{{count}} Element(e) konnten auf diesem Gerät nicht gelesen werden und wurden übersprungen. Sie werden bei der nächsten Synchronisierung automatisch erneut versucht — meist liegt eine abweichende Sync-Passphrase vor.",
   "verifierUnsupported": "Dein Sync-Server muss aktualisiert werden, um die Schlüsselverifizierung zu unterstützen.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/de/timeline.json
+++ b/src/locales/de/timeline.json
@@ -31,6 +31,7 @@
   "syncingTitle": "Synchronisierung…",
   "syncErrorSimple": "Sync-Fehler",
   "cloudSyncTitle": "Cloud-Synchronisierung",
+  "lastSyncedTitle": "Zuletzt synchronisiert {{time}}",
   "addMilestone": "+ Meilenstein hinzufügen",
   "addChapter": "+ Kapitel hinzufügen",
   "filterAll": "alle",

--- a/src/locales/en/sync.json
+++ b/src/locales/en/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "history",
   "wrongPassphrase": "Wrong sync passphrase — it must exactly match the passphrase used on your other devices.",
   "vaultSkippedToast": "{{count}} item(s) couldn't be read — check cloud sync settings.",
+  "restoredToast": "Restored {{count}} milestone(s) from the cloud.",
   "vaultSkippedNote": "{{count}} item(s) couldn't be read on this device and were skipped. They'll be retried automatically on the next sync — this usually means a sync passphrase mismatch.",
   "verifierUnsupported": "Your sync server needs to be updated to support key verification.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/en/timeline.json
+++ b/src/locales/en/timeline.json
@@ -43,6 +43,7 @@
   "syncingTitle": "Syncing...",
   "syncErrorSimple": "Sync error",
   "cloudSyncTitle": "Cloud sync",
+  "lastSyncedTitle": "Last synced {{time}}",
   "addMilestone": "+ add milestone",
   "addMilestoneShort": "+ milestone",
   "addChapter": "+ add chapter",

--- a/src/locales/es/sync.json
+++ b/src/locales/es/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "historial",
   "wrongPassphrase": "Frase de contraseña de sincronización incorrecta — debe coincidir exactamente con la usada en tus otros dispositivos.",
   "vaultSkippedToast": "{{count}} elemento(s) no se pudieron leer — revisa los ajustes de sincronización en la nube.",
+  "restoredToast": "Se restauraron {{count}} hito(s) desde la nube.",
   "vaultSkippedNote": "{{count}} elemento(s) no se pudieron leer en este dispositivo y se omitieron. Se reintentarán automáticamente en la próxima sincronización — esto suele indicar una frase de contraseña de sincronización distinta.",
   "verifierUnsupported": "Tu servidor de sincronización debe actualizarse para admitir la verificación de clave.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/es/timeline.json
+++ b/src/locales/es/timeline.json
@@ -31,6 +31,7 @@
   "syncingTitle": "Sincronizando…",
   "syncErrorSimple": "Error de sync",
   "cloudSyncTitle": "Sincronización en la nube",
+  "lastSyncedTitle": "Última sincronización {{time}}",
   "addMilestone": "+ añadir hito",
   "addChapter": "+ añadir capítulo",
   "filterAll": "todos",

--- a/src/locales/fr/sync.json
+++ b/src/locales/fr/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "historique",
   "wrongPassphrase": "Phrase secrète de synchronisation incorrecte — elle doit correspondre exactement à celle utilisée sur vos autres appareils.",
   "vaultSkippedToast": "{{count}} élément(s) illisible(s) — vérifiez les réglages de synchronisation cloud.",
+  "restoredToast": "{{count}} jalon(s) restauré(s) depuis le cloud.",
   "vaultSkippedNote": "{{count}} élément(s) n'ont pas pu être lus sur cet appareil et ont été ignorés. Ils seront réessayés automatiquement lors de la prochaine synchronisation — cela indique généralement une phrase secrète de synchronisation différente.",
   "verifierUnsupported": "Votre serveur de synchronisation doit être mis à jour pour prendre en charge la vérification de clé.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/fr/timeline.json
+++ b/src/locales/fr/timeline.json
@@ -31,6 +31,7 @@
   "syncingTitle": "Synchronisation…",
   "syncErrorSimple": "Erreur de sync",
   "cloudSyncTitle": "Synchronisation cloud",
+  "lastSyncedTitle": "Dernière synchronisation {{time}}",
   "addMilestone": "+ ajouter un jalon",
   "addMilestoneShort": "+ jalon",
   "addChapter": "+ ajouter un chapitre",

--- a/src/locales/it/sync.json
+++ b/src/locales/it/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "cronologia",
   "wrongPassphrase": "Passphrase di sincronizzazione errata — deve corrispondere esattamente a quella usata sugli altri dispositivi.",
   "vaultSkippedToast": "{{count}} elemento/i non leggibili — controlla le impostazioni di sincronizzazione cloud.",
+  "restoredToast": "Ripristinati {{count}} traguardo/i dalla nuvola.",
   "vaultSkippedNote": "{{count}} elemento/i non sono stati letti su questo dispositivo e sono stati ignorati. Verranno ritentati automaticamente alla prossima sincronizzazione — di solito indica una passphrase di sincronizzazione diversa.",
   "verifierUnsupported": "Il tuo server di sincronizzazione deve essere aggiornato per supportare la verifica della chiave.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/it/timeline.json
+++ b/src/locales/it/timeline.json
@@ -31,6 +31,7 @@
   "syncingTitle": "Sincronizzazione…",
   "syncErrorSimple": "Errore di sync",
   "cloudSyncTitle": "Sincronizzazione cloud",
+  "lastSyncedTitle": "Ultima sincronizzazione {{time}}",
   "addMilestone": "+ aggiungi traguardo",
   "addChapter": "+ aggiungi capitolo",
   "filterAll": "tutti",

--- a/src/locales/pt/sync.json
+++ b/src/locales/pt/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "histórico",
   "wrongPassphrase": "Frase-passe de sincronização incorreta — deve corresponder exatamente à usada nos seus outros dispositivos.",
   "vaultSkippedToast": "{{count}} item(ns) não puderam ser lidos — verifique as definições de sincronização na nuvem.",
+  "restoredToast": "{{count}} marco(s) restaurado(s) da nuvem.",
   "vaultSkippedNote": "{{count}} item(ns) não puderam ser lidos neste dispositivo e foram ignorados. Serão repetidos automaticamente na próxima sincronização — normalmente indica uma frase-passe de sincronização diferente.",
   "verifierUnsupported": "O seu servidor de sincronização precisa de ser atualizado para suportar a verificação de chave.",
   "authFailed": "Authentication failed — check your username and password in sync settings.",

--- a/src/locales/pt/timeline.json
+++ b/src/locales/pt/timeline.json
@@ -31,6 +31,7 @@
   "syncingTitle": "Sincronizando…",
   "syncErrorSimple": "Erro de sync",
   "cloudSyncTitle": "Sincronização na nuvem",
+  "lastSyncedTitle": "Última sincronização {{time}}",
   "addMilestone": "+ adicionar marco",
   "addChapter": "+ adicionar capítulo",
   "filterAll": "todos",

--- a/src/locales/zh_CN/sync.json
+++ b/src/locales/zh_CN/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "备份记录",
   "wrongPassphrase": "加密金钥错误。请确认与其他设备一致。",
   "vaultSkippedToast": "有{{count}}个条目无法读取。请检查云端同步设置。",
+  "restoredToast": "已从云端恢复{{count}}个里程碑。",
   "vaultSkippedNote": "本设备上有{{count}}个条目无法读取并已跳过。下次同步时将自动重试，这通常表示加密金钥不一致。",
   "verifierUnsupported": "请更新您的同步服务器以支持金钥验证。",
   "authFailed": "验证失败: 请检查同步设定中的用户名与密码",

--- a/src/locales/zh_CN/timeline.json
+++ b/src/locales/zh_CN/timeline.json
@@ -43,6 +43,7 @@
   "syncingTitle": "正在同步...",
   "syncErrorSimple": "同步错误",
   "cloudSyncTitle": "云端同步",
+  "lastSyncedTitle": "上次同步 {{time}}",
   "addMilestone": "+ 创建里程碑",
   "addMilestoneShort": "+ 新里程碑",
   "addChapter": "+ 新添章节",

--- a/src/locales/zh_HK/sync.json
+++ b/src/locales/zh_HK/sync.json
@@ -52,6 +52,7 @@
   "historyTab": "備份記錄",
   "wrongPassphrase": "加密金鑰(W-key)不匹配。請確認與其他裝置一致。",
   "vaultSkippedToast": "有{{count}}個項目無法讀取。請檢查雲端同步設定。",
+  "restoredToast": "已從雲端還原{{count}}個里程碑。",
   "vaultSkippedNote": "本裝置上有{{count}}個項目無法讀取並已略過。下次同步時將自動重試，這通常表示加密金鑰(W-key)不一致。",
   "verifierUnsupported": "請更新您的同步伺服器以支援金鑰驗證。",
   "authFailed": "驗證失敗: 請檢查同步設定中的用戶名與密碼",

--- a/src/locales/zh_HK/timeline.json
+++ b/src/locales/zh_HK/timeline.json
@@ -43,6 +43,7 @@
   "syncingTitle": "正在同步...",
   "syncErrorSimple": "同步錯誤",
   "cloudSyncTitle": "雲端同步",
+  "lastSyncedTitle": "上次同步 {{time}}",
   "addMilestone": "+ 創建里程碑",
   "addMilestoneShort": "+ 新里程碑",
   "addChapter": "+ 新添章節",

--- a/src/sync/adapter.applyPayload.test.js
+++ b/src/sync/adapter.applyPayload.test.js
@@ -1,0 +1,79 @@
+// applyPayload — first-restore event (#253).
+//
+// The sync dot goes green on the first successful cycle, which alone doesn't
+// tell a user their timeline has actually landed on a new device. applyPayload
+// emits a one-time 'lifeglance:restored' event when a previously-empty device
+// receives milestones, so the UI can confirm the restore is done. These tests
+// pin that edge: fire once on empty→N, never on subsequent syncs, never when
+// the applied payload carries no milestones.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+
+// Minimal localStorage for the node test environment (fake-indexeddb supplies
+// IndexedDB only). applyPayload persists tombstones/categories to localStorage.
+if (typeof globalThis.localStorage === 'undefined') {
+  const m = new Map()
+  globalThis.localStorage = {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  }
+}
+// applyPayload dispatches on window; provide one in the node env.
+if (typeof globalThis.window === 'undefined') globalThis.window = new EventTarget()
+
+import { makeApplyPayload } from './adapter.js'
+import { initDB, dbGetAll } from '../data/db.js'
+import { buildMilestone } from '../data/milestones.js'
+
+const payloadWith = (milestones) => ({ lives: { default: { milestones, chapters: [] } } })
+
+// Capture 'lifeglance:restored' events fired during `fn`.
+async function withRestoredEvents(fn) {
+  const events = []
+  const onRestored = (e) => events.push(e.detail)
+  window.addEventListener('lifeglance:restored', onRestored)
+  try { await fn() } finally { window.removeEventListener('lifeglance:restored', onRestored) }
+  return events
+}
+
+describe('applyPayload — first-restore event', () => {
+  beforeEach(async () => {
+    global.indexedDB = new IDBFactory()
+    localStorage.clear()
+    await initDB()
+  })
+
+  it('fires once with the milestone count when an empty device receives data', async () => {
+    const apply = makeApplyPayload(() => {}, () => {})
+    const remote = [buildMilestone({ title: 'A', date: '2020-01-01' }), buildMilestone({ title: 'B', date: '2021-01-01' })]
+
+    const events = await withRestoredEvents(() => apply(payloadWith(remote)))
+
+    expect(events).toEqual([{ count: 2 }])
+    expect((await dbGetAll()).length).toBe(2)
+  })
+
+  it('does not fire again once the device already holds milestones', async () => {
+    const apply = makeApplyPayload(() => {}, () => {})
+    const first = [buildMilestone({ title: 'A', date: '2020-01-01' })]
+    await apply(payloadWith(first))
+
+    // A later sync brings an additional milestone; the device is no longer empty.
+    const second = [...(await dbGetAll()), buildMilestone({ title: 'B', date: '2021-01-01' })]
+    const events = await withRestoredEvents(() => apply(payloadWith(second)))
+
+    expect(events).toEqual([])
+    expect((await dbGetAll()).length).toBe(2)
+  })
+
+  it('does not fire when the applied payload carries no milestones', async () => {
+    const apply = makeApplyPayload(() => {}, () => {})
+    const events = await withRestoredEvents(() => apply(payloadWith([])))
+
+    expect(events).toEqual([])
+    expect((await dbGetAll()).length).toBe(0)
+  })
+})

--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -103,6 +103,19 @@ export const makeApplyPayload = (setMilestones, setChapters) =>
     const [freshMilestones, freshChapters] = await Promise.all([dbGetAll(), dbGetAllChapters()]);
     setMilestones(freshMilestones);
     setChapters(freshChapters);
+
+    // First-restore signal: a device that held no milestones just received some
+    // from the remote (a new-device restore, or the real payload arriving after
+    // an encryption-handshake stub). Emit a one-time event so the UI can confirm
+    // the restore is actually done — the sync dot goes green on the first ok
+    // cycle, which alone doesn't tell the user their timeline has landed (#253).
+    // Edge-only: currentMilestones was empty, so ordinary later syncs never fire.
+    if (currentMilestones.length === 0 && freshMilestones.length > 0 &&
+        typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('lifeglance:restored', {
+        detail: { count: freshMilestones.length },
+      }));
+    }
   };
 
 // mergePayloads — synchronous CRDT merge


### PR DESCRIPTION
## Summary

Addresses the UX gap surfaced in the WebDAV test notes (#253): the sync dot goes green on the first successful cycle, but green only means "a sync completed" — it doesn't tell the user their timeline has actually landed on a new device. In the encryption-handshake flow, a stub file can sync (green) *before* the real payload arrives, so users saw green yet an empty timeline and resorted to refreshing repeatedly.

Two client-side signals close the gap:

- **Honest green tooltip** — when synced, the dot's title now reads `Last synced <time>` instead of the generic "Cloud sync", so hovering explains what green means.
- **First-restore toast** — `applyPayload` emits a one-time `lifeglance:restored` event when a previously-empty device receives milestones; `TimelineView` surfaces it as a "Restored N milestone(s)" toast — a definite "done" signal. Edge-triggered on empty→N, so ordinary later syncs never re-fire, and the handshake stub (which carries no milestones) never triggers it prematurely.

## Deliberately not done

Re-coloring the green dot on "restore complete" — CRDT merges make "complete" ill-defined (an empty result can be legitimate), and it would mean forking `@glance-apps/sync`. The tooltip + toast deliver the missing feedback without that risk.

## Changes

- `src/sync/adapter.js` — emit `lifeglance:restored` from `applyPayload` on the empty→N edge.
- `src/components/timeline/TimelineView.jsx` — listen for the event and toast; honest green tooltip.
- `src/locales/*/timeline.json` (8) — new `lastSyncedTitle` string.
- `src/locales/*/sync.json` (8) — new `restoredToast` string, using each locale's existing term for "milestone".
- `src/sync/adapter.applyPayload.test.js` — pins the restore-event edge (fires once on empty→N, never again once populated, never when the payload has no milestones).

## Testing

- New test + full sync suite: **73/73 pass.**
- All locale JSON valid; zh_CN/zh_HK `sync.json` verified at exact key parity with English after rebasing onto the #254 translation work.
- ESLint on changed files: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142MBE3ho4m1khCpgoQoYzJ)_