### PR TITLE
Wire vault DB-engine errors into the sync indicator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { initDB, dbGetAll, dbGetAllChapters } from './data/db'
 import { backfillMediaIds } from './data/milestones'
 import { initSyncEngine, getSyncEngine } from './sync/engine'
 import { initDbSyncEngine, getDbSyncEngine } from './sync/dbSync'
+import { combineTierErrors } from './sync/status'
 import { useVaultEventStream } from './hooks/useVaultEventStream'
 import { drainIntentsNow } from './hooks/useIntentPoller'
 import { buildWidgetSnapshot } from './utils/widgetSnapshot'
@@ -24,6 +25,13 @@ export default function App() {
   const [syncStatus,  setSyncStatus]  = useState('idle')
   const [syncError,   setSyncError]   = useState(null)
   const [syncHalted,  setSyncHalted]  = useState(false)
+  // Vault (DB-tier) error, kept SEPARATE from the WebDAV tier's syncError so
+  // the two engines' cycles can't clobber each other's state; the display
+  // combines them with precedence (combineTierErrors). Shape:
+  // { message, code, hard } | null. hard=true is the sync 1.10 credential
+  // halt, which the engine re-surfaces on every attempted cycle — so
+  // clear-on-null is safe (nulls never arrive while halted).
+  const [vaultError,  setVaultError]  = useState(null)
   const [lastSynced,  setLastSynced]  = useState(null)
   // Per-row quarantine signal from the sync engine: { count, entityIds, at } | null.
   // Drives a transient toast (TimelineView) and a durable amber note (CloudSyncModal).
@@ -151,6 +159,13 @@ export default function App() {
           // it's missing and vault intents are in use, prompt for it (same modal
           // the WebDAV engine uses); onUnlocked re-runs the DB sync to derive it.
           onPassphraseRequired: () => setShowPassphraseModal(true),
+          // Surface vault-side errors (issue #289): KEY_MISMATCH, network, and
+          // the sync 1.10 CREDENTIAL_INVALID halt / QUOTA_EXCEEDED all arrive
+          // here. The engine emits (message, code, isHardStop) and fires
+          // (null, null, false) as its clean-cycle reset.
+          onError: (message, code, isHardStop) => {
+            setVaultError(message == null ? null : { message, code, hard: !!isHardStop })
+          },
         })
 
         // Restore encryption session key from IDB so the passphrase prompt
@@ -270,6 +285,9 @@ export default function App() {
     setScreen('timeline')
   }
 
+  // One indicator, two tiers: precedence applied at render time (status.js).
+  const { error: displayError, halted: displayHalted } = combineTierErrors(syncError, syncHalted, vaultError)
+
   const content = screen === 'loading' ? (
     <div className="app-loading">
       <span className="cursor" style={{ width: '8px', height: '8px', borderRadius: '50%' }} />
@@ -283,8 +301,8 @@ export default function App() {
       chapters={chapters}
       setChapters={setChapters}
       syncStatus={syncStatus}
-      syncError={syncError}
-      syncHalted={syncHalted}
+      syncError={displayError}
+      syncHalted={displayHalted}
       lastSynced={lastSynced}
       vaultSkipped={vaultSkipped}
       onOpenCloudSync={() => setCloudSyncOpen(true)}
@@ -313,8 +331,8 @@ export default function App() {
       {cloudSyncOpen && (
         <CloudSyncModal
           syncStatus={syncStatus}
-          syncError={syncError}
-          syncHalted={syncHalted}
+          syncError={displayError}
+          syncHalted={displayHalted}
           lastSynced={lastSynced}
           vaultSkipped={vaultSkipped}
           onClose={() => setCloudSyncOpen(false)}

--- a/src/sync/status.js
+++ b/src/sync/status.js
@@ -61,3 +61,22 @@ export const syncErrorText = (syncError, t) => {
   const key = SYNC_ERROR_I18N_KEYS[syncError.code]
   return key ? t(key) : syncError.message
 }
+
+// Two sync tiers, one indicator. Each engine owns its OWN error state — the
+// WebDAV tier's ({message, code} + its halted flag) and the vault tier's
+// ({message, code, hard} from the DB engine's onError) — because wiring both
+// engines to one state would let their cycles clobber/clear each other's
+// errors. Precedence is applied here, at render time:
+//   1. A vault HARD halt (sync 1.10 CREDENTIAL_INVALID, isHardStop=true)
+//      outranks everything: the engine has terminally stopped and re-surfaces
+//      the halt on every attempted cycle, so it stays visible until recovery.
+//   2. Otherwise the WebDAV tier's error wins (its halted flag is
+//      tier-specific and its wiring is the long-established one).
+//   3. Otherwise a transient vault error shows.
+// Returns { error, halted } in the exact shape the existing indicator and
+// modal props consume.
+export const combineTierErrors = (syncError, syncHalted, vaultError) => {
+  if (vaultError?.hard) return { error: vaultError, halted: true }
+  if (syncError) return { error: syncError, halted: !!syncHalted }
+  return { error: vaultError ?? null, halted: !!syncHalted }
+}

--- a/src/sync/status.test.js
+++ b/src/sync/status.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isSyncing, SYNC_ERROR_I18N_KEYS, syncErrorText } from './status.js'
+import { isSyncing, SYNC_ERROR_I18N_KEYS, combineTierErrors, syncErrorText } from './status.js'
 
 describe('isSyncing', () => {
   it('is true for the in-flight statuses', () => {
@@ -69,5 +69,27 @@ describe('syncErrorText', () => {
     // never reach the display layer. If it ever did, it falls back to raw text
     // rather than being treated as a known, scary error.
     expect(SYNC_ERROR_I18N_KEYS.ACCOUNT_ID_REQUIRED).toBeUndefined()
+  })
+})
+
+describe('combineTierErrors — two tiers, one indicator', () => {
+  const webdavErr = { message: 'webdav down', code: 'NETWORK_ERROR' }
+  const vaultErr  = { message: 'vault down', code: 'NETWORK_ERROR', hard: false }
+  const vaultHalt = { message: 'credential rejected', code: 'CREDENTIAL_INVALID', hard: true }
+
+  it('no errors: clean', () => {
+    expect(combineTierErrors(null, false, null)).toEqual({ error: null, halted: false })
+  })
+
+  it('a vault hard halt outranks a WebDAV error and forces halted styling', () => {
+    expect(combineTierErrors(webdavErr, false, vaultHalt)).toEqual({ error: vaultHalt, halted: true })
+  })
+
+  it('the WebDAV tier wins over a transient vault error', () => {
+    expect(combineTierErrors(webdavErr, true, vaultErr)).toEqual({ error: webdavErr, halted: true })
+  })
+
+  it('a transient vault error shows when WebDAV is clean', () => {
+    expect(combineTierErrors(null, false, vaultErr)).toEqual({ error: vaultErr, halted: false })
   })
 })


### PR DESCRIPTION
Closes #289

The vault engine's `onError` went nowhere — App passed no error callback, so `KEY_MISMATCH`, network failures, and the sync-1.10 `CREDENTIAL_INVALID` halt / `QUOTA_EXCEEDED` were emitted and silently dropped. A credential-halted device stopped syncing with no visible indication of why, even though #288 put the strings and code mapping in place.

## Design (the part #289 said needed care)

The two tiers keep **separate** error state so their cycles can't clobber each other:

- WebDAV keeps `syncError`/`syncHalted` exactly as before.
- The vault tier gets its own `vaultError` (`{message, code, hard}`), fed by the engine's `(message, code, isHardStop)` emissions, cleared on the engine's null resets. Clear-on-null is safe for the halt because the 1.10 engine **re-surfaces a standing credential halt on every attempted cycle** and never fires the clean-cycle null reset while halted (verified against the 1.10 source) — so the halt display is sticky by construction, and clears itself the moment a recovered engine's cycles run clean.

Precedence lives in `status.js` as `combineTierErrors` (unit-tested): a vault hard halt outranks everything and forces halted styling; otherwise the WebDAV tier's error wins; otherwise a transient vault error shows. App computes the combined pair at render time and feeds the **existing** `syncError`/`syncHalted` props of TimelineView and CloudSyncModal — zero component changes, and vault errors render localized through the same `syncErrorText` path (which is why the #288/#294 locale work makes this drop-in).

## Deliberately not in scope

- `onStatusChange` from the vault engine stays unwired: two engines driving the one status dot would flicker against each other, and the dot's error color already follows the combined error.
- The known 1.10 nuance where a cycle's `onError(null)` reset can clear a transient error while a backoff window is still open. That's the "event stream, not status store" behavior; the fix is backoff-aware status via `getBackoffState()`, which is the follow-up tracked alongside lastGLANCE #250.

## Verification

4 new precedence tests (431 total passing), lint at baseline, production build clean. Manual check once merged: enter a wrong vault token on a test config and the indicator goes rose with the localized credential message instead of staying silently green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_