### PR TITLE
Bump version to 2.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), [lastGLANCE](https://github.com/krelltunez/lastGLANCE) (recent upkeep), and lifeGLANCE (your whole timeline).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.6.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.6.3-green.svg)](../../releases)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release bump: `package.json`, `package-lock.json`, and the README version badge to `2.6.3`.

## Why patch
Everything since 2.6.2 is fixes, localization, and one small UX clarification. No new user-facing feature, no breaking change for this app.

## Notable changes since 2.6.2
- **Sync reliability** (`@glance-apps/sync` 1.5.3 to 1.6.0): fixes a case where a newer local edit could be silently lost to a peer's delete, and a case where an entity could vanish across devices after a failed sync push. (The library's "delete no longer always wins" note is a data-integrity fix; lifeGLANCE does not rely on delete-always-wins semantics, so it is not breaking here.)
- **Pin-color dots** in milestone detail now explain they control the home-screen countdown widgets.
- **Translations**: full milestone parity across all eight languages (de, en, es, fr, it, pt, zh_CN, zh_HK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_