### PR TITLE
ios: confirm shares in the extension instead of trying to open the app

### DIFF
--- a/docs/ios-share-extension-spec.md
+++ b/docs/ios-share-extension-spec.md
@@ -4,7 +4,9 @@ Status: **implemented** — all sections below are built and registered in
 `App.xcodeproj`. Retained as the design record for the "share text/link →
 pre-filled Add-milestone sheet" flow on iOS, matching what Android already does.
 Where the shipped code deliberately departs from the original sketch, the section
-says so. Still **unverified on a device** — see *Acceptance tests*.
+says so — most importantly §3a, where the "share opens the app" behaviour this
+document was written around turned out to be prohibited by iOS and had to be
+replaced. Partly device-verified; see *Acceptance tests*.
 
 ## Goal
 
@@ -119,8 +121,15 @@ extension would fail to launch. The two must be changed together.
 ### 3. `LifeGlanceShare/ShareViewController.swift`
 
 Responsibilities: pull text/URL/title from the extension context, build the
-`{ text, subject }` payload, write it to the App Group, foreground the host app,
-and complete the request. Sketch:
+`{ text, subject }` payload, append it to the App Group queue, confirm to the user,
+and complete the request.
+
+> **The host app is never foregrounded.** The original sketch below ended by
+> opening `lifeglance://share` via the responder chain. That does not work and
+> cannot be made to — see *The auto-open leg* — so the shipped controller shows a
+> confirmation sheet instead. Read that section before this sketch.
+
+Sketch (retained as the design record; the auto-open half is obsolete):
 
 ```swift
 import UIKit
@@ -188,28 +197,66 @@ final class ShareViewController: UIViewController {
 }
 ```
 
-> Note: the `openURL:` responder-chain hop is the standard way an extension
-> foregrounds its host app. If a future iOS release removes it, fall back to
-> completing the request without opening — the web layer still picks up
-> `pending_share` the next time the app is opened manually.
+### 3a. The auto-open leg — removed, and why it can't come back
+
+The contingency the note above hedged on is now the permanent state, and the
+cause is stronger than "a release removed it": **iOS bars app extensions from
+opening URLs at all.** `UIApplication` is marked unavailable in extensions; the
+`openURL:` responder-chain walk was a runtime end-run around that build-time
+block, and iOS 18 closed it (`responds(to:)` fails, or UIKit logs *BUG IN CLIENT
+OF UIKIT*). Apple DTS, answering this exact question for a Share Extension:
+
+> "App extensions are not allowed to open URLs directly. This isn't accidental,
+> but a deliberate design choice on Apple's part. Don't try to bypass such
+> restrictions using Silly Runtime Hacks™."
+
+`extensionContext.open(_:)` is not a way around it either — it is documented for
+Today widgets, and reports are that it returns `success = false` from a Share
+Extension.
+
+Observed symptom before the fix: sharing a Safari page appeared to do nothing at
+all, and the pre-filled Add sheet was discovered later, on the next manual app
+launch. The payload path was working the whole time; the silence was the bug,
+because a UI-less extension gives no other signal.
+
+**What replaced it:** a confirmation sheet ("Saved to lifeGLANCE" + the captured
+title + Done). Apple's own suggested alternative is a local notification the user
+taps to open the app; that was declined deliberately, because lifeGLANCE ships
+with no notification code or permission anywhere, and introducing its first
+permission prompt for share convenience is a poor trade in a no-account,
+local-first app. Revisit only if notifications arrive for another reason.
+
+Do not re-add an auto-open attempt. `AppDelegate.handleWidgetDeepLink` has no
+`share` case for the same reason.
 
 ### 4. `WidgetStore` additions (`WidgetModel.swift`)
 
-Add a third pending key alongside the existing target/action ones:
+Add a third pending key alongside the existing target/action ones. It holds a
+**queue** (array of JSON strings), not a single value:
 
 ```swift
-static let keyPendingShare = "pending_share"   // JSON string { text, subject }
+static let keyPendingShare = "pending_share"   // [String] of JSON { text, subject }
 
-static func setPendingShare(_ json: String) {
-    defaults?.set(json, forKey: keyPendingShare)
-}
-
-static func consumePendingShare() -> String? {
-    guard let s = defaults?.string(forKey: keyPendingShare) else { return nil }
-    defaults?.removeObject(forKey: keyPendingShare)
-    return s
-}
+// Pops the oldest entry, leaving the rest queued. Returns a single JSON string,
+// so the JS contract is unchanged: one share per consumeLaunchTarget(), matching
+// the one Add-milestone sheet the app can show.
+static func consumePendingShare() -> String? { … }
 ```
+
+There is deliberately **no writer here** — the extension appends to the App Group
+inline (`ShareViewController.enqueue`) so it stays a single self-contained file,
+as §1 explains. This side only reads.
+
+**Why a queue and not one slot.** With auto-open, every share immediately
+foregrounded the app and drained the slot, so last-write-wins was safe. Without
+it, shares pile up until the user next opens lifeGLANCE — so sharing two things
+before opening the app silently discarded the first. Android keeps a single slot
+and is *not* affected, because its `ACTION_SEND` path really does open the app
+each time.
+
+Both readers tolerate a legacy single-string value written before the queue
+existed, so an app updating in place does not drop a share captured by the old
+build.
 
 ### 5. `WidgetBridgePlugin.consumeLaunchTarget` (App target)
 
@@ -222,12 +269,12 @@ if let share = WidgetStore.consumePendingShare() {
 }
 ```
 
-### 6. `AppDelegate` (optional)
+### 6. `AppDelegate` — nothing to do
 
-`lifeglance://share` needs no stashing (the extension already wrote `pending_share`),
-so `handleWidgetDeepLink` can simply accept the host without action. Add a
-`case "share": break` with a comment so the scheme is clearly handled rather than
-silently hitting `default`.
+Originally this section added a `case "share": break` so the deep link was
+visibly handled. That case has been **removed**: `lifeglance://share` is never
+fired, because the extension cannot open the app (§3a). A comment in
+`handleWidgetDeepLink` records why, so the absence reads as deliberate.
 
 ## Data contract (must match Android/JS)
 
@@ -244,8 +291,11 @@ the title, and keeps the full text as a note — no iOS-side truncation needed.
 
 - **URL-only share (Safari):** put the URL into `text` (not a separate field) so the
   existing draft logic finds it; `subject` = page title.
-- **Nothing usable:** complete the request without writing `pending_share`, so the
-  app doesn't open a blank draft.
+- **Nothing usable:** queue nothing, so the app doesn't open a blank draft, and
+  tell the user so ("Nothing to save") rather than dismissing silently.
+- **Several shares before the app is opened:** all are kept, oldest first, and
+  surface one per `consumeLaunchTarget()`. Note the app only drains one per
+  launch/resume today — see *Known gap* below.
 - **Images / files:** out of scope; the activation rule restricts to text/URL/page,
   so non-text attachments never reach us.
 - **App Group sandbox:** the extension must use `UserDefaults(suiteName:)`, never
@@ -255,21 +305,46 @@ the title, and keeps the full text as a note — no iOS-side truncation needed.
 
 `.github/workflows/ios.yml` compiles the extension, which catches project and
 Swift errors, but it never runs the app — so nothing below is covered by CI.
-All four remain outstanding:
 
-1. Share plain text from Notes → app opens → Add sheet titled from the text.
-2. Share a URL from Safari → Add sheet with the URL populated and hostname/title.
+Tests 0–3 passed on device (Safari page share, before the confirmation UI landed).
+Note the expected result is **no longer** "the app opens" — it is "the extension
+confirms, and the draft is waiting on next launch":
+
+0. lifeGLANCE appears in the share sheet at all. An activation-rule or
+   principal-class error presents as a silently missing entry, not a crash.
+1. Share plain text from Notes → "Saved to lifeGLANCE" → open app → Add sheet
+   titled from the text.
+2. Share a URL from Safari → open app → Add sheet with URL and hostname/title.
 3. Share with an explicit subject/title → subject becomes the title.
-4. Share something empty/unusable → app does not open a blank draft.
 
-Test 0, implied by the rest: **lifeGLANCE actually appears in the share sheet.**
-An activation-rule or principal-class error presents as a silently missing entry
-rather than a crash, so confirm the entry exists before reading anything into
-tests 1–4.
+Still outstanding, all new with the confirmation UI and queue:
+
+4. Share something empty/unusable → "Nothing to save", and no blank draft on
+   next launch.
+5. The confirmation sheet renders correctly in light and dark, and Done dismisses.
+6. **Queue:** share three items without opening the app in between, then open the
+   app three times (backgrounding between) → all three drafts appear, oldest
+   first, none lost.
+7. Upgrade path: a share captured by the pre-queue build still surfaces after
+   updating to this one.
+
+## Known gap
+
+The app drains **one** queued share per launch/resume, because
+`consumeLaunchTarget()` is called from `TimelineView`'s `visibilitychange`
+handler and the app can only show one Add sheet at a time. Sharing three things
+then opening the app once yields the first draft; the other two wait for the next
+resume. Nothing is lost, but draining the rest as each sheet is dismissed would
+be the better behaviour — a small `TimelineView` change, deliberately not bundled
+with the native fix.
 
 ## Out of scope
 
 - Rich-media (image/file) shares.
-- A custom compose UI in the extension.
+- A compose/edit UI in the extension. The confirmation sheet added in §3a is
+  deliberately read-only — it reports what was captured, it does not let the user
+  edit the milestone before saving.
+- Opening the host app from the extension, by any means, including a local
+  notification the user taps (§3a).
 - Deriving the extension's `MARKETING_VERSION` from `package.json` (tracked
   separately with the App target — see the version-drift note in the iOS cleanup).

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -54,12 +54,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         case "new":
             defaults?.set("new", forKey: "pending_action")
-        case "share":
-            // The Share Extension already wrote "pending_share" to the App Group
-            // before opening this URL; nothing to stash here. Opening the app is
-            // enough — the web layer reads the share via consumeLaunchTarget() on
-            // resume. Handled explicitly so it doesn't fall through to default.
-            break
+        // There is deliberately no "share" case. The Share Extension does not open
+        // the app: iOS bars app extensions from opening URLs, so lifeglance://share
+        // is never fired. Shares are queued under "pending_share" in the App Group
+        // and drained by WidgetBridgePlugin.consumeLaunchTarget() on the next launch
+        // or resume. See docs/ios-share-extension-spec.md before re-adding it.
         default:
             break
         }

--- a/ios/App/LifeGlanceShare/README.md
+++ b/ios/App/LifeGlanceShare/README.md
@@ -6,9 +6,17 @@ Android `ACTION_SEND` share target). Implements the spec in
 
 | File | Purpose |
 | ---- | ------- |
-| `ShareViewController.swift` | Reads shared text/URL, writes `pending_share` to the App Group, opens the host app. No UI. |
+| `ShareViewController.swift` | Reads shared text/URL, appends it to the `pending_share` queue in the App Group, and shows a confirmation sheet. |
 | `Info.plist` | `NSExtension` config + activation rule (text / web URL / web page). |
 | `LifeGlanceShare.entitlements` | App Group `group.com.lifeglance`. |
+
+**This extension does not open lifeGLANCE, and cannot.** iOS bars app extensions
+from opening URLs; the responder-chain `openURL:` trick this was originally built
+on stopped working in iOS 18 and is explicitly disavowed by Apple. A share
+therefore lands quietly in the App Group and surfaces the next time the user opens
+the app — the confirmation sheet exists so that reads as success rather than as
+nothing having happened. Full reasoning in `docs/ios-share-extension-spec.md` §3a;
+please read it before attempting to restore an auto-open.
 
 The app-side hooks are wired: `WidgetStore.consumePendingShare()`
 (`WidgetModel.swift`), the `share` field in
@@ -48,10 +56,12 @@ key must change back in the same commit.
 CI (`.github/workflows/ios.yml`) compiles the extension but cannot exercise it —
 there is no device or simulator run. These four are device-only:
 
-1. Share plain text from Notes → lifeGLANCE opens with the Add sheet titled from the text.
-2. Share a link from Safari → Add sheet with the URL populated and hostname/title.
+1. Share plain text from Notes → "Saved to lifeGLANCE" → open the app → Add sheet titled from the text.
+2. Share a link from Safari → open the app → Add sheet with the URL populated and hostname/title.
 3. Share with an explicit subject/title → subject becomes the title.
-4. Share something empty/unusable → app does not open a blank draft.
+4. Share something empty/unusable → "Nothing to save", and no blank draft later.
+5. Share three items without opening the app in between → all three drafts appear
+   across subsequent resumes, oldest first, none lost.
 
 Check specifically that lifeGLANCE **appears in the share sheet at all** — an
 activation-rule or principal-class mistake shows up as a silently missing entry,

--- a/ios/App/LifeGlanceShare/ShareViewController.swift
+++ b/ios/App/LifeGlanceShare/ShareViewController.swift
@@ -2,13 +2,22 @@ import UIKit
 import UniformTypeIdentifiers
 
 // Share Extension entry point. Receives text / links shared into lifeGLANCE from
-// the iOS share sheet, stashes them in the App Group under "pending_share", then
-// opens the host app — which reads the share via WidgetBridge.consumeLaunchTarget()
-// on resume and opens a pre-filled Add-milestone sheet. This mirrors the Android
-// ACTION_SEND path (MainActivity.handleShareIntent).
+// the iOS share sheet, appends them to a queue in the App Group under
+// "pending_share", and confirms to the user. The app drains that queue via
+// WidgetBridge.consumeLaunchTarget() on launch/resume and opens a pre-filled
+// Add-milestone sheet. This mirrors the Android ACTION_SEND path
+// (MainActivity.handleShareIntent).
 //
-// The payload written is a JSON string { "text": …, "subject": … } (either key
+// Each queued entry is a JSON string { "text": …, "subject": … } (either key
 // optional), the exact shape src/native/shareDraft.js expects.
+//
+// NOTE ON WHY THIS SHOWS UI: the extension deliberately does NOT try to open the
+// host app. App extensions are barred from opening URLs — the old trick of walking
+// the responder chain for openURL: stopped working in iOS 18, and Apple DTS is
+// explicit that this is by design and should not be worked around. So a share can
+// only land quietly in the App Group, which without any UI is indistinguishable
+// from the share having failed. This confirmation sheet is that missing feedback.
+// See docs/ios-share-extension-spec.md.
 //
 // Kept self-contained — it writes to the App Group inline rather than importing the
 // widgets' WidgetStore — so the extension target only needs this one Swift file, the
@@ -19,16 +28,32 @@ final class ShareViewController: UIViewController {
     private let appGroupId = "group.com.lifeglance"
     private let pendingShareKey = "pending_share"
 
+    // Matches Palette in the widgets' WidgetTheme.swift and the web app's dark theme
+    // tokens in src/index.css. Duplicated rather than shared to keep this target to
+    // a single file.
+    private let bgColor = UIColor(red: 0x0F / 255, green: 0x11 / 255, blue: 0x17 / 255, alpha: 1)
+    private let textColor = UIColor(red: 0xE8 / 255, green: 0xE0 / 255, blue: 0xD0 / 255, alpha: 1)
+    private let amberColor = UIColor(red: 0xC8 / 255, green: 0xA9 / 255, blue: 0x6E / 255, alpha: 1)
+    private let mutedColor = UIColor(red: 0x8A / 255, green: 0x82 / 255, blue: 0x70 / 255, alpha: 1)
+
+    private let card = UIView()
+    private let headline = UILabel()
+    private let detail = UILabel()
+    private let doneButton = UIButton(type: .system)
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        buildUI()
         Task {
-            await handleShare()
-            openHostAndFinish()
+            let saved = await handleShare()
+            show(saved: saved)
         }
     }
 
-    private func handleShare() async {
-        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else { return }
+    // Extracts the shared item and, if there is anything usable, appends it to the
+    // pending-share queue. Returns the title we captured, or nil if nothing usable.
+    private func handleShare() async -> String? {
+        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else { return nil }
 
         var text = ""
         var subject = ""
@@ -54,16 +79,33 @@ final class ShareViewController: UIViewController {
 
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedSubject = subject.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedText.isEmpty || !trimmedSubject.isEmpty else { return }
+        guard !trimmedText.isEmpty || !trimmedSubject.isEmpty else { return nil }
 
         var payload: [String: String] = [:]
         if !trimmedText.isEmpty { payload["text"] = trimmedText }
         if !trimmedSubject.isEmpty { payload["subject"] = trimmedSubject }
 
-        if let data = try? JSONSerialization.data(withJSONObject: payload),
-           let json = String(data: data, encoding: .utf8) {
-            UserDefaults(suiteName: appGroupId)?.set(json, forKey: pendingShareKey)
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else { return nil }
+
+        enqueue(json)
+        return trimmedSubject.isEmpty ? trimmedText : trimmedSubject
+    }
+
+    // Appends to the pending-share queue. A queue rather than a single slot because
+    // the app is no longer brought forward on share: entries now pile up until the
+    // user next opens lifeGLANCE, so a last-write-wins slot would silently drop every
+    // share but the most recent. Legacy single-string values are migrated in place.
+    private func enqueue(_ json: String) {
+        let defaults = UserDefaults(suiteName: appGroupId)
+        var queue: [String] = []
+        if let existing = defaults?.array(forKey: pendingShareKey) as? [String] {
+            queue = existing
+        } else if let legacy = defaults?.string(forKey: pendingShareKey) {
+            queue = [legacy]
         }
+        queue.append(json)
+        defaults?.set(queue, forKey: pendingShareKey)
     }
 
     private func loadURL(from provider: NSItemProvider) async -> String? {
@@ -82,22 +124,64 @@ final class ShareViewController: UIViewController {
         return nil
     }
 
-    // Bring the host app forward, then finish. An extension can't touch
-    // UIApplication.shared, so walk the responder chain to whoever implements
-    // openURL:. Opening lifeglance://share is enough — the share payload is already
-    // in the App Group; AppDelegate accepts the "share" host as a no-op.
-    private func openHostAndFinish() {
-        if let url = URL(string: "lifeglance://share") {
-            var responder: UIResponder? = self
-            let selector = sel_registerName("openURL:")
-            while let r = responder {
-                if r.responds(to: selector) {
-                    _ = r.perform(selector, with: url)
-                    break
-                }
-                responder = r.next
-            }
+    // MARK: - UI
+
+    private func buildUI() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+
+        card.backgroundColor = bgColor
+        card.layer.cornerRadius = 16
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.alpha = 0
+        view.addSubview(card)
+
+        headline.font = .systemFont(ofSize: 17, weight: .semibold)
+        headline.textColor = textColor
+        headline.numberOfLines = 1
+        headline.textAlignment = .center
+
+        detail.font = .systemFont(ofSize: 14)
+        detail.textColor = mutedColor
+        detail.numberOfLines = 3
+        detail.textAlignment = .center
+
+        doneButton.setTitle("Done", for: .normal)
+        doneButton.setTitleColor(amberColor, for: .normal)
+        doneButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        doneButton.addTarget(self, action: #selector(finish), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [headline, detail, doneButton])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            card.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            card.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            card.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 32),
+            card.widthAnchor.constraint(lessThanOrEqualToConstant: 340),
+            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -20),
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+        ])
+    }
+
+    // `saved` is the captured title, or nil when the item held nothing usable.
+    private func show(saved: String?) {
+        if let title = saved {
+            headline.text = "Saved to lifeGLANCE"
+            detail.text = "\(title)\n\nIt'll be waiting as a new milestone next time you open the app."
+        } else {
+            headline.text = "Nothing to save"
+            detail.text = "This item didn't contain any text or link lifeGLANCE could use."
         }
+        UIView.animate(withDuration: 0.2) { self.card.alpha = 1 }
+    }
+
+    @objc private func finish() {
         extensionContext?.completeRequest(returningItems: nil)
     }
 }

--- a/ios/App/LifeGlanceWidgets/WidgetModel.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetModel.swift
@@ -49,16 +49,34 @@ enum WidgetStore {
         return action
     }
 
-    // A share written by the Share Extension: a JSON string { text, subject }.
-    static func setPendingShare(_ json: String) {
-        defaults?.set(json, forKey: keyPendingShare)
-    }
-
-    // Returns and clears a pending share left by the Share Extension.
+    // Shares are a queue of JSON strings { text, subject }, written by the Share
+    // Extension (ShareViewController.enqueue, which writes to the App Group inline
+    // rather than depending on this file). There is deliberately no writer here —
+    // this side only reads. A queue rather than one slot because iOS cannot bring
+    // the app forward on share, so entries accumulate between app launches and a
+    // last-write-wins slot would silently drop all but the most recent.
+    //
+    // Pops the oldest pending share, leaving any others queued for the next call.
+    // Returns a single JSON string so the JS contract is unchanged: one share per
+    // consumeLaunchTarget(), matching the one Add-milestone sheet the app can show.
+    // Tolerates a legacy single-string value written before the queue existed.
     static func consumePendingShare() -> String? {
-        guard let share = defaults?.string(forKey: keyPendingShare) else { return nil }
+        if var queue = defaults?.array(forKey: keyPendingShare) as? [String] {
+            guard !queue.isEmpty else {
+                defaults?.removeObject(forKey: keyPendingShare)
+                return nil
+            }
+            let next = queue.removeFirst()
+            if queue.isEmpty {
+                defaults?.removeObject(forKey: keyPendingShare)
+            } else {
+                defaults?.set(queue, forKey: keyPendingShare)
+            }
+            return next
+        }
+        guard let legacy = defaults?.string(forKey: keyPendingShare) else { return nil }
         defaults?.removeObject(forKey: keyPendingShare)
-        return share
+        return legacy
     }
 }
 


### PR DESCRIPTION
Sharing a Safari page appeared to do nothing: the payload was captured, queued and rendered correctly, but the app was never brought forward, so the pre-filled Add sheet was only discovered on the next manual launch.

The auto-open leg cannot be fixed. iOS marks UIApplication unavailable in app extensions; the openURL: responder-chain walk was a runtime end-run around that build-time block, and iOS 18 closed it. Apple DTS, on this exact question for a Share Extension: "App extensions are not allowed to open URLs directly. This isn't accidental, but a deliberate design choice on Apple's part." extensionContext.open() is not an alternative — it is documented for Today widgets and reportedly returns success = false here.

So the payload path was never the bug; the silence was, because a UI-less extension gives no other signal. ShareViewController now shows a confirmation sheet ("Saved to lifeGLANCE", the captured title, Done), and says "Nothing to save" rather than dismissing silently when an item holds nothing usable. Colors mirror the widgets' Palette and the web app's dark theme tokens.

Apple's suggested alternative, a local notification the user taps, was declined: lifeGLANCE has no notification code or permission anywhere, and introducing its first permission prompt for share convenience is a poor trade in a no-account, local-first app.

Also fixes a data-loss bug this promotes from theoretical to likely. pending_share was a single last-write-wins slot, which was safe only because every share used to foreground the app and drain it immediately. With shares now accumulating between launches, sharing two things before opening the app silently discarded the first. It is now a queue, popped oldest-first, one per consumeLaunchTarget() so the JS contract is unchanged. Both sides still accept a legacy single-string value, so a share captured by the previous build survives the update. Android is unaffected — its ACTION_SEND path really does open the app each time.

Removes the now-unreachable code: the responder-chain walk, the AppDelegate "share" deep-link case, and WidgetStore's pending-share writer (which never had a caller, since the extension writes to the App Group inline). Each leaves a comment explaining why, so the absence reads as deliberate.

Docs: spec gains §3a recording why auto-open is prohibited and must not be re-added, plus the queue rationale, revised acceptance tests, and a known gap — the app drains only one queued share per resume, since TimelineView shows one Add sheet at a time. Draining the rest as each sheet is dismissed is a small web-layer change, deliberately not bundled with this native fix.


Claude-Session: https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ