### PR TITLE
ios: implement Share Extension (share-to-app parity with Android)

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -54,6 +54,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         case "new":
             defaults?.set("new", forKey: "pending_action")
+        case "share":
+            // The Share Extension already wrote "pending_share" to the App Group
+            // before opening this URL; nothing to stash here. Opening the app is
+            // enough — the web layer reads the share via consumeLaunchTarget() on
+            // resume. Handled explicitly so it doesn't fall through to default.
+            break
         default:
             break
         }

--- a/ios/App/App/WidgetBridgePlugin.swift
+++ b/ios/App/App/WidgetBridgePlugin.swift
@@ -37,6 +37,11 @@ public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
         if let action = WidgetStore.consumePendingAction() {
             result["action"] = action
         }
+        // A share left by the Share Extension: a JSON string { text, subject } the
+        // web layer parses into an Add-milestone draft (matches the Android side).
+        if let share = WidgetStore.consumePendingShare() {
+            result["share"] = share
+        }
         call.resolve(result)
     }
 }

--- a/ios/App/LifeGlanceShare/Info.plist
+++ b/ios/App/LifeGlanceShare/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios/App/LifeGlanceShare/LifeGlanceShare.entitlements
+++ b/ios/App/LifeGlanceShare/LifeGlanceShare.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lifeglance</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/LifeGlanceShare/README.md
+++ b/ios/App/LifeGlanceShare/README.md
@@ -1,0 +1,56 @@
+# LifeGlanceShare — iOS Share Extension
+
+Native half of the "share text/link into lifeGLANCE" feature (parity with the
+Android `ACTION_SEND` share target). Implements the spec in
+`docs/ios-share-extension-spec.md`.
+
+The source is complete and lives here:
+
+| File | Purpose |
+| ---- | ------- |
+| `ShareViewController.swift` | Reads shared text/URL, writes `pending_share` to the App Group, opens the host app. No UI. |
+| `Info.plist` | `NSExtension` config + activation rule (text / web URL / web page). |
+| `LifeGlanceShare.entitlements` | App Group `group.com.lifeglance`. |
+
+The app-side hooks are already wired on this branch:
+`WidgetStore.consumePendingShare()` (`WidgetModel.swift`), the `share` field in
+`WidgetBridgePlugin.consumeLaunchTarget`, and the `share` host in
+`AppDelegate.handleWidgetDeepLink`. The web layer already consumes it
+(`TimelineView` → `shareToMilestoneDraft`), so **no JS changes are needed**.
+
+## One remaining step: register the target in Xcode
+
+The Xcode project uses the modern synchronized-folder format (`objectVersion 70`),
+and the target graph (native target, embed-extension build phase, signing) is best
+created through Xcode so provisioning is set up correctly. It is intentionally not
+hand-edited into `project.pbxproj`. To finish:
+
+1. Open `ios/App/App.xcodeproj`.
+2. **File ▸ New ▸ Target… ▸ Share Extension.**
+   - Product name: **LifeGlanceShare**
+   - Bundle identifier: **com.lifeglance.share**
+   - Language: Swift, and **embed in the App target** when prompted.
+3. Xcode generates a `ShareViewController.swift`, an `Info.plist`, and a
+   `MainInterface.storyboard`. **Replace/point them at the files in this folder**
+   and **delete the generated `MainInterface.storyboard`** (this extension has no
+   UI — activation uses `NSExtensionPrincipalClass`, not a storyboard).
+4. In the target's **Build Settings**:
+   - `INFOPLIST_FILE` = `LifeGlanceShare/Info.plist`
+   - `GENERATE_INFOPLIST_FILE` = `YES`
+   - `CODE_SIGN_ENTITLEMENTS` = `LifeGlanceShare/LifeGlanceShare.entitlements`
+   - `IPHONEOS_DEPLOYMENT_TARGET` = `15.0` (match App)
+   - `MARKETING_VERSION` = `2.6.2`, `CURRENT_PROJECT_VERSION` = `1` (match App)
+5. **Signing & Capabilities ▸ + Capability ▸ App Groups**, and check
+   `group.com.lifeglance` (must match the entitlements file above).
+6. Confirm the **App** target's *Embed Foundation Extensions* build phase lists
+   `LifeGlanceShare.appex` (Xcode adds this when you choose "embed in App").
+
+Then `npx cap sync ios` and build. The iOS CI workflow will start covering the
+extension automatically once the target exists.
+
+## Manual test
+
+1. Share plain text from Notes → lifeGLANCE opens with the Add sheet titled from the text.
+2. Share a link from Safari → Add sheet with the URL populated and hostname/title.
+3. Share with an explicit subject/title → subject becomes the title.
+4. Share something empty/unusable → app does not open a blank draft.

--- a/ios/App/LifeGlanceShare/ShareViewController.swift
+++ b/ios/App/LifeGlanceShare/ShareViewController.swift
@@ -1,0 +1,103 @@
+import UIKit
+import UniformTypeIdentifiers
+
+// Share Extension entry point. Receives text / links shared into lifeGLANCE from
+// the iOS share sheet, stashes them in the App Group under "pending_share", then
+// opens the host app — which reads the share via WidgetBridge.consumeLaunchTarget()
+// on resume and opens a pre-filled Add-milestone sheet. This mirrors the Android
+// ACTION_SEND path (MainActivity.handleShareIntent).
+//
+// The payload written is a JSON string { "text": …, "subject": … } (either key
+// optional), the exact shape src/native/shareDraft.js expects.
+//
+// Kept self-contained — it writes to the App Group inline rather than importing the
+// widgets' WidgetStore — so the extension target only needs this one Swift file, the
+// same approach AppDelegate.handleWidgetDeepLink already uses on the app side.
+@objc(ShareViewController)
+final class ShareViewController: UIViewController {
+
+    private let appGroupId = "group.com.lifeglance"
+    private let pendingShareKey = "pending_share"
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        Task {
+            await handleShare()
+            openHostAndFinish()
+        }
+    }
+
+    private func handleShare() async {
+        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else { return }
+
+        var text = ""
+        var subject = ""
+
+        for item in items {
+            // The item's content text (a Safari page title, or text the user typed /
+            // selected) maps to Android's EXTRA_SUBJECT.
+            if subject.isEmpty,
+               let content = item.attributedContentText?.string,
+               !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                subject = content
+            }
+            for provider in item.attachments ?? [] {
+                if text.isEmpty, let url = await loadURL(from: provider) {
+                    // Put the URL into `text` so shareToMilestoneDraft() extracts it,
+                    // exactly like Android's EXTRA_TEXT usually carrying the link.
+                    text = url
+                } else if text.isEmpty, let plain = await loadText(from: provider) {
+                    text = plain
+                }
+            }
+        }
+
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSubject = subject.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty || !trimmedSubject.isEmpty else { return }
+
+        var payload: [String: String] = [:]
+        if !trimmedText.isEmpty { payload["text"] = trimmedText }
+        if !trimmedSubject.isEmpty { payload["subject"] = trimmedSubject }
+
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let json = String(data: data, encoding: .utf8) {
+            UserDefaults(suiteName: appGroupId)?.set(json, forKey: pendingShareKey)
+        }
+    }
+
+    private func loadURL(from provider: NSItemProvider) async -> String? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) else { return nil }
+        let item = try? await provider.loadItem(forTypeIdentifier: UTType.url.identifier)
+        if let url = item as? URL { return url.absoluteString }
+        if let url = item as? NSURL { return url.absoluteString }
+        return nil
+    }
+
+    private func loadText(from provider: NSItemProvider) async -> String? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) else { return nil }
+        let item = try? await provider.loadItem(forTypeIdentifier: UTType.plainText.identifier)
+        if let s = item as? String { return s }
+        if let s = item as? NSString { return s as String }
+        return nil
+    }
+
+    // Bring the host app forward, then finish. An extension can't touch
+    // UIApplication.shared, so walk the responder chain to whoever implements
+    // openURL:. Opening lifeglance://share is enough — the share payload is already
+    // in the App Group; AppDelegate accepts the "share" host as a no-op.
+    private func openHostAndFinish() {
+        if let url = URL(string: "lifeglance://share") {
+            var responder: UIResponder? = self
+            let selector = sel_registerName("openURL:")
+            while let r = responder {
+                if r.responds(to: selector) {
+                    _ = r.perform(selector, with: url)
+                    break
+                }
+                responder = r.next
+            }
+        }
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+}

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -17,6 +17,7 @@ enum WidgetStore {
     static let keySnapshot = "snapshot"
     static let keyPendingTarget = "pending_target"
     static let keyPendingAction = "pending_action"
+    static let keyPendingShare = "pending_share"
 
     private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroupId) }
 
@@ -46,6 +47,18 @@ enum WidgetStore {
         guard let action = defaults?.string(forKey: keyPendingAction) else { return nil }
         defaults?.removeObject(forKey: keyPendingAction)
         return action
+    }
+
+    // A share written by the Share Extension: a JSON string { text, subject }.
+    static func setPendingShare(_ json: String) {
+        defaults?.set(json, forKey: keyPendingShare)
+    }
+
+    // Returns and clears a pending share left by the Share Extension.
+    static func consumePendingShare() -> String? {
+        guard let share = defaults?.string(forKey: keyPendingShare) else { return nil }
+        defaults?.removeObject(forKey: keyPendingShare)
+        return share
     }
 }
 


### PR DESCRIPTION
Implements the native iOS side of "share text/link into lifeGLANCE", matching the Android `ACTION_SEND` share target. Implements the spec in `docs/ios-share-extension-spec.md` (PR #261).

The web/JS layer (`TimelineView` → `consumeWidgetLaunchTarget()` → `shareToMilestoneDraft()`) and the App Group storage already existed; this fills the native gap, so **no JS changes are needed**.

## New `LifeGlanceShare` extension (`ios/App/LifeGlanceShare/`)
- **`ShareViewController.swift`** — no-UI controller that reads the shared text / URL / title, writes a `{ text, subject }` JSON payload to the App Group under `pending_share`, opens the host app, and completes. Self-contained (writes to the App Group inline, the same pattern `AppDelegate` uses) so the target needs only this one Swift file.
- **`Info.plist`** — `NSExtension` share-services config with a text / web-URL / web-page activation rule.
- **`LifeGlanceShare.entitlements`** — App Group `group.com.lifeglance`.

## App-side hooks
- `WidgetStore` gains `setPendingShare` / `consumePendingShare` (`WidgetModel.swift`).
- `WidgetBridgePlugin.consumeLaunchTarget` now returns `share`, mirroring the Android `ret.put("share", …)`.
- `AppDelegate` accepts the `lifeglance://share` host as a no-op (the payload is already stashed by the extension).

## Remaining step (must be done in Xcode)
The Xcode target itself is **not** wired into `project.pbxproj` — the project uses the synchronized-folder format (`objectVersion 70`), and target + signing/provisioning setup belongs in Xcode. `ios/App/LifeGlanceShare/README.md` has the exact 6-step registration (target name, bundle id, build settings, App Group capability, embed phase). The source here is drop-in ready; the extension goes live once the target is registered.

## Validation
Plists parse, Swift brace/paren balance checks pass, and the App Group IDs are consistent across all files. Not compiled (no macOS runner available here).

## Notes
- Depends conceptually on the spec in #261 but has no file overlap with it; the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_