### PR TITLE
Fix platform-unstable lockfile from source-map override leakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9554,6 +9554,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     },
     "workbox-build": {
       "glob": "^13.0.6",
-      "source-map": "^0.8.0"
+      "source-map": "^0.8.0",
+      "source-map-support": {
+        "source-map": "^0.6.1"
+      }
     },
     "@trapezedev/project": {
       "conventional-changelog": "^8.1.1"


### PR DESCRIPTION
## Summary

**Fixes the CI failure on main** introduced by the "Refresh lockfile" commit — and the root cause behind the lockfile flip-flopping that's been happening since #303.

The `workbox-build` → `source-map ^0.8.0` override also applied to `source-map-support` (reachable inside workbox-build's subtree via `@rollup/plugin-terser` → `terser`), which declares `source-map ^0.6.0`. That conflicting requirement made npm's tree computation unstable: the lockfile settles differently on macOS vs Linux (sharp's platform-specific optional deps shift hoisting), so a lockfile written by `npm install` on one OS fails `npm ci` on the other with `Missing: source-map@0.6.1`. A macOS-side refresh landed on main and broke both Linux CI workflows. The same conflict caused the earlier "needs two `npm install` passes" quirk during #303.

**Fix:** a counter-override nested inside the `workbox-build` rule pins `source-map-support`'s `source-map` back to `^0.6.1` (more specific override rules win), plus a from-scratch lockfile regeneration. Credit to the sibling investigation in lastGLANCE for identifying the leakage mechanism.

## Verification (on Linux, where main currently fails)

- `npm ci` passes on the first try
- A subsequent `npm install` leaves the lockfile **byte-identical** (checksum-verified) — the platform ping-pong is gone
- `npm ls` reports a healthy tree: workbox-build gets source-map 0.8.0, source-map-support keeps 0.6.1
- Still 0 deprecation warnings, 0 vulnerabilities
- 452/452 tests pass; build output unchanged (41 precache entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk8QGcTXcynS4yeymaBeQp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk8QGcTXcynS4yeymaBeQp)_