### PR TITLE
Release 3.1.0: version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Prepares the 3.1.0 release (GLANCEvault SSE push as the headliner): version bump 3.0.1 → 3.1.0 in package.json + lockfile. Android `versionName`/`versionCode` derive from this automatically; the iOS marketing version follows via `sync-ios-version` on the next iOS build.

Release notes go on the GitHub Release for the `v3.1.0` tag (repo convention: GitHub Releases, no CHANGELOG.md).

## Verification

- Lockfile diff is exactly the two version fields (`npm ci` passes cleanly)
- 452/452 tests pass

After merge: create the GitHub Release for tag `v3.1.0` with the drafted notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk8QGcTXcynS4yeymaBeQp