### PR TITLE
Version 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
One commit: `version` 3.1.0 to 3.2.0 in `package.json` and `package-lock.json`. Nothing else.

## Version

- versionName: 3.1.0 to 3.2.0
- versionCode: 30100000 to 30200000

Derived by `app/build.gradle`'s scheme, `(major * 10000 + minor * 100 + patch) * 1000 + buildNumber`. Monotonic, and clear of 3.1.0's 30100001 to 30100999 interim build band.

## Why minor rather than patch

The release carries #308's standing vault backoff banner: new user-visible UI plus three new strings across eight locales. A release takes the highest bump of anything in it, so the `@glance-apps/billing` 0.2.2 fixes (#309) ride along without setting the ceiling.

The precedent is direct. lastGLANCE shipped the identical change, its #262, which #308 is the lift of, and versioned it as a minor in 2.3.0.

#310's iOS share-extension work also landed. It does not change the call, since minor already covers everything below it.

## Release contents

Everything intended for 3.2.0 is now on `main`. This is the last piece.

- #308, standing vault backoff banner (the reason this is a minor)
- #309, `@glance-apps/billing` 0.2.2, plus the WorkManager version unified through `variables.gradle`
- #310, iOS share extension confirmation sheet and the pending-share queue fix

## Verification

`npm test` passes, 452 tests in 38 files. The version bump does not touch app code.

Note that `sync:ios-version` has not been run, so the iOS `MARKETING_VERSION` still reads 3.1.0. It syncs on `npm run build:ios`, which matters more than usual this release given #310 is iOS-only.