### PR TITLE
Bump version to 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.6.1-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.6.2-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Patch release bump, 2.6.1 to 2.6.2.

## Changes

- `package.json`: `2.6.1` to `2.6.2`
- `package-lock.json`: root version updated to match (via `npm install`)
- `README.md`: version badge updated to `2.6.2`

## Notes

Version-only change. The lockfile diff is limited to the two version lines with no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142MBE3ho4m1khCpgoQoYzJ)_