### PR TITLE
Add GLANCEvault SSE push (web transport)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,8 @@ import { initDB, dbGetAll, dbGetAllChapters } from './data/db'
 import { backfillMediaIds } from './data/milestones'
 import { initSyncEngine, getSyncEngine } from './sync/engine'
 import { initDbSyncEngine, getDbSyncEngine } from './sync/dbSync'
+import { useVaultEventStream } from './hooks/useVaultEventStream'
+import { drainIntentsNow } from './hooks/useIntentPoller'
 import { buildWidgetSnapshot } from './utils/widgetSnapshot'
 import { pushWidgetSnapshot } from './native/widgetBridge'
 import { useSubscription } from './billing/billing'
@@ -163,6 +165,15 @@ export default function App() {
         setScreen('onboarding')
       })
   }, [])
+
+  // GLANCEvault SSE push: instant drains of the same sync/intents paths the
+  // intervals below poll. Purely additive — the polls stay the correctness
+  // backstop, and the hook is inert unless the vault is enabled (and re-reads
+  // the config on lifeglance:vault-config-changed).
+  useVaultEventStream({
+    drainSync: () => { getDbSyncEngine()?.sync() },
+    drainIntents: drainIntentsNow,
+  })
 
   // Sync interval — trigger sync every 60 seconds with a random initial jitter
   // so multiple browser windows don't stay phase-locked after a hot reload.

--- a/src/hooks/useIntentPoller.js
+++ b/src/hooks/useIntentPoller.js
@@ -15,6 +15,13 @@ export function isRelevantInboundEvent({ action, emitted_by, payload } = {}) {
   return false
 }
 
+// The mounted poller's runPoll, so the vault SSE nudge path (useVaultEventStream
+// → drainIntentsNow) can trigger an immediate intents drain with the SAME
+// handlers and cursors the interval uses. Null while no poller is mounted —
+// drainIntentsNow is then a no-op and the mount-time poll covers the gap.
+let activeIntentDrain = null
+export function drainIntentsNow() { activeIntentDrain?.() }
+
 // Polls the WebDAV events directory while the component is mounted (foreground).
 // Calls the appropriate handler for each inbound event:
 //   onInboundCreate(payload)  — dayGLANCE pushed a new Goal → create milestone
@@ -86,7 +93,11 @@ export function useIntentPoller({
     runPoll() // app start / mount: receive + flush anything persisted from a previous session
     const ms = Math.max(1, intervalMin) * 60 * 1000
     const id = setInterval(runPoll, ms)
-    return () => clearInterval(id)
+    activeIntentDrain = runPoll
+    return () => {
+      clearInterval(id)
+      if (activeIntentDrain === runPoll) activeIntentDrain = null
+    }
   }, [runPoll, intervalMin])
 
   // Re-drain the moment the vault intents key becomes available (dbSync dispatches

--- a/src/hooks/useVaultEventStream.js
+++ b/src/hooks/useVaultEventStream.js
@@ -1,0 +1,188 @@
+// React lifecycle wrapper for the GLANCEvault SSE push client.
+//
+// Opens the authenticated /events stream when the vault is enabled AND the app
+// is visible, turns nudges into instant drains of the EXISTING sync/intents
+// drains (debounced, seq-deduped), reconnects with jittered backoff on any
+// drop, reconciles via the server's `ready` frame on every (re)connect, and
+// tears the connection down cleanly on background / unmount. The pure transport
+// lives in ../sync/vaultEventStream; this file only wires it to React + the app.
+//
+// CORE INVARIANT: purely ADDITIVE. It never starts, stops, or slows the
+// existing poll cadences (the 60-second sync interval in App.jsx, the intent
+// poller's 2-minute cadence). Those keep running as the correctness backstop,
+// so a missed nudge or an SSE-down window is always caught by the next poll.
+// If SSE is unavailable (native shell without the plugin, old server,
+// buffering proxy) or throws, the app degrades to exactly today's polling
+// behavior.
+//
+// Config reactivity: unlike lastGLANCE (where a vault config change reloads the
+// app, so its hook is mount-keyed), lifeGLANCE re-activates the engine IN PLACE
+// (vaultSetup's runVaultSetup/disableVault → reinitDbSyncEngine). Those paths
+// dispatch `lifeglance:vault-config-changed`; this hook listens and rebuilds
+// the SSE client with the fresh config — same in-place contract as the engine.
+
+import { useEffect, useRef, useState } from 'react'
+import { readVaultConfig } from '../sync/dbSync.js'
+import { VaultSse } from '../native/vaultSse.js'
+import {
+  createBridgeSseClient,
+  createNudgeCoalescer,
+  createVaultEventClient,
+  detectSseTransport,
+  openWebSseStream,
+} from '../sync/vaultEventStream.js'
+
+export function useVaultEventStream({ drainSync, drainIntents }) {
+  // Keep the drain callbacks fresh without re-running the main effect (which
+  // would tear down and re-open the connection on every render). Updated in an
+  // effect, matching useIntentPoller's ref pattern.
+  const drainSyncRef = useRef(drainSync)
+  const drainIntentsRef = useRef(drainIntents)
+  useEffect(() => { drainSyncRef.current = drainSync }, [drainSync])
+  useEffect(() => { drainIntentsRef.current = drainIntents }, [drainIntents])
+
+  // Bumped whenever vaultSetup re-activates/disables the vault in place, so the
+  // effect below re-reads the config and rebuilds (or tears down) the client.
+  const [configEpoch, setConfigEpoch] = useState(0)
+  useEffect(() => {
+    const bump = () => setConfigEpoch((e) => e + 1)
+    window.addEventListener('lifeglance:vault-config-changed', bump)
+    return () => window.removeEventListener('lifeglance:vault-config-changed', bump)
+  }, [])
+
+  useEffect(() => {
+    if (!readVaultConfig()) return undefined
+
+    const transport = detectSseTransport()
+    if (transport !== 'web' && transport !== 'native-bridge') {
+      // 'native-unsupported' (a shell without the VaultSse plugin) / 'none'
+      // (SSR): nothing to open, nothing to clean up — polling backstop only.
+      if (import.meta.env?.DEV) {
+        console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only')
+      }
+      return undefined
+    }
+
+    // Observability: a live, inspectable snapshot so SSE health can be checked
+    // in a packaged build with no devtools — run `window.__glanceVaultSse` in
+    // the console (same incantation as the sibling apps, deliberately).
+    // Counters make a reconnect storm (many connects, few events) immediately
+    // obvious; `stalled: true` is the buffering-reverse-proxy signature (stream
+    // opened, no `ready` frame arrived). Per-transition console lines are gated
+    // behind the `lifeglance-debug-push` localStorage flag; genuine errors and
+    // the stalled diagnostic still log unconditionally.
+    const diag = {
+      state: 'idle', transport, connects: 0, events: 0, drains: 0,
+      lastEventSeq: null, lastError: null, stalled: false, terminal: null,
+      lastConnectedAt: null,
+    }
+    window.__glanceVaultSse = diag
+
+    const sseDebug = () => {
+      try { return localStorage.getItem('lifeglance-debug-push') === '1' } catch { return false }
+    }
+
+    const coalescer = createNudgeCoalescer({
+      onDrain: (kind) => {
+        diag.drains += 1
+        if (sseDebug()) console.info('[vault-sse] drain →', kind)
+        if (kind === 'sync') drainSyncRef.current()
+        else drainIntentsRef.current()
+      },
+      onDrainError: (msg, err) => console.warn('[vault-sse]', msg, err instanceof Error ? err.message : err),
+    })
+
+    const onStateChange = (state, detail) => {
+      diag.state = state
+      if (state === 'connecting') diag.connects += 1
+      if (state === 'open') { diag.lastConnectedAt = new Date().toISOString(); diag.stalled = false }
+      if (state === 'stalled') {
+        // A healthy path delivers `ready` immediately; an open-but-silent
+        // stream almost certainly means a buffering reverse proxy. Polling
+        // masks this completely, so say it out loud once per occurrence.
+        diag.stalled = true
+        console.warn('[vault-sse] stream opened but no frame arrived — a reverse proxy is likely buffering /events; SSE is inert and polling is covering')
+      } else if (state === 'error') {
+        diag.lastError = detail instanceof Error ? detail.message
+          : detail?.message ?? String(detail ?? 'error')
+        // A coded error from the native reader is TERMINAL: native stopped and
+        // will not reconnect ('auth' / 'insecure' / 'unsupported'). It surfaces
+        // exactly once — warn loudly; a config re-save re-activates in place,
+        // which starts a fresh reader. Polling covers meanwhile.
+        if (detail && typeof detail === 'object' && detail.code) {
+          diag.terminal = detail.code
+          console.warn(`[vault-sse] terminal error (${detail.code}) — native reader stopped, not reconnecting:`, diag.lastError)
+        } else {
+          console.warn('[vault-sse] error:', diag.lastError)
+        }
+      } else if (state === 'unsupported-server') {
+        console.warn('[vault-sse] this GLANCEvault server predates /events — push disabled, polling covers')
+      } else if (sseDebug()) {
+        console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`)
+      }
+    }
+
+    const getConnection = () => readVaultConfig()
+
+    const onEvent = (evt) => {
+      diag.events += 1
+      if (typeof evt?.seq === 'number') diag.lastEventSeq = evt.seq
+      coalescer.handleEvent(evt)
+    }
+
+    // ── NATIVE-BRIDGE: the shell owns the socket + reconnect + fg/bg ─────────
+    if (transport === 'native-bridge') {
+      const client = createBridgeSseClient({
+        getConnection,
+        // JS → native: hand over the connection and say "SSE desired on". The
+        // shell connects only while the app is foreground and reconnects with
+        // backoff — all invisible here.
+        startNative: (c) => {
+          VaultSse.start({ vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId })
+            .catch(err => onStateChange('error', err instanceof Error ? err.message : String(err)))
+        },
+        stopNative: () => { VaultSse.stop().catch(() => { /* teardown is best-effort */ }) },
+        onEvent,
+        onStateChange,
+      })
+      // Native → JS: every reader message arrives as an sseMessage plugin event.
+      let handle
+      VaultSse.addListener('sseMessage', client.receive).then(h => { handle = h })
+      // No visibilitychange wiring here: the native shell owns
+      // foreground/background and reconnect. The renderer only declares intent
+      // and hands over the connection.
+      client.start()
+
+      return () => {
+        client.stop()
+        handle?.remove()
+        coalescer.cancel()
+      }
+    }
+
+    // ── WEB: JS owns the fetch stream + reconnect/backoff ────────────────────
+    const client = createVaultEventClient({
+      getConnection,
+      openStream: openWebSseStream,
+      onEvent,
+      onStateChange,
+    })
+
+    // Drop SSE on background, reopen on foreground. The (re)connect delivers a
+    // fresh `ready` seq that reconciles anything missed while hidden; the
+    // polls cover the gap regardless.
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') client.start()
+      else client.stop()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    if (document.visibilityState !== 'hidden') client.start()
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      client.stop()
+      coalescer.cancel()
+    }
+  }, [configEpoch])
+}

--- a/src/native/vaultSse.js
+++ b/src/native/vaultSse.js
@@ -1,0 +1,31 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native GLANCEvault SSE reader (the Android and iOS shells implement the same
+// plugin surface, ported from lastGLANCE's; neither lifeGLANCE shell carries it
+// yet — PR 2/3 of the SSE rollout). The WebView cannot stream /events (vault
+// HTTP rides the buffered CapacitorHttp path), so the SHELL owns the socket —
+// connecting while foreground, dropping on background, reconnecting with
+// backoff — and pushes every reader message in as an `sseMessage` plugin event.
+// The renderer's bridge client (createBridgeSseClient in
+// src/sync/vaultEventStream.js) funnels frames through the SAME parseSseFrame
+// → coalescer → drains as the web transport.
+//
+// Message shapes (identical across the GLANCE app family, so the renderer
+// logic is shared code):
+//   {type:'open'}                    a native (re)connection was established
+//   {type:'frame', block:'…'}        one raw SSE event block
+//   {type:'closed'}                  the stream dropped (native will reconnect)
+//   {type:'error', message, code?}   coded errors are TERMINAL — native stopped
+//                                    and will NOT reconnect ('auth' = rejected
+//                                    token, 'insecure' = refused cleartext URL,
+//                                    'unsupported' = server predates /events)
+
+export const VaultSse = registerPlugin('VaultSse')
+
+// Strict capability probe: true only when a native shell actually registered
+// the plugin. A shell predating the reader answers false and the app keeps its
+// polling behavior — the same degrade-to-polling contract the sibling apps
+// established.
+export function isVaultSseNativeAvailable() {
+  return Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('VaultSse')
+}

--- a/src/sync/vaultEventStream.js
+++ b/src/sync/vaultEventStream.js
@@ -1,0 +1,477 @@
+// GLANCEvault SSE push client — lifeGLANCE port of the family's proven core
+// (lastGLANCE src/sync/vaultEventStream.ts, itself the hardened descendant of
+// dayGLANCE's post-#1316 truthful-protocol client): web transport + the
+// native-bridge renderer half, jitter, terminal 404 classification, and the
+// stalled-stream diagnostic.
+//
+// WIRE CONTRACT (verified against the glance-vault server source and observed
+// live): the server emits authenticated per-account named SSE events at
+// GET {vaultUrl}/events?accountId= whose data is exactly {"seq":N}:
+//   • `event: ready`    — once per successful connection, carrying the account's
+//     latest seq (0 for a never-written account); the reconnect reconcile point.
+//   • `event: activity` — whenever the account seq advances.
+// plus comment-line heartbeats (`: ...`) every ~20s. Nothing else is on the
+// wire: no kind/scope discriminator, no `id:`, no `retry:` (reconnect timing is
+// entirely client-owned; the server never reads Last-Event-ID). A nudge carries
+// ONLY the latest account seq — no payload, and no hint of WHAT advanced: sync
+// writes, intent landings, and blob bookkeeping all draw from the one
+// per-account counter (blob bookkeeping without even emitting), so the only
+// correct response to any nudge is to drain everything, and the seq is an
+// opaque watermark — never compare gap sizes against local cursors.
+//
+// CORE INVARIANT: push is an optimization; POLLING IS THE CORRECTNESS BACKSTOP.
+// Nothing here ever stops, slows, or references the existing poll cadences (the
+// 60-second sync interval in App.jsx, the intent poller's 2-minute cadence). A
+// nudge only ADDS an instant drain on top; if any of this throws or the stream
+// drops, polling keeps delivering. Everything is idempotent — a nudge triggers
+// the SAME drains the polls trigger, and those re-read their own cursors and
+// no-op when there is nothing new. The engine's self-enforced backoff
+// (@glance-apps/sync 1.10.0) additionally guarantees a nudge-triggered cycle
+// can never hammer a failing server.
+//
+// TRANSPORTS:
+//   • WEB (browser/PWA): EventSource cannot set an Authorization header, and the
+//     vault authenticates with a Bearer token — so we use a fetch-based
+//     streaming reader (response.body.getReader()). See openWebSseStream.
+//   • NATIVE-BRIDGE (Capacitor shells with the VaultSse plugin): vault HTTP
+//     rides CapacitorHttp (whole-body, cannot stream), so the SHELL owns the
+//     socket — a native SSE reader that connects while foreground, drops on
+//     background, reconnects with backoff, and pushes each raw SSE block in as
+//     a plugin event. The renderer reuses the SAME parseSseFrame + coalescer +
+//     drains — only the transport INPUT differs (see createBridgeSseClient).
+//     No vault CORS change: a native HTTP client has no browser origin.
+//   • NATIVE-UNSUPPORTED (a shell without the plugin — an older APK/IPA until
+//     the readers ship): polling only, exactly today's behavior.
+
+import { isNativePlatform } from './nativeHttp'
+import { isVaultSseNativeAvailable } from '../native/vaultSse'
+
+// ─── SSE frame parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parse ONE SSE event block (the text between blank-line boundaries) into the
+ * nudge object {seq}, or null if the block carries no usable data.
+ *
+ * The event NAME (`ready` | `activity`) is deliberately not surfaced: both carry
+ * the same instruction — the account seq advanced past what we knew — so the
+ * data line is the whole contract. Ignores comment lines (leading ':', used for
+ * heartbeats) and non-data fields (event:, id:, retry: — the server sends only
+ * event: and data: today; tolerating the rest is plain SSE-spec hygiene).
+ * Concatenates multiple data: lines per the SSE spec, then JSON-parses. Returns
+ * null on a heartbeat-only block or unparseable data so the caller can skip it.
+ */
+export function parseSseFrame(block) {
+  if (!block) return null
+  const dataLines = []
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line || line.startsWith(':')) continue // blank or comment (heartbeat)
+    const colon = line.indexOf(':')
+    const field = colon === -1 ? line : line.slice(0, colon)
+    let value = colon === -1 ? '' : line.slice(colon + 1)
+    if (value.startsWith(' ')) value = value.slice(1) // SSE strips one leading space
+    if (field === 'data') dataLines.push(value)
+  }
+  if (dataLines.length === 0) return null
+  try {
+    return JSON.parse(dataLines.join('\n'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Feed a growing SSE text buffer, emitting each COMPLETE event (delimited by a
+ * blank line) via onEvent and returning the unconsumed remainder to carry into
+ * the next chunk. Normalizes CRLF/CR to LF first.
+ */
+export function drainSseBuffer(buffer, onEvent) {
+  let buf = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  let idx
+  while ((idx = buf.indexOf('\n\n')) !== -1) {
+    const block = buf.slice(0, idx)
+    buf = buf.slice(idx + 2)
+    const evt = parseSseFrame(block)
+    if (evt) onEvent(evt)
+  }
+  return buf
+}
+
+// ─── transport detection ─────────────────────────────────────────────────────
+
+/**
+ * Which SSE consumption path this runtime supports:
+ * 'web' | 'native-bridge' | 'native-unsupported' | 'none'. 'web' and
+ * 'native-bridge' open a stream; every other value degrades to polling (the
+ * permanent correctness backstop).
+ */
+export function detectSseTransport() {
+  if (typeof window === 'undefined') return 'none'
+  // Capacitor shell: the shell streams natively when it carries the VaultSse
+  // plugin; an older shell degrades to polling (see header).
+  if (isNativePlatform()) return isVaultSseNativeAvailable() ? 'native-bridge' : 'native-unsupported'
+  if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web'
+  return 'none'
+}
+
+// ─── web streaming reader ────────────────────────────────────────────────────
+
+// Thrown when GET /events comes back 404: the vault predates the SSE endpoint
+// (no catch-all JSON 404 exists server-side, so an unmatched route is Express's
+// default). Terminal for the client — reconnecting cannot fix a server that
+// lacks the route — so the connection loop stops and polling carries on alone.
+// Every other status (400/401/403/429/5xx) means the route exists and the
+// condition may clear, so those stay ordinary retryable connect failures.
+export class SseUnsupportedError extends Error {
+  constructor() {
+    super('vault SSE connect failed: 404 — this GLANCEvault server predates /events')
+    this.code = 'SSE_UNSUPPORTED'
+  }
+}
+
+/**
+ * Open the vault /events SSE stream over a fetch streaming body and pump parsed
+ * {seq} nudges to onEvent until the stream ends or the signal aborts.
+ * Authenticates with the same Bearer token the other vault calls use and scopes
+ * to accountId (query param, mirroring the sync endpoints).
+ *
+ * `credentials: 'omit'` is load-bearing: the vault's CORS layer never sets
+ * Access-Control-Allow-Credentials (the token rides in a header by design), so
+ * an include-credentials fetch would be rejected by the browser.
+ *
+ * Resolves when the server closes the stream (a clean disconnect the caller
+ * will reconnect from). Rejects on connect failure / network error / abort —
+ * and with SseUnsupportedError on 404, which the caller treats as terminal.
+ *
+ * @param {object} args
+ * @param {{vaultUrl: string, vaultToken: string, accountId: string}} args.connection
+ * @param {AbortSignal} [args.signal]
+ * @param {Function} [args.onOpen]
+ * @param {Function} args.onEvent
+ * @param {Function} [args.fetchImpl]
+ */
+export async function openWebSseStream({ connection, signal, onOpen, onEvent, fetchImpl }) {
+  const doFetch = fetchImpl || globalThis.fetch
+  const base = connection.vaultUrl.replace(/\/+$/, '')
+  const url = `${base}/events?accountId=${encodeURIComponent(connection.accountId)}`
+  const res = await doFetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${connection.vaultToken}`,
+      Accept: 'text/event-stream',
+    },
+    credentials: 'omit',
+    signal,
+  })
+  if (res && res.status === 404) throw new SseUnsupportedError()
+  if (!res || !res.ok || !res.body) {
+    throw new Error(`vault SSE connect failed: ${res ? res.status : 'no response'}`)
+  }
+  onOpen?.()
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      buffer = drainSseBuffer(buffer, onEvent)
+    }
+  } finally {
+    try { reader.releaseLock() } catch { /* ignore */ }
+  }
+}
+
+// ─── nudge coalescer (seq cursor + debounce) ─────────────────────────────────
+
+/**
+ * Turns a stream of nudge events into debounced drain calls, with a seq cursor
+ * so stale/duplicate nudges are ignored.
+ *
+ * The account seq is a single unified monotonic counter on the server — sync
+ * writes, intent landings, and blob bookkeeping all advance it — so ONE cursor
+ * is correct: an event is "behind" (worth acting on) only when its seq exceeds
+ * the highest we've already reacted to.
+ *
+ * Every accepted nudge drains BOTH sides. The wire carries no scope (data is
+ * exactly {"seq":N}), and the shared counter means a scope couldn't safely
+ * narrow a drain even if one existed. Rapid nudges within debounceMs coalesce
+ * into a single drain pair.
+ *
+ * onDrain(kind) is called with 'sync' then 'intents' on each flush. The split
+ * callback is kept deliberately (mirroring the sibling apps): it is the ONE
+ * seam where routing would slot in if a future server ever scoped its nudges —
+ * no such protocol exists or is planned today. It runs inside a try/catch so a
+ * throwing drain can never break the debounce timer or the SSE loop.
+ */
+export function createNudgeCoalescer({
+  onDrain,
+  debounceMs = 400,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onDrainError,
+}) {
+  let lastSeq = -Infinity
+  let timer = null
+
+  const runDrain = (kind) => {
+    try {
+      onDrain(kind)
+    } catch (err) {
+      onDrainError?.(`vault-sse drain (${kind}) failed`, err)
+    }
+  }
+
+  const flush = () => {
+    timer = null
+    // Deterministic order: sync before intents.
+    runDrain('sync')
+    runDrain('intents')
+  }
+
+  // Debounce ONLY — no throttle. lifeGLANCE's first-activation seeding has
+  // always been behind a one-shot persisted flag (dbSync.js SEEDED_KEY), so a
+  // device's own pushes can't re-mark and self-nudge into a loop; drains fire
+  // near-instantly on real changes, which is the point of SSE. Polling remains
+  // the backstop for any coalesced nudge.
+  const schedule = () => {
+    if (timer) clearTimeoutFn(timer)
+    timer = setTimeoutFn(flush, debounceMs)
+  }
+
+  const handleEvent = (evt) => {
+    const seq = evt?.seq
+    if (typeof seq !== 'number' || Number.isNaN(seq)) return false
+    if (seq <= lastSeq) return false // not behind — coalesced/stale, ignore
+    lastSeq = seq
+    schedule()
+    return true
+  }
+
+  return {
+    handleEvent,
+    getCursor: () => lastSeq,
+    cancel: () => { if (timer) { clearTimeoutFn(timer); timer = null } },
+  }
+}
+
+// ─── connection client (reconnect + backoff) ─────────────────────────────────
+
+/**
+ * Manages the SSE connection lifecycle: connect, pump events through onEvent,
+ * and on any drop reconnect with capped, JITTERED exponential backoff. It NEVER
+ * touches polling — polling is a separate concern and remains the backstop for
+ * every gap this client leaves (backoff waits, background, permanent failure).
+ *
+ * Three behaviors earned by the family's server audit (carried from lastGLANCE):
+ *   • Jitter (±25%) on every reconnect delay. SSE connects count against the
+ *     vault's per-IP rate limiter, and the connection-cap slot for a silently
+ *     dead socket can outlive the client that held it — jitter keeps a fleet of
+ *     reconnecting devices from synchronizing into bursts against either.
+ *   • SseUnsupportedError (404) is TERMINAL: the loop stops for good and
+ *     reports 'unsupported-server'. Reconnecting cannot grow a route the server
+ *     doesn't have, and polling covers the app identically either way.
+ *   • Stalled-stream diagnostic: a connection that opens but delivers no frame
+ *     within readyTimeoutMs reports 'stalled' once. The server sends `ready`
+ *     immediately on connect, so a silent open stream almost certainly means a
+ *     buffering reverse proxy — the one SSE failure mode that is otherwise
+ *     invisible, because polling masks it completely.
+ *
+ * Backoff resets only after a connection proves STABLE (open ≥ minStableMs) —
+ * an open-then-immediate-drop endpoint would otherwise reconnect every
+ * backoffBaseMs forever, a storm that also re-fires the ready reconcile drain
+ * every cycle.
+ *
+ * States reported via onStateChange: 'connecting' | 'open' | 'closed' |
+ * 'error' | 'stalled' | 'unsupported' | 'unsupported-server' | 'stopped'.
+ */
+export function createVaultEventClient({
+  getConnection,
+  openStream,
+  onEvent,
+  supported = true,
+  backoffBaseMs = 1000,
+  backoffMaxMs = 30000,
+  minStableMs = 5000,
+  readyTimeoutMs = 5000,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  now = () => Date.now(),
+  random = Math.random,
+  onStateChange,
+}) {
+  let stopped = true
+  let looping = false
+  let attempt = 0
+  let abortController = null
+  let reconnectTimer = null
+  let readyTimer = null
+
+  const clearReadyTimer = () => {
+    if (readyTimer) { clearTimeoutFn(readyTimer); readyTimer = null }
+  }
+
+  const loop = async () => {
+    if (looping) return
+    looping = true
+    while (!stopped) {
+      const connection = supported ? getConnection() : null
+      if (!connection) break // nothing to connect to → let polling cover it
+      abortController = typeof AbortController !== 'undefined' ? new AbortController() : null
+      onStateChange?.('connecting')
+      const startedAt = now()
+      try {
+        await openStream({
+          connection,
+          signal: abortController?.signal,
+          // Backoff is NOT reset here — see minStableMs note in the doc block.
+          onOpen: () => {
+            onStateChange?.('open')
+            // The server's `ready` frame arrives immediately on a healthy path;
+            // an open-but-silent stream is the buffering-proxy signature.
+            clearReadyTimer()
+            readyTimer = setTimeoutFn(() => {
+              readyTimer = null
+              onStateChange?.('stalled')
+            }, readyTimeoutMs)
+          },
+          onEvent: (evt) => {
+            clearReadyTimer()
+            onEvent(evt)
+          },
+        })
+        // Stream ended cleanly (server closed / heartbeat gap) — reconnect soon.
+        onStateChange?.('closed')
+      } catch (err) {
+        if (err?.code === 'SSE_UNSUPPORTED') {
+          // Terminal: the server has no /events route. Stop for good.
+          onStateChange?.('unsupported-server', err)
+          stopped = true
+          break
+        }
+        // Connect/network/abort error — SSE is additive, so we swallow it and
+        // reconnect. Polling keeps delivering in the meantime.
+        if (!stopped) onStateChange?.('error', err)
+      } finally {
+        clearReadyTimer()
+      }
+      if (stopped) break
+      // Reset backoff ONLY for a connection that stayed open long enough to be
+      // healthy; a flapping open/close keeps backing off (up to backoffMaxMs).
+      if (now() - startedAt >= minStableMs) attempt = 0
+      const delay = Math.min(backoffMaxMs, backoffBaseMs * 2 ** attempt) * (0.75 + random() * 0.5)
+      attempt += 1
+      await new Promise((resolve) => { reconnectTimer = setTimeoutFn(resolve, delay) })
+      reconnectTimer = null
+    }
+    looping = false
+  }
+
+  return {
+    start() {
+      if (!supported) { onStateChange?.('unsupported'); return }
+      stopped = false
+      if (!looping) { attempt = 0; loop() }
+    },
+    stop() {
+      stopped = true
+      clearReadyTimer()
+      if (abortController) { try { abortController.abort() } catch { /* ignore */ } abortController = null }
+      if (reconnectTimer) { clearTimeoutFn(reconnectTimer); reconnectTimer = null }
+      onStateChange?.('stopped')
+    },
+    isRunning: () => !stopped,
+    isSupported: () => supported,
+  }
+}
+
+// ─── bridge-fed client (native shell owns the socket) ────────────────────────
+
+/**
+ * The renderer half of the 'native-bridge' transport. Unlike
+ * createVaultEventClient (which owns a fetch stream + JS-side
+ * reconnect/backoff), here the NATIVE SHELL owns the socket and its whole
+ * lifecycle: it connects when foreground, drops on background, and reconnects
+ * with backoff — all invisible to JS. This client's job is only to (a) tell
+ * native "SSE desired on/off" with the connection params, and (b) funnel the
+ * raw SSE blocks native pushes back through the SAME parseSseFrame + onEvent
+ * (→ coalescer → drains) the web path uses. There is deliberately NO JS
+ * reconnect loop here — reconnect belongs to exactly ONE owner per transport,
+ * and for native that owner is the shell. Polling remains the backstop.
+ *
+ * `receive` is fed by the VaultSse plugin's `sseMessage` events (see
+ * src/native/vaultSse.js for the message shapes). A coded error means the
+ * native reader stopped TERMINALLY and will not reconnect ('auth',
+ * 'insecure', 'unsupported') — surfaced once via onStateChange with the code
+ * attached so the consumer can distinguish it.
+ */
+export function createBridgeSseClient({
+  getConnection,
+  startNative,
+  stopNative,
+  onEvent,
+  onStateChange,
+}) {
+  let running = false
+
+  // The native shell pushes messages here. Accepts a parsed object OR a JSON
+  // string (a shell that stringifies is handled too). Never throws — a
+  // malformed push is ignored so it can't break the bridge.
+  const receive = (msg) => {
+    if (typeof msg === 'string') {
+      try { msg = JSON.parse(msg) } catch { return }
+    }
+    if (!msg || typeof msg !== 'object') return
+    switch (msg.type) {
+      case 'open':
+        onStateChange?.('open')
+        break
+      case 'frame': {
+        // Reuse the EXISTING parser: native did transport + frame boundary
+        // detection; {seq} extraction stays in ONE place (parseSseFrame).
+        if (typeof msg.block === 'string') {
+          const evt = parseSseFrame(msg.block)
+          if (evt) onEvent(evt)
+        }
+        break
+      }
+      case 'closed':
+        onStateChange?.('closed')
+        break
+      case 'error':
+        // A coded error is terminal — native stopped and will NOT reconnect —
+        // so it surfaces exactly once. Non-coded errors are informational
+        // (native owns the retry).
+        onStateChange?.('error', msg.code ? { message: msg.message, code: msg.code } : msg.message)
+        break
+      default:
+        break
+    }
+  }
+
+  return {
+    receive,
+    start() {
+      if (running) return false
+      const connection = getConnection()
+      if (!connection) return false // nothing to connect to → polling covers it
+      running = true
+      onStateChange?.('connecting')
+      try {
+        startNative(connection)
+      } catch (err) {
+        onStateChange?.('error', err instanceof Error ? err.message : String(err))
+      }
+      return true
+    },
+    stop() {
+      if (!running) return
+      running = false
+      try { stopNative() } catch { /* teardown must not throw */ }
+      onStateChange?.('stopped')
+    },
+    isRunning: () => running,
+  }
+}

--- a/src/sync/vaultEventStream.test.js
+++ b/src/sync/vaultEventStream.test.js
@@ -1,0 +1,348 @@
+// Tests for the SSE push client core, against the REAL wire format (verified
+// from the glance-vault server source and observed live): named events
+// `event: ready` / `event: activity` whose data is exactly {"seq":N}, plus
+// comment-line heartbeats. No test fabricates fields the server does not send.
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  parseSseFrame,
+  drainSseBuffer,
+  createBridgeSseClient,
+  createNudgeCoalescer,
+  createVaultEventClient,
+  openWebSseStream,
+  SseUnsupportedError,
+} from './vaultEventStream'
+
+// Real frames, byte-shaped as the server sends them.
+const READY = 'event: ready\ndata: {"seq":3}'
+const ACTIVITY = (seq) => `event: activity\ndata: {"seq":${seq}}`
+
+describe('parseSseFrame', () => {
+  it('parses a ready frame to its {seq} nudge (event name not surfaced)', () => {
+    expect(parseSseFrame(READY)).toEqual({ seq: 3 })
+  })
+
+  it('parses an activity frame identically', () => {
+    expect(parseSseFrame(ACTIVITY(7))).toEqual({ seq: 7 })
+  })
+
+  it('returns null for a heartbeat-only block', () => {
+    expect(parseSseFrame(': heartbeat')).toBeNull()
+  })
+
+  it('tolerates CRLF line endings', () => {
+    expect(parseSseFrame('event: activity\r\ndata: {"seq":9}\r')).toEqual({ seq: 9 })
+  })
+
+  it('concatenates multiple data lines per the SSE spec', () => {
+    expect(parseSseFrame('data: {"seq"\ndata: :12}')).toEqual({ seq: 12 })
+  })
+
+  it('returns null on unparseable data and on event-name-only blocks', () => {
+    expect(parseSseFrame('data: not-json')).toBeNull()
+    expect(parseSseFrame('event: ready')).toBeNull()
+  })
+})
+
+describe('drainSseBuffer', () => {
+  it('emits each complete event and returns the unconsumed remainder', () => {
+    const seen = []
+    const rest = drainSseBuffer(`${READY}\n\n${ACTIVITY(5)}\n\n${ACTIVITY(6)}`, e => seen.push(e))
+    expect(seen).toEqual([{ seq: 3 }, { seq: 5 }])
+    expect(rest).toBe(ACTIVITY(6)) // incomplete: no blank-line delimiter yet
+  })
+
+  it('reassembles frames split across chunk boundaries', () => {
+    const seen = []
+    let buf = ''
+    for (const chunk of ['event: acti', 'vity\nda', 'ta: {"seq":42}\n', '\n: heartbeat\n\n']) {
+      buf = drainSseBuffer(buf + chunk, e => seen.push(e))
+    }
+    expect(seen).toEqual([{ seq: 42 }])
+    expect(buf).toBe('')
+  })
+})
+
+// Timer harness: captures scheduled callbacks so tests fire them explicitly.
+function makeTimers() {
+  let nextId = 1
+  const pending = new Map()
+  return {
+    setTimeoutFn: (cb) => { const id = nextId++; pending.set(id, cb); return id },
+    clearTimeoutFn: (id) => { pending.delete(id) },
+    fire: () => { const cbs = [...pending.values()]; pending.clear(); cbs.forEach(cb => cb()) },
+    pendingCount: () => pending.size,
+  }
+}
+
+describe('createNudgeCoalescer', () => {
+  it('accepts advancing seqs, ignores stale and duplicate ones', () => {
+    const timers = makeTimers()
+    const c = createNudgeCoalescer({ onDrain: () => {}, ...timers })
+    expect(c.handleEvent({ seq: 3 })).toBe(true)   // ready
+    expect(c.handleEvent({ seq: 3 })).toBe(false)  // duplicate
+    expect(c.handleEvent({ seq: 2 })).toBe(false)  // stale
+    expect(c.handleEvent({ seq: 7 })).toBe(true)   // advanced
+    expect(c.handleEvent(null)).toBe(false)
+    expect(c.handleEvent({ seq: NaN })).toBe(false)
+    expect(c.getCursor()).toBe(7)
+  })
+
+  it('coalesces a burst into ONE flush that drains sync then intents', () => {
+    const timers = makeTimers()
+    const drains = []
+    const c = createNudgeCoalescer({ onDrain: k => drains.push(k), ...timers })
+    c.handleEvent({ seq: 1 })
+    c.handleEvent({ seq: 2 })
+    c.handleEvent({ seq: 3 })
+    expect(drains).toEqual([]) // debounced, nothing yet
+    timers.fire()
+    expect(drains).toEqual(['sync', 'intents'])
+  })
+
+  it('a throwing sync drain does not prevent the intents drain', () => {
+    const timers = makeTimers()
+    const drains = []
+    const errors = []
+    const c = createNudgeCoalescer({
+      onDrain: k => { drains.push(k); if (k === 'sync') throw new Error('boom') },
+      onDrainError: msg => errors.push(msg),
+      ...timers,
+    })
+    c.handleEvent({ seq: 1 })
+    timers.fire()
+    expect(drains).toEqual(['sync', 'intents'])
+    expect(errors).toEqual(['vault-sse drain (sync) failed'])
+  })
+
+  it('cancel() drops a pending flush', () => {
+    const timers = makeTimers()
+    const drains = []
+    const c = createNudgeCoalescer({ onDrain: k => drains.push(k), ...timers })
+    c.handleEvent({ seq: 1 })
+    c.cancel()
+    timers.fire()
+    expect(drains).toEqual([])
+  })
+})
+
+describe('createVaultEventClient', () => {
+  const connection = { vaultUrl: 'http://v', vaultToken: 't', accountId: 'a' }
+
+  // Runs the client loop against a scripted openStream. Reconnect delays are
+  // captured; timers fire on a microtask so the loop advances without real
+  // waiting. random=0.5 makes the ±25% jitter factor exactly 1.0.
+  function run(openStream, opts = {}) {
+    const delays = []
+    const states = []
+    let nowIdx = 0
+    const nowSteps = opts.nowSteps
+    const client = createVaultEventClient({
+      getConnection: () => connection,
+      openStream,
+      onEvent: () => {},
+      now: nowSteps ? () => nowSteps[Math.min(nowIdx++, nowSteps.length - 1)] : () => 0,
+      random: opts.random ?? (() => 0.5),
+      setTimeoutFn: (cb, ms) => {
+        delays.push(ms)
+        queueMicrotask(cb)
+        return 0
+      },
+      clearTimeoutFn: () => {},
+      onStateChange: s => states.push(s),
+    })
+    return { client, delays, states }
+  }
+
+  it('backs off exponentially with the jitter factor applied, capped at max', async () => {
+    let calls = 0
+    const { client, delays } = run(async () => {
+      calls++
+      if (calls >= 8) client.stop()
+      throw new Error('connect refused')
+    })
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(8))
+    // random=0.5 → factor 1.0 → raw ladder: 1s 2s 4s 8s 16s 30s(cap) 30s ...
+    expect(delays.slice(0, 7)).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000])
+  })
+
+  it('jitter spreads the delay within ±25%', async () => {
+    let calls = 0
+    const { client, delays } = run(async () => {
+      calls++
+      if (calls >= 2) client.stop()
+      throw new Error('nope')
+    }, { random: () => 0 }) // low edge
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(2))
+    expect(delays[0]).toBe(750) // 1000 * 0.75
+  })
+
+  it('resets the backoff only after a connection proves stable', async () => {
+    let calls = 0
+    const { client, delays } = run(
+      async () => {
+        calls++
+        if (calls >= 4) client.stop()
+        throw new Error('drop')
+      },
+      // now() is read twice per connection (startedAt, then the stability
+      // check). Connections 1-2 last 0ms (unstable → ladder climbs); the THIRD
+      // lasts 6s (≥ minStableMs 5s) → attempt resets, so its delay drops back
+      // to the base instead of continuing to 4s.
+      { nowSteps: [0, 0, 0, 0, 1000, 7000, 7000, 7000] },
+    )
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(4))
+    expect(delays.slice(0, 3)).toEqual([1000, 2000, 1000])
+  })
+
+  it('treats a 404 (SseUnsupportedError) as terminal: stops, never retries', async () => {
+    let calls = 0
+    const { client, states, delays } = run(async () => {
+      calls++
+      throw new SseUnsupportedError()
+    })
+    client.start()
+    await vi.waitFor(() => expect(states).toContain('unsupported-server'))
+    expect(calls).toBe(1)
+    expect(delays).toEqual([]) // no reconnect was ever scheduled
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('reports stalled when a stream opens but no frame arrives in time', async () => {
+    const { client, states } = run(async ({ onOpen }) => {
+      onOpen?.()
+      // Never emits an event, never resolves promptly: the ready timer (also on
+      // the microtask timer harness) fires first.
+      await new Promise(resolve => { setTimeout(resolve, 5) })
+      client.stop()
+    })
+    client.start()
+    await vi.waitFor(() => expect(states).toContain('stalled'))
+  })
+})
+
+describe('createBridgeSseClient', () => {
+  const connection = { vaultUrl: 'http://v', vaultToken: 't', accountId: 'a' }
+
+  function make(getConnection = () => connection) {
+    const started = []
+    let stops = 0
+    const events = []
+    const states = []
+    const client = createBridgeSseClient({
+      getConnection,
+      startNative: c => started.push(c),
+      stopNative: () => { stops++ },
+      onEvent: e => events.push(e),
+      onStateChange: (s, d) => states.push([s, d]),
+    })
+    return { client, started, events, states, stops: () => stops }
+  }
+
+  it('start hands the connection to native; stop tears down; both idempotent', () => {
+    const { client, started, stops } = make()
+    expect(client.start()).toBe(true)
+    expect(client.start()).toBe(false) // already running
+    expect(started).toEqual([connection])
+    client.stop()
+    client.stop()
+    expect(stops()).toBe(1)
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('does not start without a connection (polling covers)', () => {
+    const { client, started } = make(() => null)
+    expect(client.start()).toBe(false)
+    expect(started).toEqual([])
+  })
+
+  it('routes frames through the shared parser and forwards only real nudges', () => {
+    const { client, events } = make()
+    client.receive({ type: 'frame', block: 'event: ready\ndata: {"seq":3}' })
+    client.receive({ type: 'frame', block: 'event: activity\ndata: {"seq":7}' })
+    client.receive({ type: 'frame', block: ': heartbeat' })    // parses to null → dropped
+    client.receive({ type: 'frame', block: 'data: not-json' }) // unparseable → dropped
+    expect(events).toEqual([{ seq: 3 }, { seq: 7 }])
+  })
+
+  it('accepts JSON-string messages from a stringifying shell', () => {
+    const { client, events, states } = make()
+    client.receive('{"type":"open"}')
+    client.receive('{"type":"frame","block":"event: activity\\ndata: {\\"seq\\":9}"}')
+    expect(states).toEqual([['open', undefined]])
+    expect(events).toEqual([{ seq: 9 }])
+  })
+
+  it('surfaces coded (terminal) errors with the code attached, plain errors without', () => {
+    const { client, states } = make()
+    client.receive({ type: 'error', message: 'auth failed: 401', code: 'auth' })
+    client.receive({ type: 'error', message: 'read reset' })
+    expect(states).toEqual([
+      ['error', { message: 'auth failed: 401', code: 'auth' }],
+      ['error', 'read reset'],
+    ])
+  })
+
+  it('ignores malformed pushes without throwing', () => {
+    const { client, events, states } = make()
+    client.receive(null)
+    client.receive(42)
+    client.receive('not json')
+    client.receive({ type: 'mystery' })
+    client.receive({ type: 'frame' }) // no block
+    expect(events).toEqual([])
+    expect(states).toEqual([])
+  })
+})
+
+describe('openWebSseStream', () => {
+  const connection = { vaultUrl: 'http://vault.test/', vaultToken: 'tok', accountId: 'acct-1' }
+
+  function sseResponse(chunks) {
+    const enc = new TextEncoder()
+    const body = new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(enc.encode(c))
+        controller.close()
+      },
+    })
+    return { ok: true, status: 200, body }
+  }
+
+  it('requests /events with Bearer auth, no credentials, and pumps real frames', async () => {
+    let captured = null
+    const seen = []
+    await openWebSseStream({
+      connection,
+      onEvent: e => seen.push(e),
+      fetchImpl: async (url, init) => {
+        captured = { url, init }
+        return sseResponse([`${READY}\n\n`, ': heartbeat\n\n', `${ACTIVITY(4)}\n\n`])
+      },
+    })
+    expect(captured.url).toBe('http://vault.test/events?accountId=acct-1')
+    expect(captured.init.headers.Authorization).toBe('Bearer tok')
+    expect(captured.init.credentials).toBe('omit')
+    expect(seen).toEqual([{ seq: 3 }, { seq: 4 }])
+  })
+
+  it('classifies a 404 as SseUnsupportedError (server predates /events)', async () => {
+    await expect(openWebSseStream({
+      connection,
+      onEvent: () => {},
+      fetchImpl: async () => ({ ok: false, status: 404, body: null }),
+    })).rejects.toBeInstanceOf(SseUnsupportedError)
+  })
+
+  it('throws a plain retryable error on any other failure status', async () => {
+    await expect(openWebSseStream({
+      connection,
+      onEvent: () => {},
+      fetchImpl: async () => ({ ok: false, status: 429, body: null }),
+    })).rejects.toThrow('vault SSE connect failed: 429')
+  })
+})

--- a/src/sync/vaultSetup.js
+++ b/src/sync/vaultSetup.js
@@ -123,6 +123,11 @@ export async function runVaultSetup({ vaultUrl, vaultToken, accountId, passphras
   // Activate IN PLACE (rebuild the engine from the freshly saved config) and kick
   // a first sync, which seeds the HWM=0 full snapshot.
   await (deps.reinit ?? defaultReinit)()
+  // The SSE hook (useVaultEventStream) mirrors the engine's in-place lifecycle:
+  // tell it the config changed so it (re)opens the stream with fresh credentials.
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('lifeglance:vault-config-changed'))
+  }
   await (deps.startSync ?? (() => getDbSyncEngine()?.sync()))()
   return { ok: true, kind: outcome.kind }
 }
@@ -135,4 +140,8 @@ export function disableVault(deps = {}) {
   try { cfg = JSON.parse(localStorage.getItem(CONFIG_KEY) || '{}') || {} } catch { cfg = {} }
   localStorage.setItem(CONFIG_KEY, JSON.stringify({ ...cfg, vaultEnabled: false }))
   ;(deps.reinit ?? defaultReinit)()
+  // Close the SSE stream too — the hook re-reads the (now disabled) config.
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('lifeglance:vault-config-changed'))
+  }
 }


### PR DESCRIPTION
SSE PR 1 of 3 (web; Android and iOS shells follow), building on the sync 1.10 bump (#288). Vault changes now arrive in about a second instead of waiting for the 60-second sync interval / 2-minute intent poll. This is the lifeGLANCE port of the family's proven client — lastGLANCE's hardened revision (its #248) of dayGLANCE's post-fix core — against the verified wire contract: named `ready`/`activity` events whose data is exactly `{"seq":N}`, comment heartbeats, no scope/id/retry fields.

## What

- **`src/sync/vaultEventStream.js`** — transport core: fetch-streaming web reader (EventSource can't send the Bearer header; `credentials: 'omit'` is load-bearing for the vault's CORS), seq-cursor coalescer draining sync then intents (400ms debounce), jittered capped backoff with a 5s stability reset, terminal 404 classification (`unsupported-server`: the vault predates `/events`), stalled-stream diagnostic (open-but-silent = buffering reverse proxy), and the bridge-fed client for native shells — dormant until PR 2/3 register the `VaultSse` plugin, at which point the shells light up with **zero further JS changes**.
- **`src/native/vaultSse.js`** — plugin surface + strict capability probe (`isPluginAvailable`), same message shapes as the sibling apps.
- **`src/hooks/useVaultEventStream.js`** — React wrapper: visibility-gated stream on web, `window.__glanceVaultSse` diagnostics, verbose tracing behind the `lifeglance-debug-push` localStorage flag. One lifeGLANCE-specific design point: lastGLANCE reloads the app on vault config changes so its hook is mount-keyed, but lifeGLANCE re-activates the engine **in place** — so `vaultSetup`'s activate/disable paths now dispatch `lifeglance:vault-config-changed` and the hook tears down/rebuilds the stream on it, mirroring the engine's lifecycle exactly.
- **`src/hooks/useIntentPoller.js`** — exports `drainIntentsNow()` so a nudge drains intents through the mounted poller's own handlers and cursors (same holder pattern as lastGLANCE).
- **`App.jsx`** — wires the hook: `drainSync` → `getDbSyncEngine()?.sync()`, `drainIntents` → `drainIntentsNow`.

## Invariants

- **Polling is untouched and remains the correctness backstop.** Push only adds instant drains; every drain is idempotent and re-reads its own cursors.
- The 1.10 engine backoff (#288) guarantees a nudge-triggered cycle can never hammer a failing vault — nudges during open windows are engine-suppressed.
- No self-nudge loop: the seeding gate here has always been the one-shot persisted flag (`SEEDED_KEY`), and per the #287 audit there is no per-cycle churn source (tombstones are event-driven and never pruned — the #287 warning about landing pruning carefully *after* SSE now applies for real).

## Verification

- 26 new unit tests against real-wire byte fixtures (parser, buffer reassembly, coalescer, backoff ladder incl. jitter edges and stability reset, terminal 404, stalled, bridge client, web reader) — 427 total passing; lint at main's baseline; production build clean.
- **Runtime harness** driving the SHIPPED bundle (esbuild from `src/`, no copies) against a stub vault speaking the real `/events` wire, with a second raw engine as the remote writer: connect → `ready` reconcile drain pair; **writer push → activity nudge → row applied in the reader's store in 462ms** (vs the 60s poll); 404 server → terminal with exactly one connect attempt; buffering-proxy simulation → `stalled` diagnostic. ALL PASS.

## Testing on your fleet

Same as the lastGLANCE round: after merge, your Docker/PWA instance connects on next load — check GLANCEvault logs for the `/events` connection, complete something on another device, and watch it land sub-second. `window.__glanceVaultSse` in the console shows `{state: 'open', transport: 'web', connects, events, drains, ...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_