### PR TITLE
milestone: clarify pin-color dots (for widgets) + complete milestone i18n

### DIFF
--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -268,8 +268,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
             {canPin && showPinHelp && (
               <div className="detail-pin-help"
                 style={{ fontSize: '0.72rem', opacity: 0.72, lineHeight: 1.45, padding: '0 0 0.55rem' }}>
-                Each colored dot pins this milestone to the matching home-screen
-                countdown widget. Tap a dot to pin it there; tap again to unpin.
+                {t('pinHelp')}
               </div>
             )}
             <div className="sheet-actions">
@@ -286,15 +285,18 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
             </div>
             <div className="sheet-actions-right">
               {canPin && (
-                <div className="detail-pin-slots" title="Pin to a home-screen countdown widget"
+                <div className="detail-pin-slots" title={t('pinCluster')}
                   style={{ display: 'flex', alignItems: 'center', gap: '4px', marginRight: '6px' }}>
                   <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>📌</span>
                   {PIN_SLOTS.map(s => {
                     const active = pins[s.id] === m.id
+                    const label = active
+                      ? t('unpinFromWidget', { color: t(`pinColor_${s.id}`) })
+                      : t('pinToWidget', { color: t(`pinColor_${s.id}`) })
                     return (
                       <button key={s.id} type="button" onClick={() => toggleSlot(s.id)}
-                        title={active ? `Unpin from the ${s.id} widget` : `Pin to the ${s.id} widget`}
-                        aria-label={active ? `Unpin from the ${s.id} widget` : `Pin to the ${s.id} widget`}
+                        title={label}
+                        aria-label={label}
                         aria-pressed={active}
                         style={{
                           width: '18px', height: '18px', borderRadius: '50%', padding: 0,
@@ -305,8 +307,8 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
                     )
                   })}
                   <button type="button" onClick={() => setShowPinHelp(v => !v)}
-                    title="What are these? Pin to a home-screen widget"
-                    aria-label="What do the pin colors do?"
+                    title={t('pinHelpToggle')}
+                    aria-label={t('pinHelpToggle')}
                     aria-expanded={showPinHelp}
                     style={{
                       width: '18px', height: '18px', borderRadius: '50%', padding: 0,

--- a/src/components/milestone/MilestoneDetail.jsx
+++ b/src/components/milestone/MilestoneDetail.jsx
@@ -30,6 +30,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
   const [posterUrl, setPosterUrl] = useState(null) // video poster (from the uploaded thumbnail)
   const [confirm,   setConfirm]   = useState(null)
   const [pins,      setPins]      = useState(readPins)
+  const [showPinHelp, setShowPinHelp] = useState(false)
 
   // Each color slot maps to its own countdown widget. Tapping a slot pins this milestone
   // to it (or clears it), then nudges the widget snapshot to re-push. Native shells only.
@@ -263,7 +264,15 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
             </div>
           </div>
         ) : (
-          <div className="sheet-actions">
+          <>
+            {canPin && showPinHelp && (
+              <div className="detail-pin-help"
+                style={{ fontSize: '0.72rem', opacity: 0.72, lineHeight: 1.45, padding: '0 0 0.55rem' }}>
+                Each colored dot pins this milestone to the matching home-screen
+                countdown widget. Tap a dot to pin it there; tap again to unpin.
+              </div>
+            )}
+            <div className="sheet-actions">
             <div className="detail-delete-group">
               <button className="btn-ghost" onClick={() => setConfirm('single')}>
                 {tc('delete')}
@@ -277,15 +286,15 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
             </div>
             <div className="sheet-actions-right">
               {canPin && (
-                <div className="detail-pin-slots" title="Pin to a countdown widget"
+                <div className="detail-pin-slots" title="Pin to a home-screen countdown widget"
                   style={{ display: 'flex', alignItems: 'center', gap: '4px', marginRight: '6px' }}>
                   <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>📌</span>
                   {PIN_SLOTS.map(s => {
                     const active = pins[s.id] === m.id
                     return (
                       <button key={s.id} type="button" onClick={() => toggleSlot(s.id)}
-                        title={active ? `Unpin from ${s.id} widget` : `Pin to ${s.id} widget`}
-                        aria-label={active ? `Unpin from ${s.id} widget` : `Pin to ${s.id} widget`}
+                        title={active ? `Unpin from the ${s.id} widget` : `Pin to the ${s.id} widget`}
+                        aria-label={active ? `Unpin from the ${s.id} widget` : `Pin to the ${s.id} widget`}
                         aria-pressed={active}
                         style={{
                           width: '18px', height: '18px', borderRadius: '50%', padding: 0,
@@ -295,6 +304,17 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
                         }} />
                     )
                   })}
+                  <button type="button" onClick={() => setShowPinHelp(v => !v)}
+                    title="What are these? Pin to a home-screen widget"
+                    aria-label="What do the pin colors do?"
+                    aria-expanded={showPinHelp}
+                    style={{
+                      width: '18px', height: '18px', borderRadius: '50%', padding: 0,
+                      marginLeft: '2px', border: '1px solid currentColor',
+                      background: 'transparent', color: 'inherit', opacity: showPinHelp ? 0.85 : 0.5,
+                      cursor: 'pointer', fontSize: '0.7rem', lineHeight: 1,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    }}>?</button>
                 </div>
               )}
               <button className="btn" onClick={() => { onClose(); onEdit(m) }}
@@ -303,6 +323,7 @@ export default function MilestoneDetail({ milestone: m, onClose, onEdit, onDelet
               </button>
             </div>
           </div>
+          </>
         )}
       </div>
     </div>

--- a/src/locales/en/milestone.json
+++ b/src/locales/en/milestone.json
@@ -54,5 +54,14 @@
   "visTabInherit": "inherit",
   "visTabShown": "shown",
   "visTabHidden": "hidden",
-  "ageYearsOld": "{{age}} y.o."
+  "ageYearsOld": "{{age}} y.o.",
+  "pinHelp": "Each colored dot pins this milestone to the matching home-screen countdown widget. Tap a dot to pin it there; tap again to unpin.",
+  "pinHelpToggle": "What do the pin colors do?",
+  "pinCluster": "Pin to a home-screen countdown widget",
+  "pinToWidget": "Pin to the {{color}} widget",
+  "unpinFromWidget": "Unpin from the {{color}} widget",
+  "pinColor_amber": "amber",
+  "pinColor_rose": "rose",
+  "pinColor_teal": "teal",
+  "pinColor_blue": "blue"
 }

--- a/src/locales/zh_CN/milestone.json
+++ b/src/locales/zh_CN/milestone.json
@@ -54,5 +54,14 @@
   "photoSyncedFromDevice": "📷 相片附件已保存在来源设备上",
   "mediaSyncedFromDevice": "🎬 音频及视频附件已保存在来源设备上",
   "mediaDownloading": "⬇️ 下载中… {{progress}}",
-  "ageYearsOld": "{{age}}岁"
+  "ageYearsOld": "{{age}}岁",
+  "pinHelp": "每个彩色圆点会将此里程碑固定到对应颜色的主屏幕倒计时小组件。点按圆点即可固定；再次点按即可取消。",
+  "pinHelpToggle": "这些圆点有什么用？",
+  "pinCluster": "固定到主屏幕倒计时小组件",
+  "pinToWidget": "固定到{{color}}小组件",
+  "unpinFromWidget": "从{{color}}小组件取消固定",
+  "pinColor_amber": "琥珀色",
+  "pinColor_rose": "玫瑰色",
+  "pinColor_teal": "青色",
+  "pinColor_blue": "蓝色"
 }

--- a/src/locales/zh_HK/milestone.json
+++ b/src/locales/zh_HK/milestone.json
@@ -54,5 +54,14 @@
   "photoSyncedFromDevice": "📷 相片附件已儲存在來源裝置上",
   "mediaSyncedFromDevice": "🎬 音訊及影片附件已儲存在來源裝置上",
   "mediaDownloading": "⬇️ 下載中… {{progress}}",
-  "ageYearsOld": "{{age}}歲"
+  "ageYearsOld": "{{age}}歲",
+  "pinHelp": "每個彩色圓點會將此里程碑固定至對應顏色的主畫面倒數小工具。點按圓點即可固定；再次點按即可取消。",
+  "pinHelpToggle": "這些圓點有什麼用？",
+  "pinCluster": "固定至主畫面倒數小工具",
+  "pinToWidget": "固定至{{color}}小工具",
+  "unpinFromWidget": "從{{color}}小工具取消固定",
+  "pinColor_amber": "琥珀色",
+  "pinColor_rose": "玫瑰色",
+  "pinColor_teal": "青色",
+  "pinColor_blue": "藍色"
 }


### PR DESCRIPTION
A user pointed out the colored pin dots in the milestone detail view aren't clearly labeled — it's not obvious they control the home-screen widgets. Fixing that turned into completing the `milestone` namespace across all locales.

## 1. Pin clarification
- Added a small tappable **`?`** after the pin dots that toggles a short inline explanation:
  > Each colored dot pins this milestone to the matching home-screen countdown widget. Tap a dot to pin it there; tap again to unpin.
- The `?` toggles an inline line (works on touch, unlike the previous hover-only `title`, which never showed on mobile — and this is a native-only feature). Also reworded the hover/aria labels.

## 2. Localized the pin strings
Moved all the new pin strings (help text, `?` toggle label, cluster/per-dot titles, four slot color names) into the `milestone` i18n namespace — no hardcoded UI English.

## 3. Completed the `milestone` namespace in every locale
While here, filled the **pre-existing** gap: de/es/fr/it/pt were each missing 9 milestone keys (`applyToSeries*`, `repeatData*`, `mediaDownloading`) that had been falling back to English. Translated those too.

**Result: all 8 locales (de, en, es, fr, it, pt, zh_CN, zh_HK) are now at full 65-key parity for `milestone` — no English fallback anywhere in this namespace.**

## Verified
- `npm run build` passes; ESLint clean (the one remaining warning is pre-existing, in the unrelated video-poster effect).
- Full key parity across all 8 locale files (verified programmatically); all parse.
- The pin UI is native-gated, so it doesn't render in the web preview.

## Review note
en / zh_CN / zh_HK I'm confident in. The **de/es/fr/it/pt strings are machine translations** (reusing each locale's existing terminology) and deserve a native pass — particularly the interpolated pin color names, where gender/agreement varies by language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)