### PR TITLE
Exit the credential halt on a verified save; align tier prune semantics

### DIFF
--- a/src/sync/adapter.js
+++ b/src/sync/adapter.js
@@ -1,5 +1,5 @@
-import { mergeArrayById, pruneTombstones } from '@glance-apps/sync';
-import { tombstoneCutoff } from './tombstoneRetention.js';
+import { mergeArrayById } from '@glance-apps/sync';
+import { tombstoneCutoff, pruneTombstoneMap } from './tombstoneRetention.js';
 import { dbGetAll, dbGetAllChapters, dbPut, dbDelete, dbPutChapter, dbDeleteChapter } from '../data/db.js';
 import { getMilestoneTombstones, getChapterTombstones } from './tombstones.js';
 import { loadCategories, saveCategories } from '../utils/colors.js';
@@ -139,11 +139,14 @@ export const mergePayloads = (local, remote) => {
   const lct = localLife.chapterTombstones ?? {};
   const rct = remoteLife.chapterTombstones ?? {};
 
-  // Shared fixed 90-day window, day-floored (tombstoneRetention.js) so both
-  // sync tiers prune identically and the cutoff is stable within a day.
+  // Shared fixed 90-day window, day-floored, and the SAME prune function as
+  // the vault tier (tombstoneRetention.js) so the two tiers agree on every
+  // entry — including undatable ones, which the package's pruneTombstones
+  // drops but the shared fail-safe prune keeps. A disagreement there would
+  // make a corrupt-timestamp entry flap between the tiers' merges.
   const cutoff = tombstoneCutoff();
-  const milestoneTombstones = pruneTombstones({ ...lmt, ...rmt }, cutoff);
-  const chapterTombstones = pruneTombstones({ ...lct, ...rct }, cutoff);
+  const milestoneTombstones = pruneTombstoneMap({ ...lmt, ...rmt }, cutoff);
+  const chapterTombstones = pruneTombstoneMap({ ...lct, ...rct }, cutoff);
 
   const { merged: mergedMilestones } = mergeArrayById(lm, rm, milestoneTombstones, null,
     { idField: 'id', timestampField: 'updated_at' });

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -26,6 +26,7 @@ import { flushOutbox, isVaultIntentsActive } from '../lib/intentsTransport.js'
 const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
 const DEVICE_ID_KEY  = 'lifeglance-db-sync-device-id'
 const SEEDED_KEY     = 'lifeglance-db-sync-seeded'
+const CREDENTIAL_HALT_KEY = 'lifeglance-db-sync-credential-halt'
 
 // Every piece of persisted vault-sync state that belongs to one account's data
 // stream. Key names must match @glance-apps/sync dbEngine.js's
@@ -40,7 +41,7 @@ const STREAM_STATE_KEYS = [
   'lifeglance-db-sync-dirty',           // persisted dirty set
   'lifeglance-db-sync-quarantine',      // undecryptable-row retry set (seq-based)
   'lifeglance-db-sync-last-synced',     // display timestamp
-  'lifeglance-db-sync-credential-halt', // sync 1.10 hard halt (old credential)
+  CREDENTIAL_HALT_KEY,                  // sync 1.10 hard halt (old credential)
 ]
 
 // Reset all per-stream sync state. Called when the vault IDENTITY changes
@@ -54,6 +55,17 @@ export const resetVaultSyncState = () => {
   for (const key of STREAM_STATE_KEYS) {
     try { localStorage.removeItem(key) } catch { /* storage unavailable — nothing to clear */ }
   }
+}
+
+// Clear ONLY the sync 1.10 credential halt (#298). Called from runVaultSetup on
+// a verified save whose identity did NOT change: the authenticated getSalt
+// probe just proved these exact credentials work, which is precisely the
+// evidence the halt is waiting for — without this, a device whose token was
+// fixed in place stayed halted forever (the package clears the halt only via
+// per-account recovery, which shared-token mode never runs). Cursors and the
+// seed flag are untouched: the stream identity didn't move.
+export const clearCredentialHalt = () => {
+  try { localStorage.removeItem(CREDENTIAL_HALT_KEY) } catch { /* storage unavailable */ }
 }
 
 let _dbEngine = null

--- a/src/sync/tombstoneRetention.test.js
+++ b/src/sync/tombstoneRetention.test.js
@@ -115,3 +115,14 @@ describe('vault tier merge + produce pruning (#287 anti-oscillation)', () => {
     expect(dirtied).toEqual([tombId]) // unchanged: exactly one, from cycle 1
   })
 })
+
+describe('both tiers agree on undatable entries (audit note)', () => {
+  it('file-tier mergePayloads keeps a garbage-timestamp tombstone, like the vault tier', async () => {
+    const { mergePayloads } = await import('./adapter.js')
+    const fresh = new Date().toISOString()
+    const local = { lives: { default: { milestones: [], chapters: [], milestoneTombstones: { ok: fresh, corrupt: 'not-a-date' }, chapterTombstones: {} } } }
+    const remote = { lives: { default: { milestones: [], chapters: [], milestoneTombstones: {}, chapterTombstones: {} } } }
+    const { data } = mergePayloads(local, remote)
+    expect(data.lives.default.milestoneTombstones).toEqual({ ok: fresh, corrupt: 'not-a-date' })
+  })
+})

--- a/src/sync/vaultSetup.js
+++ b/src/sync/vaultSetup.js
@@ -26,7 +26,7 @@ import {
   setupDbRootKey as defaultSetupDbRootKey,
 } from '@glance-apps/sync'
 import { setupVaultIntentsRootKey as defaultSetupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
-import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine, resetVaultSyncState as defaultResetVaultSyncState } from './dbSync.js'
+import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine, resetVaultSyncState as defaultResetVaultSyncState, clearCredentialHalt as defaultClearCredentialHalt } from './dbSync.js'
 import { nativeVaultFetchImpl } from './nativeVaultFetch.js'
 
 const CONFIG_KEY    = 'lifeglance-cloud-sync-config'
@@ -118,7 +118,14 @@ export async function runVaultSetup({ vaultUrl, vaultToken, accountId, passphras
   try { prev = JSON.parse(localStorage.getItem(CONFIG_KEY) || 'null') } catch { prev = null }
   const identityChanged = !!(prev && prev.vaultUrl && prev.accountId &&
     (prev.vaultUrl.trim() !== vaultUrl.trim() || prev.accountId.trim() !== accountId.trim()))
-  if (identityChanged) (deps.resetVaultSyncState ?? defaultResetVaultSyncState)()
+  if (identityChanged) {
+    ;(deps.resetVaultSyncState ?? defaultResetVaultSyncState)()
+  } else {
+    // Same identity, credentials just re-verified: exit any standing sync 1.10
+    // credential halt (#298). The probe above IS the proof of restored access;
+    // cursors stay (nothing about the data stream moved).
+    ;(deps.clearCredentialHalt ?? defaultClearCredentialHalt)()
+  }
 
   // Persist the exact shape the engine reads (WebDAV fields preserved).
   ;(deps.persist ?? persistVaultConfig)({ vaultUrl, vaultToken, accountId })

--- a/src/sync/vaultSetup.test.js
+++ b/src/sync/vaultSetup.test.js
@@ -201,6 +201,38 @@ describe('runVaultSetup — stream-state reset on identity change (#286)', () =>
   })
 })
 
+describe('runVaultSetup — credential-halt recovery (#298)', () => {
+  const okClient = clientReturning(() => new Uint8Array(16).fill(1))
+  const HALT_KEY = 'lifeglance-db-sync-credential-halt'
+
+  it('a verified SAME-identity re-save clears a standing credential halt', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    localStorage.setItem(HALT_KEY, JSON.stringify({ message: 'rejected' }))
+    const { runVaultSetup: run } = await import('./vaultSetup.js')
+    const r = await run({ ...CREDS, vaultToken: 'fixed-tok', passphrase: 'pw' }, spyDeps(okClient))
+    expect(r.ok).toBe(true)
+    expect(localStorage.getItem(HALT_KEY)).toBeNull()
+  })
+
+  it('an identity-change save clears the halt too (via the full reset)', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    localStorage.setItem(HALT_KEY, JSON.stringify({ message: 'rejected' }))
+    const { runVaultSetup: run } = await import('./vaultSetup.js')
+    await run({ ...CREDS, accountId: 'house-2', passphrase: 'pw' }, spyDeps(okClient))
+    expect(localStorage.getItem(HALT_KEY)).toBeNull()
+  })
+
+  it('a FAILED verification leaves the halt in place (no proof, no exit)', async () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ vaultEnabled: true, ...CREDS }))
+    localStorage.setItem(HALT_KEY, JSON.stringify({ message: 'rejected' }))
+    const deps = spyDeps(clientReturning(() => { throw vaultError(401) }))
+    const { runVaultSetup: run } = await import('./vaultSetup.js')
+    const r = await run({ ...CREDS, passphrase: 'pw' }, deps)
+    expect(r.ok).toBe(false)
+    expect(localStorage.getItem(HALT_KEY)).not.toBeNull()
+  })
+})
+
 describe('disableVault', () => {
   it('clears only vaultEnabled, keeps WebDAV + vault creds, rebuilds engine', async () => {
     const webdav = { provider: 'nextcloud', url: 'https://nc.example', username: 'me', enabled: true }


### PR DESCRIPTION
Closes #298

Both findings from the pre-release cloud-sync audit, fixed now rather than deferred.

## Credential-halt recovery (#298)

The sync 1.10 `CREDENTIAL_INVALID` halt is cleared only by the package's per-account recovery flow (never runs in shared-token mode), and the #286 identity reset only fires when the account or server changes. A halted device whose token was fixed **in place** stayed halted forever — showing the `credentialInvalid` message ("ask whoever runs your sync server to restore access") after the admin had already done exactly that.

`runVaultSetup` now clears the halt key on a **verified same-identity save**: the authenticated `getSalt` probe that gates every save is precisely the proof of restored access the halt awaits. The boundaries that keep this safe:

- A **failed** verification leaves the halt standing — no proof, no exit, so a user mashing save with a still-bad token can't turn the halt into a retry loop (each escape requires a probe the server accepted).
- Cursors and the seed flag are untouched — the stream identity didn't move, so no re-seed.
- Identity-change saves already clear it via the #295 full reset; this covers the other branch.

## Tier prune alignment (the audit note)

The file tier pruned with the package's `pruneTombstones`, which **drops** undatable entries; the shared `tombstoneRetention` prune deliberately **keeps** them (losing a tombstone risks resurrecting a deletion; keeping one costs bytes). The file tier now uses the same `pruneTombstoneMap`, so the two tiers agree on every entry including corrupt-timestamp ones — closing the last way the two merges could disagree about a tombstone.

## Verification

Four new tests: verified same-identity save clears the halt; identity-change save clears it via the full reset; failed verification leaves it standing; `mergePayloads` keeps an undatable entry exactly like the vault tier. 452 total passing, lint at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_