### PR TITLE
Clarify dayGLANCE credential label as WebDAV app password

### DIFF
--- a/src/locales/de/dayglance.json
+++ b/src/locales/de/dayglance.json
@@ -13,7 +13,7 @@
   "enableLinking": "Ziel↔Meilenstein-Verknüpfung aktivieren",
   "webdavUrl": "WebDAV-Basis-URL",
   "username": "Benutzername",
-  "passwordToken": "Passwort / Token",
+  "passwordToken": "WebDAV-App-Passwort",
   "eventsPath": "Ereignispfad",
   "eventsPathDefault": "(Standard: /GLANCE/events/)",
   "testing": "wird getestet…",

--- a/src/locales/en/dayglance.json
+++ b/src/locales/en/dayglance.json
@@ -20,7 +20,7 @@
   "vaultNotConfigured": "GLANCEvault isn't set up yet. Configure it in Cloud Sync first, then intents will deliver over the vault.",
   "webdavUrl": "WebDAV base URL",
   "username": "Username",
-  "passwordToken": "Password / token",
+  "passwordToken": "WebDAV app password",
   "eventsPath": "Events path",
   "eventsPathDefault": "(default: /GLANCE/events/)",
   "testing": "testing…",

--- a/src/locales/es/dayglance.json
+++ b/src/locales/es/dayglance.json
@@ -13,7 +13,7 @@
   "enableLinking": "activar vinculación Objetivo↔Hito",
   "webdavUrl": "URL base WebDAV",
   "username": "Nombre de usuario",
-  "passwordToken": "Contraseña / token",
+  "passwordToken": "contraseña de aplicación WebDAV",
   "eventsPath": "Ruta de eventos",
   "eventsPathDefault": "(predeterminado: /GLANCE/events/)",
   "testing": "probando…",

--- a/src/locales/fr/dayglance.json
+++ b/src/locales/fr/dayglance.json
@@ -13,7 +13,7 @@
   "enableLinking": "activer la liaison Objectif↔Jalon",
   "webdavUrl": "URL de base WebDAV",
   "username": "Nom d'utilisateur",
-  "passwordToken": "Mot de passe / jeton",
+  "passwordToken": "mot de passe d'application WebDAV",
   "eventsPath": "Chemin des événements",
   "eventsPathDefault": "(défaut : /GLANCE/events/)",
   "testing": "test en cours…",

--- a/src/locales/it/dayglance.json
+++ b/src/locales/it/dayglance.json
@@ -13,7 +13,7 @@
   "enableLinking": "abilita collegamento Obiettivo↔Traguardo",
   "webdavUrl": "URL base WebDAV",
   "username": "Nome utente",
-  "passwordToken": "Password / token",
+  "passwordToken": "password dell'app WebDAV",
   "eventsPath": "Percorso eventi",
   "eventsPathDefault": "(predefinito: /GLANCE/events/)",
   "testing": "test in corso…",

--- a/src/locales/pt/dayglance.json
+++ b/src/locales/pt/dayglance.json
@@ -13,7 +13,7 @@
   "enableLinking": "ativar vinculação Objetivo↔Marco",
   "webdavUrl": "URL base WebDAV",
   "username": "Nome de usuário",
-  "passwordToken": "Senha / token",
+  "passwordToken": "senha do aplicativo WebDAV",
   "eventsPath": "Caminho dos eventos",
   "eventsPathDefault": "(padrão: /GLANCE/events/)",
   "testing": "testando…",

--- a/src/locales/zh_CN/dayglance.json
+++ b/src/locales/zh_CN/dayglance.json
@@ -20,7 +20,7 @@
   "vaultNotConfigured": "请先完成「云端同步」的「GLANCEvault同步」设定，事件将经由Vault传送",
   "webdavUrl": "WebDAV服务器地址",
   "username": "用户名 (User)",
-  "passwordToken": "密码 / 令牌",
+  "passwordToken": "WebDAV 密码 (Password)",
   "eventsPath": "Events存放路径",
   "eventsPathDefault": "(预设: /GLANCE/events/)",
   "testing": "测试中…",

--- a/src/locales/zh_HK/dayglance.json
+++ b/src/locales/zh_HK/dayglance.json
@@ -20,7 +20,7 @@
   "vaultNotConfigured": "請先完成「雲端同步」的「GLANCEvault同步」設定，事件將經由Vault傳送",
   "webdavUrl": "WebDAV伺服器地址",
   "username": "用戶名 (User)",
-  "passwordToken": "密碼 / 令牌",
+  "passwordToken": "WebDAV 密碼 (Password)",
   "eventsPath": "Events存放路徑",
   "eventsPathDefault": "(預設: /GLANCE/events/)",
   "testing": "測試中…",


### PR DESCRIPTION
## Summary

Renames the dayGLANCE integration credential field from the vague `Password / token` to `WebDAV app password` across all eight locales.

This follows from the discussion on PR #259, where @win2ter raised that the app's several distinct secrets (WebDAV app password, sync passphrase, GLANCEvault device token, dayGLANCE token) can be hard to tell apart at the prompt. Reviewing the source, the credentials are already labeled descriptively and scoped to their own titled sections, with one exception: this dayGLANCE field. `Password / token` did not say which credential it was and read as conceptually close to the GLANCEvault `Device token`.

The field is actually the WebDAV app password for the integration's WebDAV endpoint. It is rendered directly under the WebDAV base URL and username in `IntegrationSettings.jsx`. Naming it `WebDAV app password` anchors it to the endpoint above it and matches how Cloud Sync already labels its WebDAV credential (`app password`). This is consistent descriptive naming in the source, not a per-locale nickname, so it carries to every language.

## Changes

- `src/locales/{de,en,es,fr,it,pt,zh_CN,zh_HK}/dayglance.json`: `passwordToken` value updated per locale, matching each language's existing "app password" wording.

| Locale | Value |
|---|---|
| en | WebDAV app password |
| de | WebDAV-App-Passwort |
| es | contraseña de aplicación WebDAV |
| fr | mot de passe d'application WebDAV |
| it | password dell'app WebDAV |
| pt | senha do aplicativo WebDAV |
| zh_CN | WebDAV 密码 (Password) |
| zh_HK | WebDAV 密碼 (Password) |

No UI code changes; the label key is unchanged. All eight files validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WycAT4sHi5QrqkmMRRx3Hh)_