### PR TITLE
Fix relative-day labels around noon and day boundaries

### DIFF
--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -2,7 +2,7 @@ import {
   differenceInYears,
   differenceInMonths,
   differenceInDays,
-  isPast,
+  differenceInCalendarDays,
 } from 'date-fns'
 import i18n from '../i18n'
 import { safeLocale } from './locale'
@@ -43,19 +43,25 @@ function toLocalNoon(dateStr) {
 export function relativeParts(dateStr) {
   const date = toLocalNoon(dateStr)
   const now  = new Date()
-  const past = isPast(date) && date < now
-  const from = past ? date : now
-  const to   = past ? now  : date
+  // Day distance in CALENDAR days so the time of day never leaks in. The
+  // previous raw 24h diff against the noon-normalized date misclassified
+  // around noon: before local noon, today read as "in 0 days" and yesterday
+  // as "today"; late in the evening, tomorrow read as "in 0 days".
+  const dayDiff = differenceInCalendarDays(date, now)
+  if (dayDiff === 0) return { key: 'relToday', today: true }
+
+  const past  = dayDiff < 0
+  const days  = Math.abs(dayDiff)
+  const from  = past ? date : now
+  const to    = past ? now  : date
   const tense  = past ? 'Past' : 'Future'
   const years  = differenceInYears(to, from)
   const months = differenceInMonths(to, from) % 12
-  const days   = differenceInDays(to, from)
 
   if (years > 0 && months > 0) return { key: `rel${tense}YrMo`, count: years, months }
   if (years > 0)               return { key: `rel${tense}Yr`,   count: years }
   if (days > 30)               return { key: `rel${tense}Mo`,   count: Math.floor(days / 30) }
-  if (past ? days > 0 : days >= 0) return { key: `rel${tense}Day`, count: days }
-  return { key: 'relToday', today: true }
+  return { key: `rel${tense}Day`, count: days }
 }
 
 export function relativeLabel(dateStr, _precision = 'day') {

--- a/src/utils/dates.test.js
+++ b/src/utils/dates.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest'
 import {
   buildDateFromParts,
   formatDateDisplay,
@@ -125,6 +125,29 @@ describe('monthNames', () => {
 describe('relativeParts', () => {
   it('returns the today key for the current date', () => {
     expect(relativeParts(isoDaysFromNow(0))).toEqual({ key: 'relToday', today: true })
+  })
+
+  // Day classification must not depend on the time of day (the raw 24h diff
+  // against noon-normalized dates used to call today "in 0 days" before local
+  // noon and tomorrow "in 0 days" late in the evening).
+  describe('around day boundaries', () => {
+    afterEach(() => vi.useRealTimers())
+
+    // Local calendar date string for `offset` days from the (mocked) now.
+    function isoLocal(offset = 0) {
+      const d = new Date()
+      d.setDate(d.getDate() + offset)
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    }
+
+    for (const hour of [0, 9, 12, 23]) {
+      it(`classifies correctly at ${String(hour).padStart(2, '0')}:30 local`, () => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 16, hour, 30, 0) })
+        expect(relativeParts(isoLocal(0))).toEqual({ key: 'relToday', today: true })
+        expect(relativeParts(isoLocal(1))).toEqual({ key: 'relFutureDay', count: 1 })
+        expect(relativeParts(isoLocal(-1))).toEqual({ key: 'relPastDay', count: 1 })
+      })
+    }
   })
 
   it('uses past day keys for recent past dates', () => {


### PR DESCRIPTION
`relativeParts()` normalized dates to local noon and then measured raw 24-hour differences, so day classification leaked the time of day:

- Before local noon, **today's date rendered "in 0 days"** instead of "today", and **yesterday rendered "today"**.
- Late in the evening, **tomorrow rendered "in 0 days"**.

Its two "today" tests had the same dependence and only failed when the suite ran before local noon — which is how this surfaced (the suite was green all evening, then failed at 01:25).

## Fix

Classify day distance with `differenceInCalendarDays`, which is time-of-day independent; the `relToday` short-circuit happens first and the month/year math is unchanged. `isPast` import dropped (no longer used).

## Tests

- The two previously time-sensitive tests now pass at any hour.
- New boundary regression tests pin today/tomorrow/yesterday classification at 00:30, 09:30, 12:30, and 23:30 via mocked clocks.
- Full suite: 350/350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNvy9eqwWuL9HJWxTfURD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNvy9eqwWuL9HJWxTfURD8)_