### PR TITLE
Bump Play Billing to 8.3.0 via @glance-apps/billing 0.2.0

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -19,5 +19,5 @@ ext {
     glanceVersion = '1.1.1'
 
     // Play Billing client used by the :glance-apps-billing module
-    playBillingVersion = '7.1.1'
+    playBillingVersion = '8.3.0'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@capacitor/filesystem": "8.1.2",
         "@capacitor/ios": "^8.4.0",
         "@capacitor/share": "8.0.1",
-        "@glance-apps/billing": "0.1.1",
+        "@glance-apps/billing": "0.2.0",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.1",
         "date-fns": "^3.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.1.tgz",
-      "integrity": "sha512-7dayiwwDAEyhZbtwtg1GOj9uJixCIS2kI/qXx12S63ec+sbrgNlXFkJ+MpgV/pE04Mq5ndJo8DiYJmGnDfjI9Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.2.0.tgz",
+      "integrity": "sha512-LG+WTxGIIjJspqVbU3WfpIqys71I7JSTn60xe2vY7jbcLlRouxbX7UQt0In3bJfV0dzpLtqvFEzx1OhwUQmbTA==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@capacitor/filesystem": "8.1.2",
     "@capacitor/ios": "^8.4.0",
     "@capacitor/share": "8.0.1",
-    "@glance-apps/billing": "0.1.1",
+    "@glance-apps/billing": "0.2.0",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

Moves the Android app onto Google Play Billing Library 8, per Google's advisory requiring apps to target Billing 8.

The BillingClient integration lives in the `@glance-apps/billing` dependency, not this repo — so this is two coordinated version bumps:

- **`android/variables.gradle`**: `playBillingVersion` `7.1.1` → **`8.3.0`**. The `:glance-apps-billing` module reads this ext var to resolve `com.android.billingclient:billing-ktx`.
- **`@glance-apps/billing`**: `0.1.1` → **`0.2.0`** (`package.json` + `package-lock.json`). This is the release whose native `PlayBillingCore` adopts Billing 8's changed `queryProductDetailsAsync` callback — the second parameter is now a `QueryProductDetailsResult`, read via `.productDetailsList` (previously a `List<ProductDetails>`).

## Why so small

The rest of the integration was already forward-compatible with Billing 8's breaking changes:

| Billing 8 change | Status |
|---|---|
| `queryProductDetailsAsync` callback → `QueryProductDetailsResult` | Fixed in `@glance-apps/billing` 0.2.0 (3 call sites) |
| `enablePendingPurchases()` no-arg removed | Already used `PendingPurchasesParams` |
| Legacy `queryPurchasesAsync(skuType, …)` removed | Already used `QueryPurchasesParams` |
| `ProrationMode` → `ReplacementMode`, `setOldSkuPurchaseToken` | N/A — no subscription upgrade/downgrade flow |
| minSdk raised to 23 | App is minSdk 24 |
| targetSdk raised to 35 | App is targetSdk 36 |

No app-side or JS changes needed — the Capacitor bridge contract is unaffected.

## Verification

- `@glance-apps/billing` 0.2.0's native source uses `queryResult.productDetailsList` at all three `queryProductDetailsAsync` sites; its own `billing-ktx` floor is `8.3.0`.
- `npm install` resolves cleanly; the installed module is 0.2.0 on the Billing 8 source, and the lockfile matches the registry metadata (no churn).
- No stale `0.1.1` billing references remain.

## Testing

Not build-verified in CI here (no Android SDK in the authoring environment). Reviewer will test on a real device — recommend exercising the `play`-channel build's purchase flow: annual trial, lifetime one-time purchase, acknowledgement, and the debug `consumeTestPurchase` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpUm8ZAnkWjiQWom47EY2x)_