### PR TITLE
ci: harden GHCR multi-arch publish for old-client ARM64 pulls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -157,6 +160,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
+          sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Ports the container-publish hardening from our sibling repo dayGLANCE (PRs #1258 and #1259) into lifeGLANCE.

## Background

dayGLANCE had a user report `no matching manifest for linux/arm64/v8` when pulling on ARM64 (Raspberry Pi / Apple Silicon). The image was already multi-arch — the arm64 manifest was present the whole time. The failure was a **pull-side manifest-resolution bug in older Docker/containerd clients**, triggered by the provenance/SBOM attestation manifests that buildx adds to the image index.

## Verified current state (before this change)

Inspecting the live `ghcr.io/krelltunez/lifeglance:latest` index confirms lifeGLANCE is in the **same** situation:

```
linux/amd64      image
linux/arm64      image
unknown/unknown  attestation-manifest
unknown/unknown  attestation-manifest
```

So arm64 **is already built and published** — this is **pull-side / old-client compatibility hardening, not an arm64 build fix**. The two `unknown/unknown` attestation-manifest entries are exactly what trips up older clients.

## Changes

Both are safe hardening for the `publish-to-ghcr` job in `.github/workflows/docker.yml`:

- **Add a `Set up QEMU` step** before `Set up Docker Buildx` — makes the arm64 emulation build explicit rather than relying on the runner having binfmt pre-registered (from #1258).
- **`provenance: false` + `sbom: false`** on the `docker/build-push-action` step — drops the attestation side-manifests so the published index is a clean list of just the amd64 + arm64 images that old clients resolve reliably (from #1259, the change that addresses the reported symptom).

## Notes / deliberately omitted

- The `# check=skip=FromPlatformFlagConstDisallowed` parser directive from #1258 is **not needed** here — this repo's `Dockerfile` uses plain `FROM node:20-alpine AS builder`, not a `--platform`-pinned builder stage.
- **No version bump.** arm64 is already published, and the workflow has a `workflow_dispatch` button to republish `latest` without cutting a release, so no version bump is required to pick up the cleaner index.
- **No desktop/Electron tag-triggered workflow** exists in this repo, so there's no unwanted release build to guard against.

## After merge

Trigger a rebuild (`workflow_dispatch` on `latest`, or the next release) and re-inspect the manifest — expect exactly `linux/amd64` and `linux/arm64`, with no `unknown/unknown` entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHC24r32CMM4RLPJEjEiQj)_