### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.6.3;
+				MARKETING_VERSION = 3.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
@@ -387,7 +387,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.6.3;
+				MARKETING_VERSION = 3.0.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance.LifeGlanceWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.3;
+				MARKETING_VERSION = 3.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -549,7 +549,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.3;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "2.6.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "2.6.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "2.6.3",
+  "version": "3.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps the app to 3.0.0 for the first Android production release on Google Play, marking the billing/paywall milestone (51 commits since v2.6.3).

## Changes

- `package.json` / `package-lock.json` → 3.0.0 — source of truth for Android; Gradle derives `versionName` and the packed `versionCode` from it.
- `ios/App/App.xcodeproj/project.pbxproj` → `MARKETING_VERSION = 3.0.0` in all four build configs, applied via `scripts/sync-ios-version.mjs` (same approach as the 2.6.3 sync).

## Notes

- Major bump rationale: introduction of billing/paywall (`@glance-apps/billing`) plus the first Play production release — a milestone on par with the v2.0.0 cloud-sync release. No breaking changes to existing user data.
- README version badge is intentionally left at 2.6.3 until the store release is approved; the GitHub release/tag will follow then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUXfb7VxqrFVGYteMU9HaF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUXfb7VxqrFVGYteMU9HaF)_