### PR TITLE
Take @glance-apps/sync 1.10.0 (backoff, credential halt, quota)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@capacitor/share": "8.0.1",
         "@glance-apps/billing": "0.2.1",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.6.1",
+        "@glance-apps/sync": "1.10.0",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2488,9 +2488,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.1.tgz",
-      "integrity": "sha512-cRdLWkX7AreC4h0Gz0lnxum/Nn/uq4OO+Jcjjxq8e4uhT5c3Z25kBDXXbA5VxLw5HGtHYBQanTy4QuYyTzBspw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.10.0.tgz",
+      "integrity": "sha512-/OCQZPm/dsv6OmOMdXj8gjmbKR9F/eXaJdr/8BR7Rs04ScxaSdw1ozSu5cejfLyziMHaelcBecaeKVK8wvmF8A==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@capacitor/share": "8.0.1",
     "@glance-apps/billing": "0.2.1",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.6.1",
+    "@glance-apps/sync": "1.10.0",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/locales/de/sync.json
+++ b/src/locales/de/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "Der Sync-Server akzeptiert den Sync-Zugriff dieses Geräts nicht mehr. Deine Änderungen sind auf diesem Gerät gespeichert. Bitte die Person, die deinen Sync-Server betreibt, den Zugriff für dieses Gerät wiederherzustellen.",
+  "quotaExceeded": "Der Sync-Server hat das Limit für dieses Konto erreicht. Deine Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitte die Person, die deinen Sync-Server betreibt, das Limit zu erhöhen.",
   "webdavSectionTitle": "WebDAV-Synchronisierung",
   "webdavEnableLabel": "Über WebDAV synchronisieren",
   "webdavEnableNote": "Mit jedem WebDAV-Server synchronisieren (Nextcloud, ownCloud usw.). Schalte dies aus, um deine Verbindungsdaten zu behalten, aber die Synchronisierung auf diesem Gerät zu stoppen — zum Beispiel beim vollständigen Wechsel zu GLANCEvault.",

--- a/src/locales/en/sync.json
+++ b/src/locales/en/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "The sync server no longer accepts this device's sync access. Your changes are saved on this device. Ask whoever runs your sync server to restore access for this device.",
+  "quotaExceeded": "The sync server has reached its limit for this account. Your changes are saved on this device and syncing will retry automatically. Ask whoever runs your sync server to raise the limit.",
   "webdavSectionTitle": "WebDAV sync",
   "webdavEnableLabel": "Sync via WebDAV",
   "webdavEnableNote": "Sync to any WebDAV server (Nextcloud, ownCloud, etc.). Turn this off to keep your connection details but stop syncing on this device — for example when moving fully to GLANCEvault.",

--- a/src/locales/es/sync.json
+++ b/src/locales/es/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "El servidor de sincronización ya no acepta el acceso de este dispositivo. Tus cambios están guardados en este dispositivo. Pide a quien administra tu servidor de sincronización que restaure el acceso para este dispositivo.",
+  "quotaExceeded": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite.",
   "webdavSectionTitle": "sincronización WebDAV",
   "webdavEnableLabel": "Sincronizar mediante WebDAV",
   "webdavEnableNote": "Sincroniza con cualquier servidor WebDAV (Nextcloud, ownCloud, etc.). Desactiva esto para conservar tus datos de conexión pero detener la sincronización en este dispositivo, por ejemplo al pasarte por completo a GLANCEvault.",

--- a/src/locales/fr/sync.json
+++ b/src/locales/fr/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "Le serveur de synchronisation n'accepte plus l'accès de cet appareil. Vos modifications sont enregistrées sur cet appareil. Demandez à la personne qui gère votre serveur de synchronisation de rétablir l'accès pour cet appareil.",
+  "quotaExceeded": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite.",
   "webdavSectionTitle": "synchronisation WebDAV",
   "webdavEnableLabel": "Synchroniser via WebDAV",
   "webdavEnableNote": "Synchronise avec n'importe quel serveur WebDAV (Nextcloud, ownCloud, etc.). Désactive ceci pour conserver tes informations de connexion tout en arrêtant la synchronisation sur cet appareil — par exemple lors d'un passage complet à GLANCEvault.",

--- a/src/locales/it/sync.json
+++ b/src/locales/it/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "Il server di sincronizzazione non accetta più l'accesso di questo dispositivo. Le tue modifiche sono salvate su questo dispositivo. Chiedi a chi gestisce il tuo server di sincronizzazione di ripristinare l'accesso per questo dispositivo.",
+  "quotaExceeded": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite.",
   "webdavSectionTitle": "sincronizzazione WebDAV",
   "webdavEnableLabel": "Sincronizza tramite WebDAV",
   "webdavEnableNote": "Sincronizza con qualsiasi server WebDAV (Nextcloud, ownCloud, ecc.). Disattiva questa opzione per mantenere i dati di connessione ma interrompere la sincronizzazione su questo dispositivo — ad esempio quando passi completamente a GLANCEvault.",

--- a/src/locales/pt/sync.json
+++ b/src/locales/pt/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "Enter your sync passphrase to continue.",
   "appIdMismatch": "This sync data belongs to a different app.",
   "schemaForwardIncompatible": "This sync data is from a newer app version — please update the app.",
+  "credentialInvalid": "O servidor de sincronização não aceita mais o acesso deste dispositivo. Suas alterações estão salvas neste dispositivo. Peça a quem administra seu servidor de sincronização que restaure o acesso para este dispositivo.",
+  "quotaExceeded": "O servidor de sincronização atingiu o limite desta conta. Suas alterações estão salvas neste dispositivo e a sincronização tentará novamente automaticamente. Peça a quem administra seu servidor de sincronização que aumente o limite.",
   "webdavSectionTitle": "sincronização WebDAV",
   "webdavEnableLabel": "Sincronizar via WebDAV",
   "webdavEnableNote": "Sincronize com qualquer servidor WebDAV (Nextcloud, ownCloud, etc.). Desative isto para manter seus dados de conexão mas parar a sincronização neste dispositivo — por exemplo, ao migrar totalmente para o GLANCEvault.",

--- a/src/locales/zh_CN/sync.json
+++ b/src/locales/zh_CN/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "输入加密金钥以继续同步",
   "appIdMismatch": "此同步数据属于其他应用程序",
   "schemaForwardIncompatible": "请更新APP: 此同步数据来自较新的版本",
+  "credentialInvalid": "同步服务器不再接受此设备的同步访问。您的更改已保存在本设备上。请联系同步服务器的管理者恢复此设备的访问权限。",
+  "quotaExceeded": "同步服务器已达到此帐号的容量上限。您的更改已保存在本设备上，同步将自动重试。请联系同步服务器的管理者提高上限。",
   "webdavSectionTitle": "「WebDAV同步」",
   "webdavEnableLabel": "启用「WebDAV同步」",
   "webdavEnableNote": "同步至「WebDAV」服务器(如 Nextcloud, ownCloud…)。关闭后将保留连线设定，但「WebDAV同步」会停止—例如当您完全转用「GLANCEvault同步」。",

--- a/src/locales/zh_HK/sync.json
+++ b/src/locales/zh_HK/sync.json
@@ -64,6 +64,8 @@
   "passphraseRequired": "輸入加密金鑰以繼續同步",
   "appIdMismatch": "此同步資料屬於其他應用程式",
   "schemaForwardIncompatible": "請更新APP: 此同步資料來自較新的版本",
+  "credentialInvalid": "同步伺服器不再接受此裝置的同步存取。您的變更已儲存在本裝置上。請聯絡同步伺服器的管理者恢復此裝置的存取權限。",
+  "quotaExceeded": "同步伺服器已達到此帳號的容量上限。您的變更已儲存在本裝置上，同步將自動重試。請聯絡同步伺服器的管理者提高上限。",
   "webdavSectionTitle": "「WebDAV同步」",
   "webdavEnableLabel": "啟用「WebDAV同步」",
   "webdavEnableNote": "同步至「WebDAV」伺服器(如 Nextcloud, ownCloud…)。關閉後將保留連線設定，但「WebDAV同步」會停止—例如當您完全轉用「GLANCEvault同步」。",

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -227,7 +227,14 @@ export const initDbSyncEngine = (opts = {}) => {
   // runs ensureRootKey (salt establishment), so bootstrap the blob/intents key
   // here too — a backgrounded first write can establish the salt before any
   // full sync does.
+  //
+  // Honour the sync 1.10 credential halt here as well: pushDirtyRows is a raw
+  // primitive with no halt guard, so without this check every local edit on a
+  // halted device would fire one doomed (401) batch request. The halt is
+  // terminal by design — the cycle stops, and so should push-on-write. Rows
+  // stay marked dirty, so everything pushes once access is restored.
   const pushNow = async () => {
+    if (engine.isCredentialHalted?.()) return { written: 0, deleted: 0, halted: true }
     await seedSnapshot()
     const r = await engine.pushDirtyRows()
     await bootstrapIntentsRootKey()

--- a/src/sync/dbSync.test.js
+++ b/src/sync/dbSync.test.js
@@ -181,4 +181,40 @@ describe('Stage 2 Part B — DB sync engine wiring', () => {
     }
     expect(fired).toBeGreaterThan(0)
   })
+
+  // The sync 1.10 credential halt must gate push-on-write too: pushDirtyRows is
+  // a raw primitive with no halt guard, so pushNow checks the halt itself.
+  // Local edits stay dirty and push once access is restored via recovery.
+  it('push-on-write goes silent under the sync 1.10 credential halt', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    await m.setupDbRootKey('pw', new Uint8Array(16).fill(9), { cryptoDBName: 'lifeglance-crypto' })
+
+    let batchCalls = 0
+    let reject = true
+    const realBatch = vault.batch
+    vault.batch = async (app, payload) => {
+      batchCalls += 1
+      if (reject) {
+        const err = new Error("batch upsert failed: 401 — the server rejected this device's credential")
+        err.code = 'CREDENTIAL_INVALID'
+        err.status = 401
+        throw err
+      }
+      return realBatch(app, payload)
+    }
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await m.milestones.addMilestone({ title: 'Doomed write', date: new Date('2021-01-01') })
+    await dbSync.sync().catch(() => {})   // cycle hits the coded 401 → engine halts
+    expect(dbSync.engine.isCredentialHalted()).toBe(true)
+
+    reject = false                        // server would accept again; the halt is terminal anyway
+    const before = batchCalls
+    const res = await dbSync.pushNow()
+    expect(batchCalls).toBe(before)       // no network attempt from push-on-write
+    expect(res).toEqual({ written: 0, deleted: 0, halted: true })
+  })
 })

--- a/src/sync/status.js
+++ b/src/sync/status.js
@@ -20,10 +20,15 @@ export const isSyncing = (status) =>
 //   APP_ID_MISMATCH             — the remote file belongs to a different app.
 //   SCHEMA_FORWARD_INCOMPATIBLE — the remote file is from a newer app version.
 //
-// GLANCEvault database-transport codes (inert until that cutover; lifeGLANCE is
-// WebDAV-only today, but the mapping keeps the presentation layer ready):
+// GLANCEvault database-transport codes (vault DB sync is opt-in alongside
+// WebDAV; note the vault engine's onError is not yet wired into the UI — the
+// mapping keeps the presentation layer ready for when it is):
 //   KEY_MISMATCH         — wrong sync passphrase for this account's existing data.
 //   VERIFIER_UNSUPPORTED — the sync server is too old to host the key verifier.
+//   CREDENTIAL_INVALID   — the vault revoked this device's token; the engine
+//                          hard-halts the cycle (sync 1.10+, isHardStop true).
+//   QUOTA_EXCEEDED       — the vault reports the account over quota; pushes
+//                          back off and retry automatically (sync 1.10+).
 //
 // ACCOUNT_ID_REQUIRED is intentionally absent: it's a benign, retryable startup
 // race handled (suppressed) in the engine's onError, not surfaced as an error.
@@ -41,9 +46,11 @@ export const SYNC_ERROR_I18N_KEYS = {
   PASSPHRASE_REQUIRED: 'passphraseRequired',
   APP_ID_MISMATCH: 'appIdMismatch',
   SCHEMA_FORWARD_INCOMPATIBLE: 'schemaForwardIncompatible',
-  // GLANCEvault database transport (inert until cutover)
+  // GLANCEvault database transport
   KEY_MISMATCH: 'wrongPassphrase',
   VERIFIER_UNSUPPORTED: 'verifierUnsupported',
+  CREDENTIAL_INVALID: 'credentialInvalid',
+  QUOTA_EXCEEDED: 'quotaExceeded',
 }
 
 // Resolves an error object ({ message, code }) to display text, translating


### PR DESCRIPTION
Bumps `@glance-apps/sync` 1.6.1 → 1.10.0, the prerequisite for the SSE push port (lifeGLANCE twin of lastGLANCE's #246). lifeGLANCE drives the package's own cycle (`engine.sync` = `dbSyncCycle`), so the 1.10 behavior arrives through the version change itself:

- **Self-enforcing backoff**: transport failures open per-half windows (30s base doubling, push cap 900s / pull cap 300s, flat 1h for auth-shaped 401s); polled cycles inside a window skip the network.
- **`CREDENTIAL_INVALID` hard halt**: a 401 with the server's `"invalid credential"` body halts the cycle terminally (recovery is user-initiated), surfaced once via `onError(message, code, isHardStop=true)`.
- **`QUOTA_EXCEEDED`**: a 413 with the quota-shaped body surfaces with its own backoff reason; retryable, not a halt.

## API compatibility

All nine imported symbols (`createDbSyncEngine`, `getSyncPassphrase`, `normalizeEtag`, `mergeArrayById`, `pruneTombstones`, `createSyncEngine`, `createVaultClient`, `setSyncPassphrase`, `setupDbRootKey`) and every engine method in use (`sync`, `pushDirtyRows`, `markDirty`, `vault.getSalt`) exist unchanged in 1.10.0. The pre-existing suite passed on 1.10.0 with zero modifications before any other change was made.

## One behavioral companion: halt-gate `pushNow`

`pushNow` (the debounced push-on-write) calls the `pushDirtyRows` primitive, which deliberately carries no halt guard — so a credential-halted device would still fire one doomed 401 batch per local edit. `pushNow` now checks `isCredentialHalted()` first and returns `{halted: true}`; rows stay dirty and push after recovery. New wiring test covers it. (Found by the runtime harness below, not by inspection.)

## Presentation prep for the new codes

`SYNC_ERROR_I18N_KEYS` maps the two new codes to `credentialInvalid`/`quotaExceeded` strings added in **all eight locales**. English wording carried verbatim from the approved lastGLANCE release; de/es/fr/it match this repo's existing registers; pt adapted to this file's Brazilian register (lastGLANCE's was European); zh_CN/zh_HK follow their files' established terminology (同步服务器/同步伺服器, 帐号/帳號). Also corrected the stale "lifeGLANCE is WebDAV-only today" comment in status.js.

**Known limitation, unchanged by this PR**: the vault engine's `onError` is not wired into the UI (only the WebDAV tier's is), so vault-side errors — including the new halt — are not yet visible to users. Tracked separately; the strings and mapping here make that wiring drop-in when it lands.

## Verification

- `npm test`: 401/401 (400 pre-existing untouched + 1 new).
- `npm run lint`: 26 warnings, byte-identical to main's baseline.
- **Runtime harness** (stub GLANCEvault over real HTTP, driving the real `initDbSyncEngine` wrapper end to end with the real data layer, virtual clock for backoff windows): HWM=0 seed then clean first cycle; persistent 500s → only 5 of 60 polled cycles touched the network; automatic recovery with the failure-era row delivered; 413 quota body → `QUOTA_EXCEEDED`, retryable, `quota`-reason window; 401 invalid-credential body → hard halt with **zero** `/sync/*` traffic across 20 subsequent cycles and a silent push-on-write. ALL PASS.

## Sequencing

This lands before the SSE port so the nudge client is built and tested against the engine's final backoff semantics (nudges during open windows are engine-suppressed in 1.10). The seed gate here is already the one-shot persisted flag, so the re-seeding loop hazard the audit chased does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_