### PR TITLE
i18n: complete milestone locale parity (de, es, fr, it, pt)

### DIFF
--- a/src/locales/de/milestone.json
+++ b/src/locales/de/milestone.json
@@ -54,5 +54,14 @@
   "pinColor_amber": "Bernstein",
   "pinColor_rose": "Rosa",
   "pinColor_teal": "Petrol",
-  "pinColor_blue": "Blau"
+  "pinColor_blue": "Blau",
+  "applyToSeries": "auf alle jährlichen Vorkommen anwenden",
+  "applyToSeriesWarning": "↻ wiederholt sich jährlich — jedes jährliche Vorkommen wird bearbeitet",
+  "applyToSeriesNote": "Überträgt Titel, Kategorie, Notiz, Link und Sichtbarkeit auf jedes Jahr. Datum und angehängte Medien bleiben nur bei diesem Vorkommen.",
+  "repeatDataLabel": "auf jedes Jahr übertragen:",
+  "repeatDataNote": "Notiz",
+  "repeatDataLink": "Link",
+  "repeatDataPhoto": "Foto",
+  "repeatDataMedia": "Audio / Video",
+  "mediaDownloading": "⬇️ Wird heruntergeladen… {{progress}}"
 }

--- a/src/locales/de/milestone.json
+++ b/src/locales/de/milestone.json
@@ -45,5 +45,14 @@
   "visTabInherit": "erben",
   "visTabShown": "sichtbar",
   "visTabHidden": "verborgen",
-  "ageYearsOld": "{{age}} J."
+  "ageYearsOld": "{{age}} J.",
+  "pinHelp": "Jeder farbige Punkt heftet diesen Meilenstein an das passende Countdown-Widget auf dem Startbildschirm. Tippe auf einen Punkt, um ihn dort anzuheften; erneut tippen, um ihn zu lösen.",
+  "pinHelpToggle": "Wofür sind die farbigen Punkte?",
+  "pinCluster": "An ein Countdown-Widget auf dem Startbildschirm anheften",
+  "pinToWidget": "An das {{color}}-Widget anheften",
+  "unpinFromWidget": "Vom {{color}}-Widget lösen",
+  "pinColor_amber": "Bernstein",
+  "pinColor_rose": "Rosa",
+  "pinColor_teal": "Petrol",
+  "pinColor_blue": "Blau"
 }

--- a/src/locales/es/milestone.json
+++ b/src/locales/es/milestone.json
@@ -45,5 +45,14 @@
   "visTabInherit": "heredar",
   "visTabShown": "visible",
   "visTabHidden": "oculto",
-  "ageYearsOld": "{{age}} años"
+  "ageYearsOld": "{{age}} años",
+  "pinHelp": "Cada punto de color fija este hito en el widget de cuenta atrás correspondiente de la pantalla de inicio. Toca un punto para fijarlo ahí; vuelve a tocarlo para quitarlo.",
+  "pinHelpToggle": "¿Para qué sirven los puntos de color?",
+  "pinCluster": "Fijar en un widget de cuenta atrás de la pantalla de inicio",
+  "pinToWidget": "Fijar en el widget {{color}}",
+  "unpinFromWidget": "Quitar del widget {{color}}",
+  "pinColor_amber": "ámbar",
+  "pinColor_rose": "rosa",
+  "pinColor_teal": "verde azulado",
+  "pinColor_blue": "azul"
 }

--- a/src/locales/es/milestone.json
+++ b/src/locales/es/milestone.json
@@ -54,5 +54,14 @@
   "pinColor_amber": "ámbar",
   "pinColor_rose": "rosa",
   "pinColor_teal": "verde azulado",
-  "pinColor_blue": "azul"
+  "pinColor_blue": "azul",
+  "applyToSeries": "aplicar a todas las ocurrencias anuales",
+  "applyToSeriesWarning": "↻ se repite cada año — se editan todas las ocurrencias anuales",
+  "applyToSeriesNote": "Aplica el título, la categoría, la nota, el enlace y la visibilidad a cada año. La fecha y los archivos adjuntos permanecen solo en esta ocurrencia.",
+  "repeatDataLabel": "aplicar a cada año:",
+  "repeatDataNote": "nota",
+  "repeatDataLink": "enlace",
+  "repeatDataPhoto": "foto",
+  "repeatDataMedia": "audio / vídeo",
+  "mediaDownloading": "⬇️ Descargando… {{progress}}"
 }

--- a/src/locales/fr/milestone.json
+++ b/src/locales/fr/milestone.json
@@ -45,5 +45,14 @@
   "visTabInherit": "hériter",
   "visTabShown": "affiché",
   "visTabHidden": "masqué",
-  "ageYearsOld": "{{age}} ans"
+  "ageYearsOld": "{{age}} ans",
+  "pinHelp": "Chaque point coloré épingle ce jalon au widget de compte à rebours correspondant sur l'écran d'accueil. Touchez un point pour l'y épingler ; touchez à nouveau pour le retirer.",
+  "pinHelpToggle": "À quoi servent les points colorés ?",
+  "pinCluster": "Épingler à un widget de compte à rebours de l'écran d'accueil",
+  "pinToWidget": "Épingler au widget {{color}}",
+  "unpinFromWidget": "Retirer du widget {{color}}",
+  "pinColor_amber": "ambre",
+  "pinColor_rose": "rose",
+  "pinColor_teal": "sarcelle",
+  "pinColor_blue": "bleu"
 }

--- a/src/locales/fr/milestone.json
+++ b/src/locales/fr/milestone.json
@@ -54,5 +54,14 @@
   "pinColor_amber": "ambre",
   "pinColor_rose": "rose",
   "pinColor_teal": "sarcelle",
-  "pinColor_blue": "bleu"
+  "pinColor_blue": "bleu",
+  "applyToSeries": "appliquer à toutes les occurrences annuelles",
+  "applyToSeriesWarning": "↻ se répète chaque année — modification de chaque occurrence annuelle",
+  "applyToSeriesNote": "Applique le titre, la catégorie, la note, le lien et la visibilité à chaque année. La date et les médias joints restent uniquement sur cette occurrence.",
+  "repeatDataLabel": "appliquer à chaque année :",
+  "repeatDataNote": "note",
+  "repeatDataLink": "lien",
+  "repeatDataPhoto": "photo",
+  "repeatDataMedia": "audio / vidéo",
+  "mediaDownloading": "⬇️ Téléchargement… {{progress}}"
 }

--- a/src/locales/it/milestone.json
+++ b/src/locales/it/milestone.json
@@ -45,5 +45,14 @@
   "visTabInherit": "eredita",
   "visTabShown": "visibile",
   "visTabHidden": "nascosto",
-  "ageYearsOld": "{{age}} anni"
+  "ageYearsOld": "{{age}} anni",
+  "pinHelp": "Ogni punto colorato fissa questo traguardo al widget conto alla rovescia corrispondente nella schermata Home. Tocca un punto per fissarlo lì; tocca di nuovo per rimuoverlo.",
+  "pinHelpToggle": "A cosa servono i punti colorati?",
+  "pinCluster": "Fissa a un widget conto alla rovescia della schermata Home",
+  "pinToWidget": "Fissa al widget {{color}}",
+  "unpinFromWidget": "Rimuovi dal widget {{color}}",
+  "pinColor_amber": "ambra",
+  "pinColor_rose": "rosa",
+  "pinColor_teal": "verde acqua",
+  "pinColor_blue": "blu"
 }

--- a/src/locales/it/milestone.json
+++ b/src/locales/it/milestone.json
@@ -54,5 +54,14 @@
   "pinColor_amber": "ambra",
   "pinColor_rose": "rosa",
   "pinColor_teal": "verde acqua",
-  "pinColor_blue": "blu"
+  "pinColor_blue": "blu",
+  "applyToSeries": "applica a tutte le occorrenze annuali",
+  "applyToSeriesWarning": "↻ si ripete ogni anno — modifica di ogni occorrenza annuale",
+  "applyToSeriesNote": "Applica titolo, categoria, nota, link e visibilità a ogni anno. La data e i media allegati restano solo su questa occorrenza.",
+  "repeatDataLabel": "applica a ogni anno:",
+  "repeatDataNote": "nota",
+  "repeatDataLink": "link",
+  "repeatDataPhoto": "foto",
+  "repeatDataMedia": "audio / video",
+  "mediaDownloading": "⬇️ Download in corso… {{progress}}"
 }

--- a/src/locales/pt/milestone.json
+++ b/src/locales/pt/milestone.json
@@ -54,5 +54,14 @@
   "pinColor_amber": "âmbar",
   "pinColor_rose": "rosa",
   "pinColor_teal": "verde-azulado",
-  "pinColor_blue": "azul"
+  "pinColor_blue": "azul",
+  "applyToSeries": "aplicar a todas as ocorrências anuais",
+  "applyToSeriesWarning": "↻ repete-se anualmente — editando todas as ocorrências anuais",
+  "applyToSeriesNote": "Aplica o título, a categoria, a nota, o link e a visibilidade a cada ano. A data e as mídias anexadas permanecem apenas nesta ocorrência.",
+  "repeatDataLabel": "aplicar a cada ano:",
+  "repeatDataNote": "nota",
+  "repeatDataLink": "link",
+  "repeatDataPhoto": "foto",
+  "repeatDataMedia": "áudio / vídeo",
+  "mediaDownloading": "⬇️ Baixando… {{progress}}"
 }

--- a/src/locales/pt/milestone.json
+++ b/src/locales/pt/milestone.json
@@ -45,5 +45,14 @@
   "visTabInherit": "herdar",
   "visTabShown": "visível",
   "visTabHidden": "oculto",
-  "ageYearsOld": "{{age}} anos"
+  "ageYearsOld": "{{age}} anos",
+  "pinHelp": "Cada ponto colorido fixa este marco no widget de contagem regressiva correspondente na tela inicial. Toque em um ponto para fixá-lo ali; toque novamente para remover.",
+  "pinHelpToggle": "Para que servem os pontos coloridos?",
+  "pinCluster": "Fixar em um widget de contagem regressiva da tela inicial",
+  "pinToWidget": "Fixar no widget {{color}}",
+  "unpinFromWidget": "Remover do widget {{color}}",
+  "pinColor_amber": "âmbar",
+  "pinColor_rose": "rosa",
+  "pinColor_teal": "verde-azulado",
+  "pinColor_blue": "azul"
 }


### PR DESCRIPTION
Lands the two `pin-widget-hint` commits that #265's merge left behind (its merge commit's parent was the en/zh_CN/zh_HK localization, before these were pushed). Without this, `main` ships German/Spanish/French/Italian/Portuguese with English fallbacks for the pin hint and nine older milestone keys.

Cherry-picked cleanly onto current `main`:
- `milestone: translate pin-widget hint into de, es, fr, it, pt` — the `pin*` keys.
- `i18n: fill pre-existing milestone gaps in de, es, fr, it, pt` — `applyToSeries*`, `repeatData*`, `mediaDownloading`.

## Result
`milestone.json` now at **full 65-key parity across all 8 locales** (de/es/fr/it/pt were stuck at 47) — no English fallback anywhere in the namespace.

## Verified
All five files parse; key counts equal `en` for every locale.

## Note
The de/es/fr/it/pt strings are machine translations reusing each locale's existing terminology — worth a native pass, especially the interpolated pin color names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_