### PR TITLE
Prune tombstone bundles at a shared fixed retention window

### DIFF
--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -1,4 +1,5 @@
 import { mergeArrayById, pruneTombstones } from '@glance-apps/sync';
+import { tombstoneCutoff } from './tombstoneRetention.js';
 import { dbGetAll, dbGetAllChapters, dbPut, dbDelete, dbPutChapter, dbDeleteChapter } from '../data/db.js';
 import { getMilestoneTombstones, getChapterTombstones } from './tombstones.js';
 import { loadCategories, saveCategories } from '../utils/colors.js';
@@ -10,7 +11,6 @@ import { loadCategories, saveCategories } from '../utils/colors.js';
 // grace period for that edge case — raising it widens the safe-offline window
 // at the cost of retaining more tombstones; don't lower it without accounting
 // for the increased resurrection risk.
-const RETENTION_MS = 90 * 86_400_000;
 
 // buildPayload — reads live IDB state. Called before every upload.
 // Accepts a milestonesRef so it can read the latest React state for milestones
@@ -139,7 +139,9 @@ export const mergePayloads = (local, remote) => {
   const lct = localLife.chapterTombstones ?? {};
   const rct = remoteLife.chapterTombstones ?? {};
 
-  const cutoff = new Date(Date.now() - RETENTION_MS);
+  // Shared fixed 90-day window, day-floored (tombstoneRetention.js) so both
+  // sync tiers prune identically and the cutoff is stable within a day.
+  const cutoff = tombstoneCutoff();
   const milestoneTombstones = pruneTombstones({ ...lmt, ...rmt }, cutoff);
   const chapterTombstones = pruneTombstones({ ...lct, ...rct }, cutoff);
 

--- a/src/sync/dbAdapter.js
+++ b/src/sync/dbAdapter.js
@@ -37,6 +37,7 @@
 
 import { normalizeMemberOps } from '../data/chapters.js'
 import { LIFE_ID, BUNDLE_KINDS, bundleEntityId } from './entityIds.js'
+import { tombstoneCutoff, pruneTombstoneMap } from './tombstoneRetention.js'
 
 export { LIFE_ID, BUNDLE_KINDS, bundleEntityId }
 
@@ -96,15 +97,21 @@ export function mergeCategories(localArr, localTs, remoteArr, remoteTs) {
 }
 
 // TOMBSTONE MAPS (A3 — don't regress the existing per-key merge).
-// id → ISO. UNION keeping the latest ISO per key (commutative). Different-id
-// tombstones from two devices both survive; same-id keeps the later stamp.
-export function mergeTombstoneMap(localMap, remoteMap) {
+// id → ISO. UNION keeping the latest ISO per key (commutative), then PRUNED at
+// the shared fixed retention cutoff (#287). Pruning inside the merge — rather
+// than as a separate local pass — is what escapes the grow-only re-inflation
+// trap: a peer's unpruned copy contributes only entries inside the window, so
+// a pruned map can never oscillate pruned↔restored across cycles. The cutoff
+// is day-floored (tombstoneRetention.js), so every merge within a UTC day
+// computes the same result and an unchanged bundle compares equal (no dirty
+// mark, no push, no SSE self-nudge).
+export function mergeTombstoneMap(localMap, remoteMap, cutoff = tombstoneCutoff()) {
   const out = { ...(localMap && typeof localMap === 'object' ? localMap : {}) }
   const r = remoteMap && typeof remoteMap === 'object' ? remoteMap : {}
   for (const [id, iso] of Object.entries(r)) {
     if (!(id in out) || ts(iso) > ts(out[id])) out[id] = iso
   }
-  return out
+  return pruneTombstoneMap(out, cutoff)
 }
 
 // CHAPTER MEMBERSHIP (A2 — within-entity set hazard → LWW-element-set).
@@ -185,7 +192,15 @@ export function makeDbAdapter({ store, markDirty = () => {} }) {
   // ── Bundle envelope <-> repr ──
   const bundleEnvelope = async (kind) => {
     const repr = await store.getBundle(kind)
-    const env = { _kind: kind, life_id: LIFE_ID, value: repr.value }
+    // Tombstone bundles are pruned at PRODUCE too (#287): the pushed envelope
+    // must carry the same pruned set the merge side computes, or a device
+    // holding a stale unpruned local copy would keep re-publishing aged-out
+    // entries for its peers to re-merge. Same day-floored cutoff as the merge,
+    // so produce and merge agree byte-for-byte within a day.
+    const value = (kind === 'milestoneTombstones' || kind === 'chapterTombstones')
+      ? pruneTombstoneMap(repr.value, tombstoneCutoff())
+      : repr.value
+    const env = { _kind: kind, life_id: LIFE_ID, value }
     if ('updatedAt' in repr) env.updatedAt = repr.updatedAt
     return env
   }

--- a/src/sync/tombstoneRetention.js
+++ b/src/sync/tombstoneRetention.js
@@ -1,0 +1,79 @@
+// Fixed tombstone-retention policy, shared by BOTH sync tiers.
+//
+// WHY THIS EXISTS (issue #287): lifeGLANCE runs two sync transports over the
+// SAME local tombstone maps:
+//   (a) the WebDAV file-tier merge (adapter.js mergePayloads), which prunes at
+//       a 90-day window it computed FULL-PRECISION per merge, and
+//   (b) the vault DB tier (dbAdapter.js mergeTombstoneMap), which was grow-only
+//       and NEVER pruned — every deletion ever made lived forever in a
+//       singleton bundle that is re-encrypted, re-pushed whole, and re-merged
+//       each time it changes.
+// Beyond unbounded growth, the mismatch is the dayGLANCE two-transport
+// heartbeat waiting to happen: with both tiers enabled, an entry the file tier
+// prunes gets re-added by the grow-only vault union, the shared singleton
+// flips pruned↔restored across cycles, each flip marks the bundle dirty, each
+// push advances the account seq, and under SSE each seq advance nudges the
+// next cycle — a continuous self-nudge loop. dayGLANCE hit exactly this and
+// landed the pattern this module ports (its tombstoneRetention.js /
+// tombstoneHorizon.js): ONE fixed window, applied identically wherever
+// tombstones are produced or merged, with the cutoff floored to the UTC day so
+// every cycle within a day computes the SAME value and an unchanged bundle
+// compares equal.
+//
+// WHY 90 DAYS: it is the file tier's long-shipped window, so aligning the
+// vault tier to it changes no existing pruning behavior. A tombstone only
+// needs to outlive the longest realistic gap before a stale device next syncs
+// and would otherwise resurrect a deleted item; 90 days covers a device left
+// in a drawer for a season. Deliberately NOT user-configurable — coupling the
+// window to a user setting is how dayGLANCE's loop started.
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export const TOMBSTONE_RETENTION_DAYS = 90
+
+/**
+ * Floor an ISO timestamp to the start of its UTC day, as an ISO string.
+ * null/undefined/unparseable pass through unchanged. Idempotent.
+ */
+export function floorToUtcDayIso(iso) {
+  if (!iso) return iso
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return iso
+  return new Date(Math.floor(t / DAY_MS) * DAY_MS).toISOString()
+}
+
+/**
+ * The day-floored cutoff Date: tombstone entries with a timestamp strictly
+ * older than this are eligible for pruning. Flooring to the UTC day keeps the
+ * cutoff STABLE across the many sync cycles within a day, so an unchanged
+ * bundle merges/produces byte-identically and nothing gets marked dirty — the
+ * anti-oscillation property the whole design hangs on.
+ *
+ * @param {number} [nowMs] current epoch ms (injectable for tests)
+ * @returns {Date}
+ */
+export function tombstoneCutoff(nowMs = Date.now()) {
+  const floored = floorToUtcDayIso(new Date(nowMs - TOMBSTONE_RETENTION_DAYS * DAY_MS).toISOString())
+  return new Date(floored)
+}
+
+/**
+ * Drop tombstone entries older than `cutoff`. Absent or unparseable timestamps
+ * are KEPT (fail-safe: never lose a tombstone we can't date — losing one risks
+ * resurrecting a deleted item, keeping one only costs bytes). Returns a NEW
+ * object; a null cutoff returns an unpruned copy.
+ *
+ * @param {Record<string,string>} map  {id → ISO deletion timestamp}
+ * @param {Date|null} cutoff
+ * @returns {Record<string,string>}
+ */
+export function pruneTombstoneMap(map, cutoff) {
+  if (!map || typeof map !== 'object') return {}
+  if (!cutoff) return { ...map }
+  const out = {}
+  for (const [id, ts] of Object.entries(map)) {
+    const t = new Date(ts).getTime()
+    if (Number.isNaN(t) || t >= cutoff.getTime()) out[id] = ts
+  }
+  return out
+}

--- a/src/sync/tombstoneRetention.test.js
+++ b/src/sync/tombstoneRetention.test.js
@@ -1,0 +1,117 @@
+// Tests for the shared fixed tombstone-retention policy (#287) — the window,
+// the day-floored cutoff's stability, the fail-safe prune, and the
+// anti-oscillation properties the vault tier's merge/produce sides hang on.
+
+import { describe, it, expect } from 'vitest'
+import {
+  TOMBSTONE_RETENTION_DAYS, floorToUtcDayIso, tombstoneCutoff, pruneTombstoneMap,
+} from './tombstoneRetention.js'
+import { mergeTombstoneMap, makeDbAdapter, bundleEntityId } from './dbAdapter.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const iso = (ms) => new Date(ms).toISOString()
+
+describe('floorToUtcDayIso', () => {
+  it('floors to the start of the UTC day and is idempotent', () => {
+    const floored = floorToUtcDayIso('2026-08-09T17:23:45.678Z')
+    expect(floored).toBe('2026-08-09T00:00:00.000Z')
+    expect(floorToUtcDayIso(floored)).toBe(floored)
+  })
+  it('passes null/undefined/garbage through unchanged', () => {
+    expect(floorToUtcDayIso(null)).toBeNull()
+    expect(floorToUtcDayIso(undefined)).toBeUndefined()
+    expect(floorToUtcDayIso('not-a-date')).toBe('not-a-date')
+  })
+})
+
+describe('tombstoneCutoff', () => {
+  it('is stable across every moment of a UTC day (the anti-churn property)', () => {
+    const morning = Date.UTC(2026, 7, 9, 0, 30)
+    const night = Date.UTC(2026, 7, 9, 23, 59)
+    expect(tombstoneCutoff(morning).getTime()).toBe(tombstoneCutoff(night).getTime())
+  })
+  it('advances exactly one day at the UTC rollover', () => {
+    const before = tombstoneCutoff(Date.UTC(2026, 7, 9, 23, 59))
+    const after = tombstoneCutoff(Date.UTC(2026, 7, 10, 0, 1))
+    expect(after.getTime() - before.getTime()).toBe(DAY_MS)
+  })
+})
+
+describe('pruneTombstoneMap', () => {
+  const now = Date.now()
+  const cutoff = tombstoneCutoff(now)
+  it('drops entries older than the cutoff, keeps newer ones', () => {
+    const old = iso(now - (TOMBSTONE_RETENTION_DAYS + 5) * DAY_MS)
+    const fresh = iso(now - 1000)
+    expect(pruneTombstoneMap({ a: old, b: fresh }, cutoff)).toEqual({ b: fresh })
+  })
+  it('keeps unparseable timestamps (fail-safe: never lose an undatable tombstone)', () => {
+    expect(pruneTombstoneMap({ a: 'garbage', b: iso(now) }, cutoff)).toEqual({ a: 'garbage', b: iso(now) })
+  })
+  it('null cutoff returns an unpruned copy; input is never mutated', () => {
+    const src = { a: iso(0) }
+    const out = pruneTombstoneMap(src, null)
+    expect(out).toEqual(src)
+    expect(out).not.toBe(src)
+  })
+})
+
+describe('vault tier merge + produce pruning (#287 anti-oscillation)', () => {
+  const now = Date.now()
+  const OLD = iso(now - (TOMBSTONE_RETENTION_DAYS + 10) * DAY_MS)
+  const FRESH = iso(now - 60_000)
+
+  it("a peer's unpruned copy cannot re-inflate a pruned map through the merge", () => {
+    const localPruned = { keep: FRESH }
+    const remoteUnpruned = { keep: FRESH, ancient: OLD }
+    expect(mergeTombstoneMap(localPruned, remoteUnpruned)).toEqual({ keep: FRESH })
+  })
+
+  it('two merges of the same inputs within a day are identical (no churn source)', () => {
+    const a = mergeTombstoneMap({ x: FRESH }, { y: FRESH, ancient: OLD })
+    const b = mergeTombstoneMap({ x: FRESH }, { y: FRESH, ancient: OLD })
+    expect(a).toEqual(b)
+  })
+
+  function makeStore(tombstones) {
+    const bundles = {
+      categories: { value: [], updatedAt: '' },
+      birthday: { value: '', updatedAt: '' },
+      milestoneTombstones: { value: tombstones },
+      chapterTombstones: { value: {} },
+    }
+    return {
+      milestones: { get: () => null, put: () => {}, delete: () => {}, all: () => [] },
+      chapters: { get: () => null, put: () => {}, delete: () => {}, all: () => [] },
+      getBundle: (kind) => bundles[kind],
+      putBundle: (kind, repr) => { bundles[kind] = repr },
+      _bundles: bundles,
+    }
+  }
+
+  it('produce: the pushed envelope is pruned even when the stored copy is stale', async () => {
+    const store = makeStore({ keep: FRESH, ancient: OLD })
+    const adapter = makeDbAdapter({ store, markDirty: () => {} })
+    const env = await adapter.getLocalEntity(bundleEntityId('milestoneTombstones'))
+    expect(env.value).toEqual({ keep: FRESH })
+  })
+
+  it('converges instead of looping: unpruned remote → ONE superset re-push, then silence', async () => {
+    const dirtied = []
+    const store = makeStore({ keep: FRESH })
+    const adapter = makeDbAdapter({ store, markDirty: (id) => dirtied.push(id) })
+    const tombId = bundleEntityId('milestoneTombstones')
+
+    // Cycle 1: a peer still carries an aged-out entry. The merge prunes it;
+    // merged != remote's raw value, so the superset re-push is marked ONCE.
+    await adapter.applyRemoteEntity(tombId, { _kind: 'milestoneTombstones', life_id: 'default', value: { keep: FRESH, ancient: OLD } })
+    expect(store._bundles.milestoneTombstones.value).toEqual({ keep: FRESH })
+    expect(dirtied).toEqual([tombId])
+
+    // Cycle 2: the re-push landed; the peer now carries the pruned value. The
+    // merge is byte-identical — no dirty mark, no push, no SSE self-nudge.
+    await adapter.applyRemoteEntity(tombId, { _kind: 'milestoneTombstones', life_id: 'default', value: { keep: FRESH } })
+    expect(store._bundles.milestoneTombstones.value).toEqual({ keep: FRESH })
+    expect(dirtied).toEqual([tombId]) // unchanged: exactly one, from cycle 1
+  })
+})

--- a/src/sync/tombstones.js
+++ b/src/sync/tombstones.js
@@ -1,4 +1,5 @@
 import { dirtyMilestoneTombstones, dirtyChapterTombstones } from './dirty.js';
+import { tombstoneCutoff, pruneTombstoneMap } from './tombstoneRetention.js';
 
 const MILESTONE_TOMBSTONE_KEY = 'lifeglance-milestone-tombstones';
 const CHAPTER_TOMBSTONE_KEY = 'lifeglance-chapter-tombstones';
@@ -19,7 +20,10 @@ export const writeMilestoneTombstone = (id) => {
   if (!hasStorage) return;
   const t = getMilestoneTombstones();
   t[id] = new Date().toISOString();
-  localStorage.setItem(MILESTONE_TOMBSTONE_KEY, JSON.stringify(t));
+  // Prune on write (#287): a real deletion is already pushing this bundle, so
+  // aging out old entries here adds no churn and bounds the local map even on
+  // a single-device install that never merges.
+  localStorage.setItem(MILESTONE_TOMBSTONE_KEY, JSON.stringify(pruneTombstoneMap(t, tombstoneCutoff())));
   dirtyMilestoneTombstones();
 };
 
@@ -27,6 +31,6 @@ export const writeChapterTombstone = (id) => {
   if (!hasStorage) return;
   const t = getChapterTombstones();
   t[id] = new Date().toISOString();
-  localStorage.setItem(CHAPTER_TOMBSTONE_KEY, JSON.stringify(t));
+  localStorage.setItem(CHAPTER_TOMBSTONE_KEY, JSON.stringify(pruneTombstoneMap(t, tombstoneCutoff())));
   dirtyChapterTombstones();
 };

--- a/src/sync/twoDevice.test.js
+++ b/src/sync/twoDevice.test.js
@@ -284,9 +284,12 @@ describe('Stage 2 Part A — two-device merge correctness', () => {
     fresh()
     seedBoth(A, B, (s) => s.putBundle('milestoneTombstones', { value: {} }))
 
-    A.store.putBundle('milestoneTombstones', { value: { 'dead-on-A': iso(2000) } })
+    // Recent stamps: tombstone bundles are pruned at the retention window on
+    // merge/produce (#287), and this test pins per-key merge semantics, not GC.
+    const now = Date.now()
+    A.store.putBundle('milestoneTombstones', { value: { 'dead-on-A': iso(now - 2000) } })
     A.markDirty(bundleEntityId('milestoneTombstones'))
-    B.store.putBundle('milestoneTombstones', { value: { 'dead-on-B': iso(3000) } })
+    B.store.putBundle('milestoneTombstones', { value: { 'dead-on-B': iso(now - 3000) } })
     B.markDirty(bundleEntityId('milestoneTombstones'))
 
     await fullSync(A, B)


### PR DESCRIPTION
Closes #287

The vault tier's tombstone maps (`milestoneTombstones`/`chapterTombstones`) were grow-only — every deletion ever made lived forever in a singleton bundle that's re-encrypted, re-pushed whole, and re-merged on each change. And a sharper problem the issue's audit flagged: the **file tier already prunes the same shared maps** at its own full-precision 90-day cutoff, which is exactly the two-transport disagreement that produced dayGLANCE's SSE heartbeat loop — with both tiers enabled, an entry the file tier prunes gets re-added by the grow-only vault union, the singleton flips pruned↔restored, each flip pushes, each push advances the seq, and under SSE (now live via #291) each seq advance nudges the next cycle.

## The fix — dayGLANCE's landed pattern, adapted

- **`tombstoneRetention.js`** (new): one fixed **90-day** window — the file tier's long-shipped value, so no existing pruning behavior changes — deliberately not user-configurable (coupling the window to a setting is how dayGLANCE's loop started). The cutoff is **floored to the UTC day**, so every cycle within a day computes the identical value; plus a fail-safe prune that keeps undatable entries (losing a tombstone risks resurrection; keeping one costs bytes).
- **Vault merge** (`mergeTombstoneMap`): union newest-per-key, **then prune**. Pruning inside the merge is what escapes the re-inflation trap — a peer's unpruned copy contributes only in-window entries.
- **Vault produce** (`bundleEnvelope`): tombstone envelopes are pruned, so a device with a stale local copy never re-publishes aged-out entries.
- **File tier** (`mergePayloads`): same window, now day-floored via the shared module — the two tiers agree byte-for-byte.
- **Write path** (`tombstones.js`): prune on each new deletion, bounding the local map even on single-device installs. A deletion is already pushing this bundle, so zero added churn.

## Convergence, not oscillation

The one behavior worth staring at: when a peer still carries an aged-out entry, the merge prunes it, merged ≠ remote, and the existing superset-re-push marks the bundle dirty **once**; after that push lands, subsequent merges compare equal and nothing is dirtied. A dedicated two-cycle test pins exactly this (one `markDirty`, then silence). Day-flooring guarantees at most one such convergence push per bundle per UTC day even at the window's moving edge.

## Verification

11 new tests (flooring idempotence, cutoff day-stability and rollover, fail-safe prune, merge re-inflation resistance, produce-side pruning, the two-cycle convergence test) — 438 total passing, lint at baseline, build clean. `twoDevice` A3's epoch-1970 fixtures were modernized to recent stamps: that test pins per-key merge semantics, not GC, and the comment now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_