### PR TITLE
Android WebDAV fixes (lastGLANCE #232/#233) + vite plugin bump

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -110,6 +110,10 @@ dependencies {
     // Home-screen widgets (Jetpack Glance, Kotlin/Compose)
     implementation "androidx.glance:glance-appwidget:$rootProject.ext.glanceVersion"
     implementation "androidx.work:work-runtime-ktx:2.9.1"
+
+    // OkHttp backs WebDavHttpPlugin — HttpURLConnection (behind CapacitorHttp)
+    // rejects WebDAV verbs like PROPFIND/MKCOL; OkHttp accepts any method.
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
 
     testImplementation "junit:junit:$junitVersion"

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -24,6 +24,7 @@ public class MainActivity extends BridgeActivity {
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(WidgetBridgePlugin.class);
         registerPlugin(BillingBridgePlugin.class);
+        registerPlugin(WebDavHttpPlugin.class);
         super.onCreate(savedInstanceState);
         handleWidgetIntent(getIntent());
         handleShareIntent(getIntent());

--- a/android/app/src/main/java/com/lifeglance/app/WebDavHttpPlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/WebDavHttpPlugin.java
@@ -1,0 +1,108 @@
+package com.lifeglance.app;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp-backed HTTP for the WebDAV verbs (PROPFIND, MKCOL, …) that Android's
+ * HttpURLConnection — the backend behind CapacitorHttp — rejects with
+ * ProtocolException ("Invalid HTTP method"). OkHttp accepts arbitrary methods.
+ *
+ * Routed from src/sync/nativeHttp.js for non-core verbs on Android only; iOS's
+ * URLSession accepts arbitrary verbs and needs no equivalent. See lastGLANCE
+ * issue #233 and docs/android-webdav-audit.md.
+ *
+ * Contract (mirrors the CapacitorHttp response shape nativeRequest consumes):
+ *   request({ method, url, headers, data }) -> { status, headers: {..}, data: string }
+ */
+@CapacitorPlugin(name = "WebDavHttp")
+public class WebDavHttpPlugin extends Plugin {
+
+    private final OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .build();
+
+    @PluginMethod
+    public void request(PluginCall call) {
+        String method = call.getString("method");
+        String url = call.getString("url");
+        if (method == null || url == null) {
+            call.reject("method and url are required");
+            return;
+        }
+        String data = call.getString("data", "");
+
+        Headers.Builder headerBuilder = new Headers.Builder();
+        String contentType = "application/octet-stream";
+        JSObject headers = call.getObject("headers");
+        if (headers != null) {
+            Iterator<String> keys = headers.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                String value = headers.optString(key, null);
+                if (value == null) continue;
+                headerBuilder.add(key, value);
+                if ("content-type".equalsIgnoreCase(key)) contentType = value;
+            }
+        }
+
+        // OkHttp requires a (possibly empty) body for methods that expect one and
+        // forbids one on GET/HEAD. PROPFIND carries an XML body; MKCOL has none.
+        RequestBody requestBody = null;
+        boolean bodyForbidden = "GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method);
+        if (!bodyForbidden) {
+            if (data != null && data.length() > 0) {
+                requestBody = RequestBody.create(data, MediaType.parse(contentType));
+            } else if (requiresBody(method)) {
+                requestBody = RequestBody.create(new byte[0], null);
+            }
+        }
+
+        Request request = new Request.Builder()
+                .url(url)
+                .method(method, requestBody)
+                .headers(headerBuilder.build())
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            JSObject responseHeaders = new JSObject();
+            Headers rh = response.headers();
+            for (int i = 0; i < rh.size(); i++) {
+                responseHeaders.put(rh.name(i), rh.value(i));
+            }
+            ResponseBody rb = response.body();
+            String responseText = rb != null ? rb.string() : "";
+
+            JSObject ret = new JSObject();
+            ret.put("status", response.code());
+            ret.put("headers", responseHeaders);
+            ret.put("data", responseText);
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("WebDAV request failed: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean requiresBody(String method) {
+        return "POST".equalsIgnoreCase(method)
+                || "PUT".equalsIgnoreCase(method)
+                || "PATCH".equalsIgnoreCase(method)
+                || "PROPPATCH".equalsIgnoreCase(method);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "8.1.2",
         "@capacitor/ios": "^8.4.0",
-        "@capacitor/share": "7.0.2",
+        "@capacitor/share": "8.0.1",
         "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.1",
@@ -2129,12 +2129,12 @@
       }
     },
     "node_modules/@capacitor/share": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-7.0.2.tgz",
-      "integrity": "sha512-VyNPo/9831xnL17IMDeft5yNdBjoKNb451P95sRcr69hulRDqHc+kndqOVaMXnaA6IyBdWnnFv/n1HUf4cXpGw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
+      "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/synapse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",
+        "@capacitor/filesystem": "8.1.2",
         "@capacitor/ios": "^8.4.0",
+        "@capacitor/share": "7.0.2",
         "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.1",
@@ -2137,6 +2139,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.2.tgz",
+      "integrity": "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.0.tgz",
@@ -2145,6 +2159,21 @@
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
       }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-7.0.2.tgz",
+      "integrity": "sha512-VyNPo/9831xnL17IMDeft5yNdBjoKNb451P95sRcr69hulRDqHc+kndqOVaMXnaA6IyBdWnnFv/n1HUf4cXpGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@capacitor/assets": "^3.0.5",
         "@capacitor/cli": "^8.4.0",
         "@eslint/js": "^9.39.4",
-        "@vitejs/plugin-react": "^4.3.1",
+        "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -1219,38 +1219,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
       "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3167,9 +3135,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3948,51 +3916,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4081,24 +4004,29 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -10326,16 +10254,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -10870,13 +10788,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^8.4.0",
     "@eslint/js": "^9.39.4",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "@capacitor/android": "^8.4.0",
     "@capacitor/core": "^8.4.0",
+    "@capacitor/filesystem": "8.1.2",
     "@capacitor/ios": "^8.4.0",
+    "@capacitor/share": "7.0.2",
     "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@capacitor/core": "^8.4.0",
     "@capacitor/filesystem": "8.1.2",
     "@capacitor/ios": "^8.4.0",
-    "@capacitor/share": "7.0.2",
+    "@capacitor/share": "8.0.1",
     "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.1",

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import Timeline          from './Timeline'
 import { collectCssVariables } from './exportImageHelpers'
+import { saveOrShareFile } from '../../native/saveFile'
 import { shareToMilestoneDraft } from '../../native/shareDraft'
 import StatsPanel        from '../stats/StatsPanel'
 import AddMilestoneSheet from '../milestone/AddMilestoneSheet'
@@ -1364,19 +1365,19 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       ctx.fillText('GLANCE', brandPad + lifeW, brandY)
       ctx.restore()
 
-      canvas.toBlob(blob => {
+      canvas.toBlob(async blob => {
         const d = new Date()
         const stamp = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
-        const a = document.createElement('a')
-        a.download = `lifeglance-${stamp}.png`
-        a.href = URL.createObjectURL(blob)
-        document.body.appendChild(a)
-        a.click()
-        document.body.removeChild(a)
-        setTimeout(() => URL.revokeObjectURL(a.href), 100)
+        try {
+          await saveOrShareFile({ filename: `lifeglance-${stamp}.png`, blob })
+        } catch (err) {
+          console.error('Export failed:', err)
+          showToast(t('exportFailed'), 'error')
+        }
       }, 'image/png')
     } catch (err) {
       console.error('Export failed:', err)
+      showToast(t('exportFailed'), 'error')
     }
   }
 
@@ -1418,14 +1419,14 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
     }
     const json = JSON.stringify(payload, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
-    const url  = URL.createObjectURL(blob)
-    const a    = document.createElement('a')
-    a.href     = url
     const d    = new Date()
     const stamp = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
-    a.download = `lifeglance-${stamp}.json`
-    a.click()
-    URL.revokeObjectURL(url)
+    try {
+      await saveOrShareFile({ filename: `lifeglance-${stamp}.json`, blob })
+    } catch (err) {
+      console.error('Backup export failed:', err)
+      showToast(t('exportFailed'), 'error')
+    }
   }
 
   // Categories changed in Settings (add / rename / recolor / delete). The list

--- a/src/locales/de/timeline.json
+++ b/src/locales/de/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "vor {{count}} Jahr",
   "yearsAgo_other": "vor {{count}} Jahren",
   "mediaVaultDeferred": "Lokal gespeichert — die Synchronisierung dieser Medien in die Cloud wird in Kürze erneut versucht.",
-  "mediaUnavailable": "Medien nicht verfügbar"
+  "mediaUnavailable": "Medien nicht verfügbar",
+  "exportFailed": "Die Datei konnte nicht gespeichert werden. Bitte versuche es erneut."
 }

--- a/src/locales/en/timeline.json
+++ b/src/locales/en/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "{{count}} year ago",
   "yearsAgo_other": "{{count}} years ago",
   "mediaVaultDeferred": "Saved locally — syncing this media to the cloud will retry shortly.",
-  "mediaUnavailable": "media unavailable"
+  "mediaUnavailable": "media unavailable",
+  "exportFailed": "Couldn’t save the file. Please try again."
 }

--- a/src/locales/es/timeline.json
+++ b/src/locales/es/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "hace {{count}} año",
   "yearsAgo_other": "hace {{count}} años",
   "mediaVaultDeferred": "Guardado localmente: la sincronización de este medio con la nube se reintentará en breve.",
-  "mediaUnavailable": "medio no disponible"
+  "mediaUnavailable": "medio no disponible",
+  "exportFailed": "No se pudo guardar el archivo. Inténtalo de nuevo."
 }

--- a/src/locales/fr/timeline.json
+++ b/src/locales/fr/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "il y a {{count}} an",
   "yearsAgo_other": "il y a {{count}} ans",
   "mediaVaultDeferred": "Enregistré localement — la synchronisation de ce média vers le cloud sera réessayée sous peu.",
-  "mediaUnavailable": "média indisponible"
+  "mediaUnavailable": "média indisponible",
+  "exportFailed": "Impossible d’enregistrer le fichier. Réessaie."
 }

--- a/src/locales/it/timeline.json
+++ b/src/locales/it/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "{{count}} anno fa",
   "yearsAgo_other": "{{count}} anni fa",
   "mediaVaultDeferred": "Salvato localmente — la sincronizzazione di questo media nel cloud verrà ritentata a breve.",
-  "mediaUnavailable": "media non disponibile"
+  "mediaUnavailable": "media non disponibile",
+  "exportFailed": "Impossibile salvare il file. Riprova."
 }

--- a/src/locales/pt/timeline.json
+++ b/src/locales/pt/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "há {{count}} ano",
   "yearsAgo_other": "há {{count}} anos",
   "mediaVaultDeferred": "Salvo localmente — a sincronização desta mídia com a nuvem será tentada novamente em breve.",
-  "mediaUnavailable": "mídia indisponível"
+  "mediaUnavailable": "mídia indisponível",
+  "exportFailed": "Não foi possível salvar o arquivo. Tente novamente."
 }

--- a/src/locales/zh_CN/timeline.json
+++ b/src/locales/zh_CN/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "{{count}}年前",
   "yearsAgo_other": "{{count}}年前",
   "mediaVaultDeferred": "保存到本机——稍后将同步媒体到云端。",
-  "mediaUnavailable": "媒体不可用"
+  "mediaUnavailable": "媒体不可用",
+  "exportFailed": "无法保存文件，请重试。"
 }

--- a/src/locales/zh_HK/timeline.json
+++ b/src/locales/zh_HK/timeline.json
@@ -61,5 +61,6 @@
   "yearsAgo_one": "{{count}}年前",
   "yearsAgo_other": "{{count}}年前",
   "mediaVaultDeferred": "儲存至本機-稍後將同步媒體到雲端。",
-  "mediaUnavailable": "媒體不可用"
+  "mediaUnavailable": "媒體不可用",
+  "exportFailed": "無法儲存檔案，請重試。"
 }

--- a/src/native/saveFile.js
+++ b/src/native/saveFile.js
@@ -1,0 +1,54 @@
+import { isNativePlatform } from '../sync/nativeHttp'
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(reader.error || new Error('file read failed'))
+    reader.onload = () => {
+      const s = String(reader.result)
+      const comma = s.indexOf(',')
+      resolve(comma >= 0 ? s.slice(comma + 1) : s) // strip the data: URL prefix
+    }
+    reader.readAsDataURL(blob)
+  })
+}
+
+// Deliver a generated file (image export, JSON backup, …) to the user.
+//
+// On web this is the classic URL.createObjectURL + <a download> anchor. In a
+// Capacitor Android WebView that anchor is a silent no-op — the shell installs
+// no DownloadListener, so the click does nothing and the export appears dead
+// (lastGLANCE #233). On native we instead write the file to the app cache via
+// @capacitor/filesystem and open the system share sheet via @capacitor/share.
+//
+// Returns true when delivered, false when the user dismissed the share sheet (a
+// cancel, not an error). Throws on real failures so callers can surface them.
+export async function saveOrShareFile({ filename, blob }) {
+  if (!isNativePlatform()) {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.download = filename
+    a.href = url
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setTimeout(() => URL.revokeObjectURL(url), 100)
+    return true
+  }
+
+  // Dynamic import so the plugin code isn't pulled into the web bundle.
+  const [{ Filesystem, Directory }, { Share }] = await Promise.all([
+    import('@capacitor/filesystem'),
+    import('@capacitor/share'),
+  ])
+  const data = await blobToBase64(blob)
+  const { uri } = await Filesystem.writeFile({ path: filename, data, directory: Directory.Cache })
+  try {
+    await Share.share({ title: filename, url: uri, dialogTitle: filename })
+    return true
+  } catch (err) {
+    const msg = String(err?.message ?? err).toLowerCase()
+    if (msg.includes('cancel') || msg.includes('abort') || msg.includes('dismiss')) return false
+    throw err
+  }
+}

--- a/src/sync/nativeHttp.js
+++ b/src/sync/nativeHttp.js
@@ -3,16 +3,47 @@
 // A native WebView enforces CORS exactly like a browser, and lifeGLANCE's sync
 // was built around a server-side CORS proxy whose URL resolves to localhost
 // inside the shell. So on native we bypass the proxy entirely and hit the
-// WebDAV server directly through the native HTTP stack via CapacitorHttp.
+// WebDAV server directly through the native HTTP stack.
 //
-// CapacitorHttp.request() is called directly (no global fetch patch), so the
-// browser/PWA build is untouched — every caller gates on isNativePlatform().
+// Two Android-specific hazards are handled here (both also fixed engine-side in
+// @glance-apps/sync 1.6.1, but the transport is where they originate):
+//
+//  1. Non-core verbs. WebDAV needs PROPFIND (listing / connection test) and
+//     MKCOL (folder creation). CapacitorHttp's Android backend is
+//     HttpURLConnection, whose setRequestMethod() throws ProtocolException
+//     ("Invalid HTTP method: PROPFIND") for anything outside the HTTP/1.1 core
+//     set. So those verbs are routed through a small OkHttp-backed plugin
+//     (WebDavHttp) on Android, which accepts any method. iOS's URLSession
+//     already accepts arbitrary verbs, so iOS stays on CapacitorHttp. This fixes
+//     the sync engine's own PROPFIND/MKCOL (issued via electronProxyFetch) and
+//     the app's calls alike (lastGLANCE issue #233).
+//
+//  2. ETag mangling. HttpURLConnection requests gzip implicitly; Apache
+//     mod_deflate then rewrites the ETag to "xyz-gzip" (nginx downgrades strong
+//     ETags to weak, W/"xyz"), which breaks If-Match and wedges file sync in a
+//     permanent 412 loop (issue #232). We send Accept-Encoding: identity to stop
+//     the mangling at the source, and normalize any validator that still slips
+//     through with the engine's exported helper.
+//
+// Every caller gates on isNativePlatform(), so the browser/PWA build is untouched.
 
-import { Capacitor, CapacitorHttp } from '@capacitor/core'
+import { Capacitor, CapacitorHttp, registerPlugin } from '@capacitor/core'
+import { normalizeEtag } from '@glance-apps/sync'
 
 export const isNativePlatform = () => Capacitor.isNativePlatform()
 
-// Case-insensitive header lookup (native header casing varies by platform).
+// OkHttp-backed transport for WebDAV verbs HttpURLConnection rejects.
+const WebDavHttp = registerPlugin('WebDavHttp')
+
+// Verbs HttpURLConnection (hence CapacitorHttp) accepts. Anything else must go
+// through OkHttp on Android.
+const CORE_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'])
+function needsOkHttp(method) {
+  return Capacitor.getPlatform() === 'android' && !CORE_METHODS.has(String(method).toUpperCase())
+}
+
+// Case-insensitive header lookup (native header casing varies by platform:
+// "ETag", "Etag", or lowercase "etag" over HTTP/2).
 function headerGet(headers, name) {
   if (!headers) return null
   const lower = name.toLowerCase()
@@ -24,15 +55,16 @@ function headerGet(headers, name) {
 
 // Low-level direct request. Returns a normalized result the adapters reshape.
 // Exported so the vault fetch adapter (nativeVaultFetch.js) can reuse the same
-// CapacitorHttp primitive the WebDAV/intents transports use.
+// primitive the WebDAV/intents transports use.
 export async function nativeRequest(method, url, headers, body) {
-  const res = await CapacitorHttp.request({
-    method,
-    url,
-    headers,
-    data: body ?? undefined,
-    responseType: 'text',
-  })
+  // Force an unencoded response so a content-coding filter can't mangle the
+  // ETag. Callers may override by passing their own Accept-Encoding.
+  const reqHeaders = { 'Accept-Encoding': 'identity', ...headers }
+
+  const res = needsOkHttp(method)
+    ? await WebDavHttp.request({ method, url, headers: reqHeaders, data: body ?? '' })
+    : await CapacitorHttp.request({ method, url, headers: reqHeaders, data: body ?? undefined, responseType: 'text' })
+
   const bodyText =
     typeof res.data === 'string' ? res.data
       : res.data == null ? ''
@@ -40,7 +72,10 @@ export async function nativeRequest(method, url, headers, body) {
   return {
     status: res.status,
     ok: res.status >= 200 && res.status < 300,
-    etag: headerGet(res.headers, 'etag'),
+    // Strip any W/ prefix or -gzip/-br suffix that survived, so the engine's
+    // If-Match round-trips the entity's real validator (the engine also
+    // normalizes on its download path; this is idempotent belt-and-suspenders).
+    etag: normalizeEtag(headerGet(res.headers, 'etag')),
     body: bodyText,
   }
 }

--- a/src/sync/nativeHttp.test.js
+++ b/src/sync/nativeHttp.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Shared, hoisted so the @capacitor/core mock factory can close over them.
+const h = vi.hoisted(() => ({ platform: 'android', capHttp: vi.fn(), webdav: vi.fn() }))
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => true, getPlatform: () => h.platform },
+  CapacitorHttp: { request: h.capHttp },
+  registerPlugin: () => ({ request: h.webdav }),
+}))
+
+// normalizeEtag is the REAL implementation from @glance-apps/sync.
+const { nativeRequest, nativeWebdavFetch } = await import('./nativeHttp.js')
+
+beforeEach(() => {
+  h.capHttp.mockReset()
+  h.webdav.mockReset()
+  h.platform = 'android'
+})
+
+describe('nativeHttp transport (#232 ETag / #233 verbs)', () => {
+  it('sends Accept-Encoding: identity to stop mod_deflate mangling the ETag', async () => {
+    h.capHttp.mockResolvedValue({ status: 200, headers: { ETag: '"abc"' }, data: '{}' })
+    await nativeRequest('GET', 'https://dav/x', { Authorization: 'Basic z' })
+    expect(h.capHttp.mock.calls[0][0].headers['Accept-Encoding']).toBe('identity')
+  })
+
+  it('caller Accept-Encoding overrides the identity default', async () => {
+    h.capHttp.mockResolvedValue({ status: 200, headers: {}, data: '' })
+    await nativeRequest('GET', 'https://dav/x', { 'Accept-Encoding': 'gzip' })
+    expect(h.capHttp.mock.calls[0][0].headers['Accept-Encoding']).toBe('gzip')
+  })
+
+  it('normalizes a weak + -gzip-mangled ETag read from a case-varied header', async () => {
+    h.capHttp.mockResolvedValue({ status: 200, headers: { Etag: 'W/"abc-gzip"' }, data: '{}' })
+    const r = await nativeRequest('GET', 'https://dav/x', {})
+    expect(r.etag).toBe('"abc"')
+  })
+
+  it('leaves a clean ETag untouched and passes a missing one through as null', async () => {
+    h.capHttp.mockResolvedValueOnce({ status: 200, headers: { etag: '"clean"' }, data: '' })
+    expect((await nativeRequest('GET', 'https://dav/x', {})).etag).toBe('"clean"')
+    h.capHttp.mockResolvedValueOnce({ status: 200, headers: {}, data: '' })
+    expect((await nativeRequest('GET', 'https://dav/x', {})).etag).toBe(null)
+  })
+
+  it('routes PROPFIND through the OkHttp plugin on Android', async () => {
+    h.webdav.mockResolvedValue({ status: 207, headers: {}, data: '<multistatus/>' })
+    const r = await nativeRequest('PROPFIND', 'https://dav/dir/', {}, '<propfind/>')
+    expect(h.webdav).toHaveBeenCalledTimes(1)
+    expect(h.capHttp).not.toHaveBeenCalled()
+    expect(r.status).toBe(207)
+  })
+
+  it('routes MKCOL through the OkHttp plugin on Android', async () => {
+    h.webdav.mockResolvedValue({ status: 201, headers: {}, data: '' })
+    await nativeRequest('MKCOL', 'https://dav/dir/', {})
+    expect(h.webdav).toHaveBeenCalledTimes(1)
+    expect(h.capHttp).not.toHaveBeenCalled()
+  })
+
+  it('keeps core verbs (GET/PUT/DELETE) on CapacitorHttp', async () => {
+    h.capHttp.mockResolvedValue({ status: 200, headers: {}, data: '' })
+    for (const m of ['GET', 'PUT', 'DELETE']) await nativeRequest(m, 'https://dav/x', {}, 'b')
+    expect(h.capHttp).toHaveBeenCalledTimes(3)
+    expect(h.webdav).not.toHaveBeenCalled()
+  })
+
+  it('on iOS, PROPFIND stays on CapacitorHttp (URLSession accepts any verb)', async () => {
+    h.platform = 'ios'
+    h.capHttp.mockResolvedValue({ status: 207, headers: {}, data: '<x/>' })
+    await nativeRequest('PROPFIND', 'https://dav/dir/', {})
+    expect(h.capHttp).toHaveBeenCalledTimes(1)
+    expect(h.webdav).not.toHaveBeenCalled()
+  })
+
+  it('nativeWebdavFetch matches the electronProxyFetch contract with a normalized etag', async () => {
+    h.capHttp.mockResolvedValue({ status: 200, headers: { etag: 'W/"v1"' }, data: '{"a":1}' })
+    const r = await nativeWebdavFetch('GET', 'https://dav/x', {})
+    expect(r).toMatchObject({ status: 200, ok: true, statusText: '', headers: { etag: '"v1"' }, body: '{"a":1}' })
+  })
+})


### PR DESCRIPTION
Audit of lifeGLANCE for the Android-only WebDAV/sync bugs fixed in lastGLANCE (#232/#233), plus a build-tooling follow-up. lifeGLANCE shares lastGLANCE's transport — **CapacitorHttp** passed to the engine as `electronProxyFetch` — so #2 and #3 apply. Tests pass (400), lint clean, web build green.

## Findings by bug class

**#1 — Engine bump: already done.** `@glance-apps/sync` is exact-pinned at 1.6.1 (the #232 fix). The transport now also reuses its exported `normalizeEtag`.

**#2 — ETag mangling / 412 loop: applied, fixed.** The ETag header lookup was already case-insensitive. Added `Accept-Encoding: identity` (stops Android's implicit gzip → Apache mod_deflate rewriting the ETag to `"xyz-gzip"` at the source) and transport-level `normalizeEtag` (belt-and-suspenders with engine 1.6.1). Covered by 9 new tests in `nativeHttp.test.js`.

**#3 — PROPFIND/MKCOL rejected on Android: applied (broadly), fixed.** CapacitorHttp's HttpURLConnection backend throws `ProtocolException` on non-core verbs. This broke, on Android: the engine's MKCOL folder-create and PROPFIND connection test / auto-backup listing (all via `electronProxyFetch`), plus the app's own MKCOL (folder creation) and PROPFIND (dayGLANCE integration test). Core GET/PUT sync survives, so it hid in try/catches. Fix: route non-core verbs through a new OkHttp-backed `WebDavHttpPlugin` on Android only (one switch in `nativeHttp.js` fixes engine + app); iOS/URLSession untouched.

**#4 — Dead export buttons: applied, fixed.** The timeline PNG export and JSON backup used `<a download>` + `a.click()` (a silent no-op in the Android WebView) and swallowed errors. New `src/native/saveFile.js` keeps the anchor on web and, on native, writes to app cache via `@capacitor/filesystem` + opens the share sheet via `@capacitor/share` (dismissal = cancel). Failures now surface via toast (`exportFailed`, 8 locales). No silent pre-restore snapshot exists, so that sub-case didn't apply.

**#5 — Provider-key mismatch: does not apply.** lifeGLANCE always populates both `webdavUrl` and `nextcloudUrl` for every provider (`CloudSyncModal`, `buildWebdavConfig`), so there's no missing-key gate or `undefined/...` Koofr URL, and no app-level `_getBackupDirUrl`.

## Build tooling

**Upgrade `@vitejs/plugin-react` 4 → 6.** The earlier `npm audit fix` bumped vite 8.0.8 → 8.1.5 (rolldown), which made plugin-react 4's esbuild JSX option throw a noisy `Invalid key: … "jsx"` warning on every dev/build. plugin-react 6 uses the oxc transform for rolldown-vite; the dev log is clean again.

## Verified vs. flagged

- **Verified here:** 400 tests (+9 transport), lint 0 errors, web build green, and a dev render of the paywall + reviewer flow with no runtime errors on the new vite plugin.
- **Could NOT verify (no Android SDK / cap sync in this env) — needs a local build:**
  1. `WebDavHttpPlugin.java` + the `okhttp:4.12.0` gradle dep must compile (`npm run build:mobile` / Android Studio).
  2. `@capacitor/filesystem` + `@capacitor/share` need `cap sync` to wire into the native projects; iOS needs `pod install` on a Mac.
  3. On-device smoke test: WebDAV connection test / first-time folder creation / auto-backup listing on Android, and the PNG/JSON export share sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWPPmTD9jprSw5GScAJ2Mn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWPPmTD9jprSw5GScAJ2Mn)_