### PR TITLE
Protect project.pbxproj from capacitor-assets rewrites

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:mobile": "vite build && cap sync && node scripts/fix-spm-platform.mjs",
     "build:ios": "npm run build && cap sync ios && node scripts/fix-spm-platform.mjs && node scripts/sync-ios-version.mjs",
     "sync:ios-version": "node scripts/sync-ios-version.mjs",
-    "assets": "capacitor-assets generate --android --ios",
+    "assets": "node scripts/generate-assets.mjs --android --ios",
     "reviewer-code": "node scripts/reviewer-code.mjs",
     "screenshots": "vite build && node scripts/screenshots.mjs",
     "feature-graphic": "node scripts/feature-graphic.mjs",

--- a/scripts/generate-assets.mjs
+++ b/scripts/generate-assets.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Run capacitor-assets while protecting ios/App/App.xcodeproj/project.pbxproj.
+//
+// @capacitor/assets loads the Xcode project through the legacy `xcode` parser
+// (via @trapezedev/project) and re-serializes it on save, even though asset
+// generation only ever writes into Assets.xcassets / android res. The rewrite
+// reformats the file — which predates Xcode's synchronized-folder project
+// format — leaving a pointless uncommitted diff that turns into merge/stash
+// conflicts and corrupts the project (Xcode: "damaged and cannot be opened").
+//
+// This wrapper snapshots the pbxproj, runs the generator with the CLI args
+// passed through (e.g. --android --ios), and restores the snapshot
+// byte-for-byte afterwards.
+import { readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const pbxPath = resolve(root, 'ios/App/App.xcodeproj/project.pbxproj')
+const snapshot = readFileSync(pbxPath)
+
+const require = createRequire(import.meta.url)
+const bin = require.resolve('@capacitor/assets/bin/capacitor-assets')
+const result = spawnSync(process.execPath, [bin, 'generate', ...process.argv.slice(2)], {
+  cwd: root,
+  stdio: 'inherit',
+})
+
+if (!snapshot.equals(readFileSync(pbxPath))) {
+  writeFileSync(pbxPath, snapshot)
+  console.log('[generate-assets] restored project.pbxproj (asset generation must not rewrite it)')
+}
+
+process.exit(result.status ?? 1)


### PR DESCRIPTION
## Summary

Prevents a recurrence of the "project 'App' is damaged and cannot be opened" incident.

**Root cause:** `@capacitor/assets` loads the Xcode project through the legacy `xcode` parser (via `@trapezedev/project`) and re-serializes `project.pbxproj` on save, even though asset generation only writes into `Assets.xcassets` and Android `res/`. The re-serialization reformats the synchronized-folder groups (the parser predates that project format), so every `npm run assets` leaves a pointless uncommitted diff on the project file. Stashing/merging around that diff put conflict markers into the pbxproj, which is what Xcode choked on.

**Fix:** `npm run assets` now runs `scripts/generate-assets.mjs`, which:
- snapshots `project.pbxproj`
- runs `capacitor-assets generate` with CLI args passed through (`--android --ios` from the npm script)
- restores the snapshot byte-for-byte if the generator rewrote it
- propagates the generator's exit code

## Verification

- `npm run assets` still generates everything (74 Android + 7 iOS assets) and `project.pbxproj` is byte-identical afterwards — clean `git status` on the xcodeproj
- Failed generator runs (bad args) exit non-zero through the wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk8QGcTXcynS4yeymaBeQp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk8QGcTXcynS4yeymaBeQp)_