### PR TITLE
Vault SSE phase 2: native Android reader via a Capacitor plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -114,6 +114,11 @@ dependencies {
     // OkHttp backs WebDavHttpPlugin — HttpURLConnection (behind CapacitorHttp)
     // rejects WebDAV verbs like PROPFIND/MKCOL; OkHttp accepts any method.
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
+
+    // Coroutines back the VaultSse SSE reader's lifecycle (single reader job,
+    // cancellable blocking reads). Glance/WorkManager pull it transitively, but
+    // the reader depends on it directly, so declare it explicitly.
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
 
     testImplementation "junit:junit:$junitVersion"

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -11,6 +11,7 @@ import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.getcapacitor.BridgeActivity;
 import com.glanceapps.billing.BillingBridgePlugin;
+import com.lifeglance.app.sse.VaultSsePlugin;
 import com.lifeglance.app.widget.WidgetData;
 
 public class MainActivity extends BridgeActivity {
@@ -25,6 +26,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(WidgetBridgePlugin.class);
         registerPlugin(BillingBridgePlugin.class);
         registerPlugin(WebDavHttpPlugin.class);
+        registerPlugin(VaultSsePlugin.class);
         super.onCreate(savedInstanceState);
         handleWidgetIntent(getIntent());
         handleShareIntent(getIntent());

--- a/android/app/src/main/java/com/lifeglance/app/sse/SseBackoff.kt
+++ b/android/app/src/main/java/com/lifeglance/app/sse/SseBackoff.kt
@@ -1,0 +1,50 @@
+package com.lifeglance.app.sse
+
+/**
+ * Capped exponential backoff with a stability reset — the Kotlin mirror of the
+ * reconnect policy in `createVaultEventClient` (src/sync/vaultEventStream.js).
+ * Ported from dayGLANCE's production reader (dayglance-android sse/SseBackoff.kt).
+ *
+ * A connection that stays open at least [minStableMs] is treated as healthy and
+ * resets the attempt counter, so a genuine long-lived stream that finally drops
+ * reconnects promptly. A connection that opens then drops immediately (a flap —
+ * server closing fast, proxy timeout, network reset) keeps backing off, up to
+ * [maxMs], so a broken endpoint can never storm the vault with reconnects.
+ *
+ * Pure and deterministic, so it is unit-testable with no clock or network.
+ */
+class SseBackoff(
+    private val baseMs: Long = 1_000,
+    private val maxMs: Long = 30_000,
+    private val minStableMs: Long = 5_000,
+) {
+
+    private var attempt = 0
+
+    /**
+     * The delay to wait before the NEXT reconnect attempt, then advances the
+     * counter. `base * 2^attempt`, capped at [maxMs]. The shift amount is clamped
+     * so a large attempt count can't overflow / wrap the Long shift.
+     */
+    fun nextDelayMs(): Long {
+        val shift = attempt.coerceIn(0, 30)
+        val delay = minOf(maxMs, baseMs shl shift)
+        attempt++
+        return delay
+    }
+
+    /**
+     * Record that a connection closed, given how long it had been open. Resets the
+     * backoff only when the connection was open at least [minStableMs] (a healthy
+     * stream), so the next reconnect starts back at [baseMs] rather than continuing
+     * to grow; a flap leaves the counter climbing.
+     */
+    fun onClosed(openDurationMs: Long) {
+        if (openDurationMs >= minStableMs) attempt = 0
+    }
+
+    /** Reset the backoff to its initial state. */
+    fun reset() {
+        attempt = 0
+    }
+}

--- a/android/app/src/main/java/com/lifeglance/app/sse/SseFraming.kt
+++ b/android/app/src/main/java/com/lifeglance/app/sse/SseFraming.kt
@@ -1,0 +1,77 @@
+package com.lifeglance.app.sse
+
+/**
+ * Incremental Server-Sent-Events frame boundary detector — the Kotlin mirror of
+ * the renderer's `drainSseBuffer` (src/sync/vaultEventStream.js). Ported from
+ * dayGLANCE's production reader (dayglance-android sse/SseFraming.kt).
+ *
+ * It does ONLY transport-level framing: accumulate stream text across reads, split
+ * complete event blocks on the blank-line delimiter, and hand each block back
+ * verbatim. It deliberately does NOT parse the `{seq}` nudge — that extraction
+ * stays in the renderer's single `parseSseFrame`, which this shell feeds each
+ * block through via the plugin event. Keeping ONE nudge parser (in the renderer)
+ * is the whole point of the bridge-fed design: the native side is a dumb, robust
+ * byte framer.
+ *
+ * Stateful per instance (holds the partial-block remainder between reads) and pure
+ * otherwise, so it is unit-testable with no network.
+ */
+class SseFraming(
+    // Cap on the retained (un-delimited) buffer. A server that streams bytes but
+    // never the "\n\n" block delimiter would otherwise grow this without bound
+    // (memory exhaustion). Real vault events are tiny nudges, so 1 MB is far above
+    // anything legitimate; a breach is treated as a stream failure by the caller.
+    private val maxBufferChars: Int = 1_048_576,
+) {
+
+    private val buffer = StringBuilder()
+
+    /**
+     * Append a decoded stream chunk and return every COMPLETE event block now
+     * available (delimited by a blank line). CRLF/CR are normalised to LF first,
+     * matching the renderer. Comment-only / heartbeat blocks (no `data:` line) are
+     * dropped here so the bridge isn't woken ~every 20 s for a frame the renderer
+     * would only parse to null anyway — a bandwidth/wakeup optimisation, not a
+     * correctness one (the renderer's parser would ignore them regardless).
+     */
+    fun append(chunk: String): List<String> {
+        buffer.append(chunk.replace("\r\n", "\n").replace('\r', '\n'))
+        val blocks = mutableListOf<String>()
+        var idx = buffer.indexOf("\n\n")
+        while (idx != -1) {
+            val block = buffer.substring(0, idx)
+            buffer.delete(0, idx + 2)
+            if (hasDataLine(block)) blocks.add(block)
+            idx = buffer.indexOf("\n\n")
+        }
+        // After draining every complete block, whatever remains is a single partial
+        // block still awaiting its delimiter. If that alone exceeds the cap the peer
+        // is misbehaving (or hostile) — bail so the caller can drop and reconnect
+        // rather than buffer unboundedly.
+        if (buffer.length > maxBufferChars) {
+            throw SseFramingOverflowException(buffer.length, maxBufferChars)
+        }
+        return blocks
+    }
+
+    /**
+     * Discard any partial block. Called when a connection drops and a new one is
+     * opened, so a half-received event from the dead stream can't be glued onto the
+     * first bytes of the fresh stream.
+     */
+    fun reset() {
+        buffer.setLength(0)
+    }
+
+    private fun hasDataLine(block: String): Boolean =
+        block.split('\n').any { it.startsWith("data:") }
+}
+
+/**
+ * Thrown by [SseFraming.append] when the retained partial-block buffer exceeds its
+ * cap. The reader treats it like any other read failure (drop the connection and
+ * reconnect with backoff), so a server that never delimits frames can't exhaust
+ * memory.
+ */
+class SseFramingOverflowException(size: Int, cap: Int) :
+    RuntimeException("SSE frame buffer exceeded cap: $size > $cap chars")

--- a/android/app/src/main/java/com/lifeglance/app/sse/VaultSseClient.kt
+++ b/android/app/src/main/java/com/lifeglance/app/sse/VaultSseClient.kt
@@ -1,0 +1,258 @@
+package com.lifeglance.app.sse
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Native GLANCEvault SSE reader. Ported from dayGLANCE's production reader
+ * (dayglance-android sse/VaultSseClient.kt); the transport, lifecycle, and
+ * terminal-error policy are identical — only the renderer delivery differs
+ * (Capacitor plugin events via [VaultSsePlugin], not a WebView global).
+ *
+ * The WebView cannot stream `text/event-stream` (vault HTTP rides the buffered
+ * CapacitorHttp path), so the SHELL opens the stream instead: an authenticated
+ * `GET {vaultUrl}/events` with the Bearer device token, read incrementally,
+ * framed into SSE event blocks ([SseFraming]), and each block pushed into the
+ * renderer via [frameSink] (which [VaultSsePlugin] wires to notifyListeners).
+ * The renderer reuses its EXISTING `parseSseFrame` + coalescer + drains — this
+ * class owns ONLY the socket, its lifecycle, and reconnect.
+ *
+ * Because this is a native HTTP client (no browser origin), it needs NO vault
+ * CORS change. POLLING in the renderer stays the correctness backstop; these
+ * pushes only add instant drains on top.
+ *
+ * LIFECYCLE — the reader runs only when BOTH are true:
+ *   • the renderer has declared SSE desired ([enable] / [disable]), and
+ *   • the Activity is foreground ([setForeground]).
+ * It drops on background and reconnects with capped exponential backoff on any
+ * drop ([SseBackoff]). Every transition funnels through [reconcile], which
+ * starts or stops the SINGLE reader coroutine, so there is never more than one
+ * connection.
+ *
+ * RECONNECT-RECONCILE — on each (re)connect the vault sends its `ready` frame
+ * carrying the account's latest seq (`{"seq":N}`); it flows through [frameSink]
+ * like any other, so the renderer's coalescer drains and catches anything missed
+ * while disconnected.
+ */
+class VaultSseClient(
+    private val frameSink: (String) -> Unit,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var readerJob: Job? = null
+
+    // The connection currently being read, so cancellation (background / disable)
+    // can force-close it and unblock the reader's blocking read().
+    @Volatile private var activeConnection: HttpURLConnection? = null
+
+    @Volatile private var desired = false
+    @Volatile private var foreground = false
+    @Volatile private var vaultUrl: String? = null
+    @Volatile private var token: String? = null
+    @Volatile private var accountId: String? = null
+
+    /** Renderer → "SSE desired ON", with the vault connection params. */
+    @Synchronized
+    fun enable(url: String, bearer: String, account: String) {
+        vaultUrl = url.trimEnd('/')
+        token = bearer
+        accountId = account
+        desired = true
+        reconcile()
+    }
+
+    /** Renderer → "SSE desired OFF". */
+    @Synchronized
+    fun disable() {
+        desired = false
+        reconcile()
+    }
+
+    /** Activity foreground/background (handleOnStart / handleOnStop). */
+    @Synchronized
+    fun setForeground(fg: Boolean) {
+        foreground = fg
+        reconcile()
+    }
+
+    /** Full teardown — Activity destroyed. No leaked connection or coroutine. */
+    @Synchronized
+    fun shutdown() {
+        desired = false
+        foreground = false
+        stopReader()
+        scope.cancel()
+    }
+
+    private fun shouldRun(): Boolean =
+        desired && foreground && vaultUrl != null && token != null && accountId != null
+
+    private fun reconcile() {
+        if (shouldRun()) startReader() else stopReader()
+    }
+
+    private fun startReader() {
+        if (readerJob?.isActive == true) return
+        val url = vaultUrl ?: return
+        val bearer = token ?: return
+        val account = accountId ?: return
+        readerJob = scope.launch { runLoop(url, bearer, account) }
+    }
+
+    private fun stopReader() {
+        readerJob?.cancel()
+        readerJob = null
+        // Unblock a reader parked in a blocking read(): coroutine cancellation alone
+        // won't interrupt java.io, so force-close the socket.
+        try { activeConnection?.disconnect() } catch (_: Exception) {}
+    }
+
+    private suspend fun runLoop(url: String, bearer: String, account: String) {
+        val backoff = SseBackoff()
+        while (coroutineContext[Job]?.isActive == true) {
+            val openedAt = System.currentTimeMillis()
+            try {
+                connectAndRead(url, bearer, account)
+            } catch (e: SseTerminalException) {
+                // TERMINAL (auth failure / insecure URL): retrying can't help, so stop
+                // the reader entirely — no reconnect. Push a coded event so the renderer
+                // surfaces it exactly once instead of every 30s. A later enable() (user
+                // fixed the token/URL) launches a fresh reader normally.
+                if (coroutineContext[Job]?.isActive != true) return
+                Log.w(TAG, "SSE terminal (${e.code}): ${e.message}")
+                push(JSONObject().put("type", "error").put("code", e.code).put("message", e.message ?: e.code))
+                return
+            } catch (e: Exception) {
+                if (coroutineContext[Job]?.isActive != true) return // cancelled → done
+                Log.w(TAG, "SSE read error: ${e.message}")
+                push(JSONObject().put("type", "error").put("message", e.message ?: "sse error"))
+            }
+            if (coroutineContext[Job]?.isActive != true) return
+            // The stream ended (server close / read timeout / drop). Tell the
+            // renderer, then reconnect with backoff — resetting it only if the
+            // connection had been healthy long enough.
+            push(JSONObject().put("type", "closed"))
+            backoff.onClosed(System.currentTimeMillis() - openedAt)
+            delay(backoff.nextDelayMs())
+        }
+    }
+
+    private suspend fun connectAndRead(url: String, bearer: String, account: String) {
+        val target = URL("$url/events?accountId=" + URLEncoder.encode(account, "UTF-8"))
+        // Belt-and-braces (the settings form is the primary gate): never send the
+        // Bearer token over cleartext http on the public internet. https is always
+        // fine; http is allowed only for loopback/LAN hosts. A refusal is TERMINAL —
+        // reconnecting can't fix a bad scheme. (Android's manifest also blocks
+        // cleartext to non-local hosts; this fails EARLY and with a clear reason.)
+        if (!isSecureOrLanUrl(target)) {
+            throw SseTerminalException("insecure", "vault SSE refused: insecure http URL")
+        }
+        val conn = (target.openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("Authorization", "Bearer $bearer")
+            setRequestProperty("Accept", "text/event-stream")
+            connectTimeout = 20_000
+            // Longer than the ~20 s server heartbeat so a healthy idle stream never
+            // trips it, but a silently-dead connection is detected and reconnected
+            // within the timeout instead of parking forever.
+            readTimeout = 60_000
+            instanceFollowRedirects = true
+        }
+        activeConnection = conn
+        try {
+            val code = conn.responseCode
+            // 401/403 are auth failures — a revoked/invalid device token. Retrying just
+            // reconnects forever at the 30s cap and re-hits the same 401, so this is
+            // TERMINAL: stop the reader and push a distinct coded event the renderer
+            // surfaces once. A fresh enable() (user fixed the token) reconnects normally.
+            if (code == 401 || code == 403) {
+                throw SseTerminalException("auth", "vault SSE auth failed: $code")
+            }
+            // 404 means the server predates /events entirely (Express default route).
+            // Same terminal logic: reconnecting cannot grow a route; the renderer's
+            // polling covers the app identically. Mirrors the web transport's
+            // SseUnsupportedError classification.
+            if (code == 404) {
+                throw SseTerminalException("unsupported", "vault SSE unavailable: server predates /events")
+            }
+            if (code !in 200..299) throw RuntimeException("vault SSE connect failed: $code")
+            push(JSONObject().put("type", "open"))
+
+            val framing = SseFraming()
+            val reader = BufferedReader(InputStreamReader(conn.inputStream, Charsets.UTF_8))
+            val chunk = CharArray(2048)
+            while (coroutineContext[Job]?.isActive == true) {
+                val n = reader.read(chunk) // blocks until data, EOF (-1), or read timeout
+                if (n == -1) break         // server closed the stream
+                for (block in framing.append(String(chunk, 0, n))) {
+                    push(JSONObject().put("type", "frame").put("block", block))
+                }
+            }
+        } finally {
+            activeConnection = null
+            try { conn.disconnect() } catch (_: Exception) {}
+        }
+    }
+
+    private fun push(msg: JSONObject) {
+        // frameSink is any-thread safe: VaultSsePlugin routes it through
+        // notifyListeners, which queues onto the Capacitor bridge.
+        frameSink(msg.toString())
+    }
+
+    // ── URL transport-security allowlist ─────────────────────────────────────
+
+    /** https is always allowed; http only for loopback/LAN hosts; anything else no. */
+    private fun isSecureOrLanUrl(url: URL): Boolean {
+        val scheme = (url.protocol ?: "").lowercase()
+        if (scheme == "https") return true
+        if (scheme != "http") return false
+        return isLocalOrLanHost(url.host ?: "")
+    }
+
+    /** True for loopback / private-LAN / *.local hosts, where cleartext http is ok. */
+    private fun isLocalOrLanHost(rawHost: String): Boolean {
+        var host = rawHost.trim().lowercase()
+        if (host.startsWith("[") && host.endsWith("]")) host = host.substring(1, host.length - 1)
+        if (host.isEmpty()) return false
+        if (host == "localhost" || host.endsWith(".localhost")) return true
+        if (host == "::1") return true
+        if (host.endsWith(".local")) return true
+        val m = Regex("""^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$""").find(host) ?: return false
+        val octets = m.groupValues.drop(1).map { it.toInt() }
+        if (octets.any { it > 255 }) return false
+        val (a, b) = octets
+        return when {
+            a == 127 -> true               // 127.0.0.0/8 loopback
+            a == 10 -> true                // 10.0.0.0/8
+            a == 192 && b == 168 -> true   // 192.168.0.0/16
+            a == 172 && b in 16..31 -> true // 172.16.0.0/12
+            else -> false
+        }
+    }
+
+    companion object {
+        private const val TAG = "VaultSseClient"
+    }
+}
+
+/**
+ * A TERMINAL SSE error: the reader must stop and NOT reconnect (retrying can't
+ * help). [code] distinguishes the cause for the renderer ('auth' =
+ * revoked/invalid token; 'insecure' = refused cleartext URL; 'unsupported' =
+ * server predates /events).
+ */
+class SseTerminalException(val code: String, message: String) : Exception(message)

--- a/android/app/src/main/java/com/lifeglance/app/sse/VaultSsePlugin.kt
+++ b/android/app/src/main/java/com/lifeglance/app/sse/VaultSsePlugin.kt
@@ -1,0 +1,79 @@
+package com.lifeglance.app.sse
+
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import org.json.JSONObject
+
+/**
+ * Capacitor face of the native GLANCEvault SSE reader ([VaultSseClient]).
+ *
+ * The renderer (src/hooks/useVaultEventStream.js, 'native-bridge' transport)
+ * declares intent with start/stop and receives every reader message as an
+ * `sseMessage` plugin event — the same `{type, block?/message?/code?}` shapes
+ * dayGLANCE's shells push, so the renderer-side bridge client is shared code:
+ *   {type:'open'}                    a (re)connection was established
+ *   {type:'frame', block:'…'}        one raw SSE event block → parseSseFrame
+ *   {type:'closed'}                  the stream dropped (native will reconnect)
+ *   {type:'error', message, code?}   a coded error is TERMINAL (native stopped)
+ *
+ * The plugin owns only the wiring: lifecycle (foreground/background via the
+ * Capacitor activity callbacks) and delivery (notifyListeners, any-thread
+ * safe). The socket, reconnect, and terminal policy live in [VaultSseClient].
+ * Capability detection needs no method here — the renderer probes
+ * Capacitor.isPluginAvailable('VaultSse'), which an older shell without this
+ * plugin answers false, degrading cleanly to polling.
+ */
+@CapacitorPlugin(name = "VaultSse")
+class VaultSsePlugin : Plugin() {
+
+    private var client: VaultSseClient? = null
+
+    override fun load() {
+        client = VaultSseClient { msg ->
+            try {
+                notifyListeners("sseMessage", JSObject.fromJSONObject(JSONObject(msg)))
+            } catch (_: Exception) {
+                // A malformed reader message must never break the bridge.
+            }
+        }
+    }
+
+    @PluginMethod
+    fun start(call: PluginCall) {
+        val url = call.getString("vaultUrl")
+        val token = call.getString("vaultToken")
+        val account = call.getString("accountId")
+        if (url.isNullOrEmpty() || token.isNullOrEmpty() || account.isNullOrEmpty()) {
+            call.reject("vaultUrl, vaultToken, and accountId are required")
+            return
+        }
+        client?.enable(url, token, account)
+        call.resolve()
+    }
+
+    @PluginMethod
+    fun stop(call: PluginCall) {
+        client?.disable()
+        call.resolve()
+    }
+
+    // Foreground/background gating mirrors dayGLANCE's Activity wiring: the
+    // reader connects only while the Activity is started, drops on stop (the OS
+    // would kill the socket anyway), and the vault's `ready` frame reconciles on
+    // every reconnect.
+    override fun handleOnStart() {
+        client?.setForeground(true)
+    }
+
+    override fun handleOnStop() {
+        client?.setForeground(false)
+    }
+
+    override fun handleOnDestroy() {
+        client?.shutdown()
+        client = null
+    }
+}

--- a/android/app/src/test/java/com/lifeglance/app/sse/SseBackoffTest.kt
+++ b/android/app/src/test/java/com/lifeglance/app/sse/SseBackoffTest.kt
@@ -1,0 +1,59 @@
+package com.lifeglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the native reconnect backoff. Mirrors the flap-guard / stability-
+ * reset policy the renderer's createVaultEventClient is tested for, so native and
+ * web reconnect behaviour match: a flap keeps backing off (no storm), a healthy
+ * connection resets so a later drop reconnects fast.
+ */
+class SseBackoffTest {
+
+    @Test
+    fun `grows exponentially and caps at maxMs`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())  // 1000 * 2^0
+        assertEquals(2_000, b.nextDelayMs())  // 2^1
+        assertEquals(4_000, b.nextDelayMs())  // 2^2
+        assertEquals(8_000, b.nextDelayMs())  // 2^3
+        assertEquals(16_000, b.nextDelayMs()) // 2^4
+        assertEquals(30_000, b.nextDelayMs()) // 32000 capped to 30000
+        assertEquals(30_000, b.nextDelayMs()) // stays capped
+    }
+
+    @Test
+    fun `a flap (closed before minStableMs) does NOT reset — backoff keeps growing`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())
+        b.onClosed(50)                        // opened then dropped fast → no reset
+        assertEquals(2_000, b.nextDelayMs())  // continues to grow, no 1s storm
+        b.onClosed(100)
+        assertEquals(4_000, b.nextDelayMs())
+    }
+
+    @Test
+    fun `a stable connection (open past minStableMs) resets so the next reconnect is fast`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        b.nextDelayMs(); b.nextDelayMs(); b.nextDelayMs() // climb to attempt=3
+        b.onClosed(10_000)                    // healthy: open 10s ≥ 5s → reset
+        assertEquals(1_000, b.nextDelayMs())  // back to base
+    }
+
+    @Test
+    fun `reset returns to base`() {
+        val b = SseBackoff(baseMs = 500)
+        b.nextDelayMs(); b.nextDelayMs()
+        b.reset()
+        assertEquals(500, b.nextDelayMs())
+    }
+
+    @Test
+    fun `many attempts never overflow the delay (stays capped, non-negative)`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        repeat(200) { b.nextDelayMs() }
+        val d = b.nextDelayMs()
+        assertEquals(30_000, d) // clamped shift → no overflow/wrap to a bogus delay
+    }
+}

--- a/android/app/src/test/java/com/lifeglance/app/sse/SseFramingTest.kt
+++ b/android/app/src/test/java/com/lifeglance/app/sse/SseFramingTest.kt
@@ -1,0 +1,90 @@
+package com.lifeglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the native SSE frame boundary detector. Mirrors the behaviour
+ * the renderer's drainSseBuffer is tested for (src/sync/vaultEventStream.test.ts),
+ * so the native framing and the JS parser agree on what a "complete event block"
+ * is. Fixtures use the REAL wire format — named `ready`/`activity` events whose
+ * data is exactly {"seq":N} — never fabricated fields.
+ */
+class SseFramingTest {
+
+    @Test
+    fun `emits complete blocks and carries the partial remainder across reads`() {
+        val f = SseFraming()
+        // Two complete events plus a partial third, split awkwardly across reads.
+        val first = f.append("event: ready\ndata: {\"seq\":1}\n\nevent: activity\ndata: {\"seq\":2")
+        assertEquals(listOf("event: ready\ndata: {\"seq\":1}"), first)
+
+        // The partial second event is buffered — nothing emitted yet.
+        val second = f.append("}\n\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":2}"), second)
+    }
+
+    @Test
+    fun `normalizes CRLF and CR frame boundaries`() {
+        val f = SseFraming()
+        val blocks = f.append("event: activity\r\ndata: {\"seq\":7}\r\n\r\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":7}"), blocks)
+    }
+
+    @Test
+    fun `drops heartbeat and comment-only blocks (no data line)`() {
+        val f = SseFraming()
+        val blocks = f.append(": heartbeat\n\nevent: ping\n\nevent: activity\ndata: {\"seq\":4}\n\n")
+        // Only the block carrying a data: line is forwarded.
+        assertEquals(listOf("event: activity\ndata: {\"seq\":4}"), blocks)
+    }
+
+    @Test
+    fun `multi-line block is forwarded verbatim for the renderer to parse`() {
+        val f = SseFraming()
+        val block = "event: activity\nid: 9\ndata: {\"seq\":9}"
+        val blocks = f.append("$block\n\n")
+        assertEquals(listOf(block), blocks)
+    }
+
+    @Test
+    fun `reset discards a partial block so a new stream does not glue onto the old`() {
+        val f = SseFraming()
+        f.append("event: activity\ndata: {\"seq\":1") // partial, buffered
+        f.reset()
+        // Fresh stream after reconnect: the leftover partial must be gone.
+        val blocks = f.append("event: ready\ndata: {\"seq\":2}\n\n")
+        assertEquals(listOf("event: ready\ndata: {\"seq\":2}"), blocks)
+    }
+
+    @Test(expected = SseFramingOverflowException::class)
+    fun `throws when a single undelimited frame exceeds the cap`() {
+        // A server that streams bytes but never the "\n\n" delimiter must not grow the
+        // buffer without bound — append throws once the retained partial exceeds the cap.
+        val f = SseFraming(maxBufferChars = 1024)
+        f.append("data: " + "x".repeat(2000)) // no blank-line boundary, over cap
+    }
+
+    @Test
+    fun `does not throw while the buffer stays under the cap and still drains`() {
+        val f = SseFraming(maxBufferChars = 1024)
+        // Under-cap partial is retained (no throw); a later delimiter completes it.
+        assertEquals(emptyList<String>(), f.append("event: activity\ndata: {\"seq\":1"))
+        val blocks = f.append("}\n\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":1}"), blocks)
+    }
+
+    @Test
+    fun `handles several complete blocks in one chunk`() {
+        val f = SseFraming()
+        val blocks = f.append(
+            "event: ready\ndata: {\"seq\":1}\n\n" +
+                "event: activity\ndata: {\"seq\":2}\n\n" +
+                "event: activity\ndata: {\"seq\":3}\n\n"
+        )
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0].contains("ready"))
+        assertTrue(blocks[2].contains("{\"seq\":3}"))
+    }
+}


### PR DESCRIPTION
SSE PR 2 of 3, following the web transport (#291). The Android WebView cannot stream `/events` (vault HTTP rides the buffered CapacitorHttp path), so the shell owns the socket: a native reader that connects while the Activity is foreground, drops on background, reconnects with capped backoff, and pushes each raw SSE block to the renderer as an `sseMessage` plugin event. The renderer side shipped in #291 and needs **zero changes** — `detectSseTransport` answers `'native-bridge'` the moment this plugin is registered, and the shared `parseSseFrame` → coalescer → drains path does the rest.

This is a package-rename port of lastGLANCE's device-proven reader (its phase 2, live on your phone/tablet since v2.2.0):

- **`sse/SseFraming.kt`**, **`sse/SseBackoff.kt`** — byte framer (blank-line delimiter, CRLF normalisation, heartbeat blocks dropped so the bridge isn't woken every 20s, 1MB overflow cap) and capped exponential backoff with the 5s stability reset. Pure classes, unit-tested.
- **`sse/VaultSseClient.kt`** — the reader: authenticated `GET /events` over HttpURLConnection, 60s read timeout comfortably above the 20s heartbeat, desired+foreground reconcile guaranteeing a single reader coroutine, and terminal (no-reconnect) classification: 401/403 auth, 404 server-predates-`/events`, and refusal of cleartext non-LAN URLs (https always allowed; http only for loopback/RFC-1918/`.local`).
- **`sse/VaultSsePlugin.kt`** — the Capacitor face: `start`/`stop`, every reader message delivered via `notifyListeners`, foreground gating on the activity lifecycle callbacks. Registered in MainActivity alongside the existing plugins.
- **`build.gradle`** — explicit `kotlinx-coroutines-android:1.8.1` (Glance/WorkManager pull it transitively; the reader depends on it directly).

## Verified here

- `SseFraming`/`SseBackoff`/`VaultSseClient` compile clean under standalone kotlinc against android+coroutines stubs.
- The ported JUnit suite passes **13/13** (real-wire byte fixtures: split chunks, CRLF, heartbeat-only blocks, overflow cap, backoff ladder + stability reset).
- No JS-side diff in this PR.

`VaultSsePlugin.kt` needs the Capacitor classpath, so its compile check lands with the first device build — same situation as the lastGLANCE round, where the identical plugin then built and ran clean on-device. It is byte-identical modulo the package name.

## Device check after merge

Build and install a debug APK, then the same routine as lastGLANCE: `window.__glanceVaultSse` via chrome://inspect should show `transport: 'native-bridge'`, the connection appears in GLANCEvault's log, a change on another device lands sub-second, and backgrounding/foregrounding the app drops and re-establishes the stream (each reconnect's `ready` frame reconciles anything missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_