### PR TITLE
chore(deps): pin @glance-apps/sync to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/core": "^8.4.0",
         "@capacitor/ios": "^8.4.0",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.5.3",
+        "@glance-apps/sync": "1.6.0",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.3.tgz",
-      "integrity": "sha512-wzRVEtGcyfbzH5tMhqeKHhiXsJobU1qvdt5JRGjD1zcxEpqpETUSsOJ8n4UQzQA27ah6AESDx1aYYphJ5TkuDQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.0.tgz",
+      "integrity": "sha512-1rDJNg7HYTfvEFrCy2oVMtiWhdNGNa3avk4JqKQfE888Zw0Sv0EevBGUAR6S8nnxlK5CN1ZOPhh5TKOWTUhSPg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@capacitor/core": "^8.4.0",
     "@capacitor/ios": "^8.4.0",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.5.3",
+    "@glance-apps/sync": "1.6.0",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
Bumps `@glance-apps/sync` from `1.5.3` to `1.6.0`.

## Changes
- `package.json`: `1.5.3` → `1.6.0`, kept as an exact pin (no `^`/`~` range), consistent with how it was pinned before.
- `package-lock.json`: updated the resolved tarball URL and `sha512` integrity hash to the 1.6.0 release.

## Notes
- No transitive dependency changes and no peer-dependency conflicts from the update.
- Scoped to just the dependency pin — no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_