### PR TITLE
Reset per-stream vault sync state when the vault identity changes

### DIFF
--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -27,6 +27,35 @@ const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
 const DEVICE_ID_KEY  = 'lifeglance-db-sync-device-id'
 const SEEDED_KEY     = 'lifeglance-db-sync-seeded'
 
+// Every piece of persisted vault-sync state that belongs to one account's data
+// stream. Key names must match @glance-apps/sync dbEngine.js's
+// `${storageKeyPrefix}-...` keys for storageKeyPrefix 'lifeglance', plus this
+// wrapper's one-shot seed flag. DEVICE_ID_KEY is deliberately absent: it
+// identifies the device (not the stream) and survives re-links.
+const STREAM_STATE_KEYS = [
+  SEEDED_KEY,
+  'lifeglance-db-sync-config',          // engine's saved identity record
+  'lifeglance-db-sync-hwm',             // pull cursor
+  'lifeglance-db-sync-push-ack',        // push idempotency marker
+  'lifeglance-db-sync-dirty',           // persisted dirty set
+  'lifeglance-db-sync-quarantine',      // undecryptable-row retry set (seq-based)
+  'lifeglance-db-sync-last-synced',     // display timestamp
+  'lifeglance-db-sync-credential-halt', // sync 1.10 hard halt (old credential)
+]
+
+// Reset all per-stream sync state. Called when the vault IDENTITY changes
+// (different accountId or vaultUrl — see runVaultSetup): cursors from one
+// account must never be applied to another. A stale pull cursor would suppress
+// the new account's low-seq rows, and the one-shot seed flag would keep this
+// device's pre-existing local data from ever uploading (#286). After the
+// reset, the next cycle re-seeds: HWM=0 pulls everything the account has, and
+// seedSnapshot marks all local entities dirty for the full-snapshot push.
+export const resetVaultSyncState = () => {
+  for (const key of STREAM_STATE_KEYS) {
+    try { localStorage.removeItem(key) } catch { /* storage unavailable — nothing to clear */ }
+  }
+}
+
 let _dbEngine = null
 let _pushTimer = null
 // Once-per-session guard so a device that can't derive the vault intents/blob key

--- a/src/sync/vaultSetup.js
+++ b/src/sync/vaultSetup.js
@@ -26,7 +26,7 @@ import {
   setupDbRootKey as defaultSetupDbRootKey,
 } from '@glance-apps/sync'
 import { setupVaultIntentsRootKey as defaultSetupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
-import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine } from './dbSync.js'
+import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine, resetVaultSyncState as defaultResetVaultSyncState } from './dbSync.js'
 import { nativeVaultFetchImpl } from './nativeVaultFetch.js'
 
 const CONFIG_KEY    = 'lifeglance-cloud-sync-config'
@@ -107,6 +107,18 @@ export async function runVaultSetup({ vaultUrl, vaultToken, accountId, passphras
     return { ok: false, kind: outcome.kind }
   }
   if (!passphrase) return { ok: false, kind: 'passphrase' }
+
+  // Identity change (different account or server): the previous stream's
+  // cursors, seed flag, and credential-halt state must not survive into the
+  // new one (#286) — a stale pull cursor would suppress the new account's
+  // low-seq rows, and the one-shot seed flag would keep this device's
+  // pre-existing data from ever uploading. A token-only rotation keeps the
+  // identity, and therefore the cursors: nothing about the data stream moved.
+  let prev = null
+  try { prev = JSON.parse(localStorage.getItem(CONFIG_KEY) || 'null') } catch { prev = null }
+  const identityChanged = !!(prev && prev.vaultUrl && prev.accountId &&
+    (prev.vaultUrl.trim() !== vaultUrl.trim() || prev.accountId.trim() !== accountId.trim()))
+  if (identityChanged) (deps.resetVaultSyncState ?? defaultResetVaultSyncState)()
 
   // Persist the exact shape the engine reads (WebDAV fields preserved).
   ;(deps.persist ?? persistVaultConfig)({ vaultUrl, vaultToken, accountId })

--- a/src/sync/vaultSetup.test.js
+++ b/src/sync/vaultSetup.test.js
@@ -147,6 +147,60 @@ describe('runVaultSetup — verify-before-save gate', () => {
   })
 })
 
+describe('runVaultSetup — stream-state reset on identity change (#286)', () => {
+  const okClient = clientReturning(() => new Uint8Array(16).fill(1))
+
+  it('re-link to a DIFFERENT account resets the per-stream sync state', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    const deps = { ...spyDeps(okClient), resetVaultSyncState: vi.fn() }
+    const r = await runVaultSetup({ ...CREDS, accountId: 'house-2', passphrase: 'pw' }, deps)
+    expect(r.ok).toBe(true)
+    expect(deps.resetVaultSyncState).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-link to a different SERVER resets too', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    const deps = { ...spyDeps(okClient), resetVaultSyncState: vi.fn() }
+    await runVaultSetup({ ...CREDS, vaultUrl: 'https://other.example', passphrase: 'pw' }, deps)
+    expect(deps.resetVaultSyncState).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-save of the SAME identity (incl. token-only rotation) keeps cursors', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    const deps = { ...spyDeps(okClient), resetVaultSyncState: vi.fn() }
+    await runVaultSetup({ ...CREDS, vaultToken: 'rotated-tok', passphrase: 'pw' }, deps)
+    expect(deps.resetVaultSyncState).not.toHaveBeenCalled()
+  })
+
+  it('a disabled-but-remembered identity still counts (disable keeps creds)', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: false, ...CREDS }))
+    const deps = { ...spyDeps(okClient), resetVaultSyncState: vi.fn() }
+    await runVaultSetup({ ...CREDS, accountId: 'house-2', passphrase: 'pw' }, deps)
+    expect(deps.resetVaultSyncState).toHaveBeenCalledTimes(1)
+  })
+
+  it('first link (no previous identity) does not reset', async () => {
+    const deps = { ...spyDeps(okClient), resetVaultSyncState: vi.fn() }
+    await runVaultSetup({ ...CREDS, passphrase: 'pw' }, deps)
+    expect(deps.resetVaultSyncState).not.toHaveBeenCalled()
+  })
+
+  it('resetVaultSyncState (the real one) clears the seed flag and every engine cursor, not the device id', async () => {
+    const { resetVaultSyncState } = await import('./dbSync.js')
+    const streamKeys = [
+      'lifeglance-db-sync-seeded', 'lifeglance-db-sync-config',
+      'lifeglance-db-sync-hwm', 'lifeglance-db-sync-push-ack',
+      'lifeglance-db-sync-dirty', 'lifeglance-db-sync-quarantine',
+      'lifeglance-db-sync-last-synced', 'lifeglance-db-sync-credential-halt',
+    ]
+    for (const k of streamKeys) localStorage.setItem(k, 'x')
+    localStorage.setItem('lifeglance-db-sync-device-id', 'dev-keep')
+    resetVaultSyncState()
+    for (const k of streamKeys) expect(localStorage.getItem(k)).toBeNull()
+    expect(localStorage.getItem('lifeglance-db-sync-device-id')).toBe('dev-keep')
+  })
+})
+
 describe('disableVault', () => {
   it('clears only vaultEnabled, keeps WebDAV + vault creds, rebuilds engine', async () => {
     const webdav = { provider: 'nextcloud', url: 'https://nc.example', username: 'me', enabled: true }


### PR DESCRIPTION
Closes #286

The one-shot seed flag (`lifeglance-db-sync-seeded`) was set once and never cleared, and the engine's persisted cursors survived any re-link. Consequence, exactly as the audit found: a device re-linked to a **different account or server** never re-seeded — its pre-existing local data silently never uploaded, and the stale pull cursor suppressed the new account's low-seq rows.

## The fix

- **`dbSync.js`** exports `resetVaultSyncState()`, clearing everything that belongs to one account's data stream: the seed flag plus all seven engine keys (`-db-sync-config`, `-hwm`, `-push-ack`, `-dirty`, `-quarantine`, `-last-synced`, and the sync-1.10 `-credential-halt`). The device id deliberately survives — it identifies the device, not the stream.
- **`vaultSetup.js`** — `runVaultSetup` compares the previously persisted `vaultUrl`/`accountId` (enabled **or** disabled, since `disableVault` keeps credentials for one-toggle re-enable) against the new values, and resets on any identity change before persisting and reactivating. The next cycle then re-seeds from HWM=0 in both directions: full pull of the new account, full-snapshot push of local data.

## The line drawn: token rotation keeps cursors

A token-only change (like your recent fleet-wide rotation) keeps the identity — nothing about the data stream moved — so cursors survive and no fleet-wide re-seed storm follows a credential refresh. Clearing the credential halt on identity change is also the correct interplay with 1.10: fresh identity, fresh verdict.

Also audited per the issue: there is no wholesale-restore path that bypasses the data layer (ICS import goes through `addMilestone` → markDirty), so re-link is the only full-state-replacement seam needing the reset today. This matches dayGLANCE's `resetVaultSyncCursor` pattern, extended for the 1.10-era keys.

## Verification

Six new tests (433 total passing, lint at baseline): different account resets; different server resets; same-identity re-save and token-only rotation keep state; a remembered-but-disabled identity still counts; first link never resets; and the real `resetVaultSyncState` clears exactly the stream keys while preserving the device id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_