### PR TITLE
chore: untrack stray agent-worktree gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ outputs/
 .DS_Store
 *.local
 .env
+
+# Claude Code agent worktrees (ephemeral; never commit)
+.claude/worktrees/


### PR DESCRIPTION
A Claude Code agent worktree was accidentally committed to `main` as a gitlink (`160000 .claude/worktrees/agent-a9cccff2dd92d7811`, via merge #196) with no matching `.gitmodules` entry. Every `git` checkout/submodule step — in CI and locally — prints:

```
fatal: No url found for submodule path '.claude/worktrees/agent-a9cccff2dd92d7811' in .gitmodules
```

## Changes
- `git rm --cached` the stray gitlink (untracks it; no real data removed — it was only a dangling commit pointer, not an actual submodule).
- Add `.claude/worktrees/` to `.gitignore` so agent worktrees are never committed again.

## Notes
- Warning-only issue (doesn't fail builds), but it's noise on every checkout and cruft in history.
- Confirmed the gitlink was the only tracked path under `.claude/`, so ignoring `.claude/worktrees/` touches no real config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_