### PR TITLE
iOS: Lock Screen widgets, and raise the deployment target to iOS 16

### DIFF
--- a/docs/ios-share-extension-spec.md
+++ b/docs/ios-share-extension-spec.md
@@ -6,7 +6,8 @@ pre-filled Add-milestone sheet" flow on iOS, matching what Android already does.
 Where the shipped code deliberately departs from the original sketch, the section
 says so — most importantly §3a, where the "share opens the app" behaviour this
 document was written around turned out to be prohibited by iOS and had to be
-replaced. Partly device-verified; see *Acceptance tests*.
+replaced. The main share path is **device-verified**; four edge cases are not.
+See *Acceptance tests*.
 
 ## Goal
 
@@ -306,9 +307,12 @@ the title, and keeps the full text as a note — no iOS-side truncation needed.
 `.github/workflows/ios.yml` compiles the extension, which catches project and
 Swift errors, but it never runs the app — so nothing below is covered by CI.
 
-Tests 0–3 passed on device (Safari page share, before the confirmation UI landed).
 Note the expected result is **no longer** "the app opens" — it is "the extension
-confirms, and the draft is waiting on next launch":
+confirms, and the draft is waiting on next launch".
+
+**Passed on device.** The main path is confirmed end to end: the extension appears
+in the share sheet, the confirmation sheet shows, and the pre-filled Add sheet is
+waiting on next launch.
 
 0. lifeGLANCE appears in the share sheet at all. An activation-rule or
    principal-class error presents as a silently missing entry, not a crash.
@@ -316,17 +320,22 @@ confirms, and the draft is waiting on next launch":
    titled from the text.
 2. Share a URL from Safari → open app → Add sheet with URL and hostname/title.
 3. Share with an explicit subject/title → subject becomes the title.
+4. The confirmation sheet appears and dismisses.
 
-Still outstanding, all new with the confirmation UI and queue:
+**Not individually confirmed.** Edge cases that a normal share never exercises, so
+passing the above says nothing about them:
 
-4. Share something empty/unusable → "Nothing to save", and no blank draft on
+5. Share something empty/unusable → "Nothing to save", and no blank draft on
    next launch.
-5. The confirmation sheet renders correctly in light and dark, and Done dismisses.
-6. **Queue:** share three items without opening the app in between, then open the
+6. The confirmation sheet in *both* light and dark appearance (only the tested
+   appearance is known good).
+7. **Queue:** share three items without opening the app in between, then open the
    app three times (backgrounding between) → all three drafts appear, oldest
-   first, none lost.
-7. Upgrade path: a share captured by the pre-queue build still surfaces after
-   updating to this one.
+   first, none lost. This is the one guarding against silent data loss, so it is
+   the most worthwhile of the four.
+8. Upgrade path: a share captured by the pre-queue build still surfaces after
+   updating to this one. Time-limited — once no install predates the queue, this
+   stops being testable and stops mattering.
 
 ## Known gap
 

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 				INFOPLIST_FILE = LifeGlanceWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LifeGlanceWidgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -464,7 +464,7 @@
 				INFOPLIST_FILE = LifeGlanceWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LifeGlanceWidgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -503,7 +503,7 @@
 				INFOPLIST_FILE = LifeGlanceShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = lifeGLANCE;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -544,7 +544,7 @@
 				INFOPLIST_FILE = LifeGlanceShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = lifeGLANCE;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -614,7 +614,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -665,7 +665,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -684,7 +684,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CTZ7352A3G;
 				INFOPLIST_FILE = App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -708,7 +708,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CTZ7352A3G;
 				INFOPLIST_FILE = App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
+++ b/ios/App/LifeGlanceWidgets/LifeGlanceWidgetsBundle.swift
@@ -55,34 +55,43 @@ struct BlueCountdownWidget: Widget {
 
 struct NextMilestoneWidget: Widget {
     var body: some WidgetConfiguration {
+        // NextMilestoneEntryView routes by family: Lock Screen sizes get the
+        // vibrant-safe accessory views, Home Screen sizes the existing ones.
         StaticConfiguration(kind: "NextMilestoneWidget", provider: SnapshotProvider()) { entry in
-            NextMilestoneView(entry: entry).widgetBackground(Palette.bg)
+            NextMilestoneEntryView(entry: entry)
         }
         .configurationDisplayName("Next milestone")
         .description("Your next upcoming milestone, with a live countdown.")
-        .supportedFamilies([.systemMedium, .systemLarge])
+        .supportedFamilies([
+            .systemMedium, .systemLarge,
+            .accessoryCircular, .accessoryRectangular, .accessoryInline,
+        ])
     }
 }
 
 struct TodayWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "TodayWidget", provider: SnapshotProvider()) { entry in
-            TodayView(entry: entry).widgetBackground(Palette.bg)
+            TodayEntryView(entry: entry)
         }
         .configurationDisplayName("Today")
         .description("Today's date and your age, with recent and upcoming milestones at larger sizes.")
-        .supportedFamilies([.systemMedium, .systemLarge])
+        // No .accessoryCircular: a date and an age have nothing to render in a
+        // circle that the system clock doesn't already show.
+        .supportedFamilies([.systemMedium, .systemLarge, .accessoryRectangular, .accessoryInline])
     }
 }
 
 struct CurrentChapterWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "CurrentChapterWidget", provider: SnapshotProvider()) { entry in
-            CurrentChapterView(entry: entry).widgetBackground(Palette.bg)
+            CurrentChapterEntryView(entry: entry)
         }
         .configurationDisplayName("Current chapter")
         .description("The chapter you're in now: how far along you are and milestones passed.")
-        .supportedFamilies([.systemMedium, .systemLarge])
+        // No .accessoryInline: chapter progress needs two values, and inline is a
+        // single line shared with the clock.
+        .supportedFamilies([.systemMedium, .systemLarge, .accessoryCircular, .accessoryRectangular])
     }
 }
 

--- a/ios/App/LifeGlanceWidgets/WidgetAccessoryViews.swift
+++ b/ios/App/LifeGlanceWidgets/WidgetAccessoryViews.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+import WidgetKit
+
+// Lock Screen (accessory) widget views. iOS 16+, which the whole project now
+// targets, so no availability gating is needed.
+//
+// These are deliberately NOT the system-family views shrunk down. Two constraints
+// drive the difference:
+//
+//  1. The Lock Screen renders accessory widgets in `WidgetRenderingMode.vibrant`:
+//     content is desaturated to a single tone and composited against the
+//     wallpaper. Palette.amber and the per-slot accent colors carry no
+//     information here — everything arrives the same shade — so these views lean
+//     on hierarchy, weight, and wording instead of color.
+//  2. They must not paint an opaque background. The system-family views call
+//     .widgetBackground(Palette.bg); accessory views use accessoryBackground()
+//     (a clear container) or AccessoryWidgetBackground() for the standard
+//     translucent circle, so the wallpaper shows through as the platform expects.
+//
+// System fonts rather than the app's monospace: the Lock Screen sits directly
+// under the system clock, and matching its typography reads better than matching
+// the app's.
+
+// MARK: - Shared helpers
+
+extension View {
+    // Accessory widgets must not fill their container with an opaque color. On
+    // iOS 17+ a container background is still required, so declare a clear one.
+    @ViewBuilder
+    func accessoryBackground() -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            containerBackground(.clear, for: .widget)
+        } else {
+            self
+        }
+    }
+}
+
+// Days until (negative = past). Nil when the date can't be parsed.
+private func daysUntil(_ iso: String) -> Int? {
+    guard let date = WidgetDate.calendarDate(iso) else { return nil }
+    return Calendar.current.dateComponents([.day], from: WidgetDate.todayDate(), to: date).day
+}
+
+// Mirrors the private helper in WidgetViews.swift: nil id yields nil, so an empty
+// widget doesn't deep-link to "lifeglance://milestone?id=" and leave the app
+// hunting for a milestone that was never there.
+private func accessoryMilestoneURL(_ id: String?) -> URL? {
+    guard let id, !id.isEmpty else { return nil }
+    return URL(string: "lifeglance://milestone?id=\(id)")
+}
+
+// MARK: - Next milestone
+
+struct NextMilestoneCircularView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        ZStack {
+            AccessoryWidgetBackground()
+            if let next = entry.snapshot?.next, let days = daysUntil(next.date) {
+                VStack(spacing: -2) {
+                    Text("\(max(days, 0))")
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .minimumScaleFactor(0.6)
+                        .lineLimit(1)
+                    Text(days == 1 ? "day" : "days")
+                        .font(.system(size: 10))
+                }
+            } else {
+                Image(systemName: "calendar")
+            }
+        }
+        .widgetURL(accessoryMilestoneURL(entry.snapshot?.next?.id))
+    }
+}
+
+struct NextMilestoneRectangularView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            if let next = entry.snapshot?.next {
+                // No color available to mark this as a label, so weight does it.
+                Text("NEXT").font(.system(size: 11, weight: .bold))
+                Text(next.title).font(.system(size: 14, weight: .semibold)).lineLimit(1)
+                Text(WidgetDate.relativeLabel(next.date)).font(.system(size: 12)).lineLimit(1)
+            } else {
+                Text("No upcoming milestones").font(.system(size: 13)).lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .widgetURL(accessoryMilestoneURL(entry.snapshot?.next?.id))
+    }
+}
+
+struct NextMilestoneInlineView: View {
+    let entry: SnapshotEntry
+
+    // .accessoryInline shares one line with the clock and ignores custom fonts
+    // and colors, so this is a single plain Text by design.
+    var body: some View {
+        if let next = entry.snapshot?.next {
+            Text("\(next.title) · \(WidgetDate.relativeLabel(next.date))")
+        } else {
+            Text("No upcoming milestones")
+        }
+    }
+}
+
+// MARK: - Current chapter
+
+struct CurrentChapterCircularView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        ZStack {
+            if let chapter = entry.snapshot?.currentChapter,
+               let fraction = WidgetDate.progressFraction(start: chapter.start, end: chapter.end) {
+                // A ring reads at this size where a percentage label would not.
+                Gauge(value: min(max(fraction, 0), 1)) {
+                    Image(systemName: "book")
+                }
+                .gaugeStyle(.accessoryCircularCapacity)
+            } else {
+                AccessoryWidgetBackground()
+                Image(systemName: "book")
+            }
+        }
+    }
+}
+
+struct CurrentChapterRectangularView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            if let chapter = entry.snapshot?.currentChapter {
+                Text("CHAPTER").font(.system(size: 11, weight: .bold))
+                Text(chapter.title).font(.system(size: 14, weight: .semibold)).lineLimit(1)
+                if let passed = chapter.passedCount, let total = chapter.totalCount, total > 0 {
+                    Text("\(passed) of \(total) milestones").font(.system(size: 12)).lineLimit(1)
+                } else if let fraction = WidgetDate.progressFraction(start: chapter.start, end: chapter.end) {
+                    Text("\(Int((min(max(fraction, 0), 1)) * 100))% through").font(.system(size: 12))
+                }
+            } else {
+                Text("No current chapter").font(.system(size: 13)).lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Today
+
+struct TodayRectangularView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(WidgetDate.weekday().uppercased()).font(.system(size: 11, weight: .bold))
+            Text(WidgetDate.todayLong()).font(.system(size: 14, weight: .semibold)).lineLimit(1)
+            if let age = WidgetDate.age(entry.snapshot?.birthday) {
+                Text("Age \(age)").font(.system(size: 12))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+}
+
+struct TodayInlineView: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        if let age = WidgetDate.age(entry.snapshot?.birthday) {
+            Text("\(WidgetDate.todayLong()) · age \(age)")
+        } else {
+            Text(WidgetDate.todayLong())
+        }
+    }
+}
+
+// MARK: - Family routers
+//
+// Each widget's content closure goes through one of these so a single `kind`
+// serves both the Home Screen and the Lock Screen. The system-family branch keeps
+// the existing opaque-background views untouched.
+
+struct NextMilestoneEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular:
+            NextMilestoneCircularView(entry: entry).accessoryBackground()
+        case .accessoryRectangular:
+            NextMilestoneRectangularView(entry: entry).accessoryBackground()
+        case .accessoryInline:
+            NextMilestoneInlineView(entry: entry)
+        default:
+            NextMilestoneView(entry: entry).widgetBackground(Palette.bg)
+        }
+    }
+}
+
+struct CurrentChapterEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular:
+            CurrentChapterCircularView(entry: entry).accessoryBackground()
+        case .accessoryRectangular:
+            CurrentChapterRectangularView(entry: entry).accessoryBackground()
+        default:
+            CurrentChapterView(entry: entry).widgetBackground(Palette.bg)
+        }
+    }
+}
+
+struct TodayEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: SnapshotEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryRectangular:
+            TodayRectangularView(entry: entry).accessoryBackground()
+        case .accessoryInline:
+            TodayInlineView(entry: entry)
+        default:
+            TodayView(entry: entry).widgetBackground(Palette.bg)
+        }
+    }
+}


### PR DESCRIPTION
## What and why

Adds Lock Screen (accessory) widget families, the roadmap's next iOS slice after the share extension. Accessory families require iOS 16, so the deployment target moves from 15.0 to 16.0 — which also unblocks App Intents, the slice after this one.

### Deployment target

Raised to 16.0 across all 8 build configs. `CapApp-SPM` deliberately stays at `.iOS(.v15)`: a package supporting 15+ is fine inside a 16+ app, and leaving it alone avoids fighting `cap sync`.

Verified from the CI build log that this actually took effect, rather than trusting a green tick. Attributing every `-target ...apple-ios<version>` to its owning target:

```
ios14.0   IONFilesystemLib                                      (SPM dependency)
ios15.0   CapacitorFilesystem, CapacitorShare                   (SPM dependencies)
ios16.0   App, LifeGlanceShare, LifeGlanceWidgetsExtension,     <- all our targets
          CapApp-SPM
```

The 14.0/15.0 entries are third-party plugins declaring their own minimums. All four of our targets build at 16.0, so `cap sync` did not revert the bump.

### Which widgets get Lock Screen variants

| Widget | Circular | Rectangular | Inline |
|---|---|---|---|
| Next milestone | days remaining | yes | yes |
| Current chapter | progress ring | yes | — |
| Today | — | yes | yes |

**The four colour-slot countdown widgets are deliberately excluded.** They exist so several pinned countdowns can coexist *distinguished by colour*, and the Lock Screen renders accessory widgets in `WidgetRenderingMode.vibrant` — everything desaturates to a single tone — so all four would be visually identical. Porting them would produce four indistinguishable widgets in the picker.

Per-family exclusions for the same reason: Today has no circular variant (a date and an age add nothing to a circle sitting beside the system clock), and Current chapter has no inline (progress needs two values, inline is one line shared with the clock).

### Why the accessory views are new rather than the existing ones shrunk

Two constraints force it:

1. **Vibrant rendering** means `Palette.amber` and the per-slot accents carry no information — everything arrives the same shade. These views lean on hierarchy, weight, and wording instead.
2. **Accessory widgets must not paint an opaque background.** The system-family views call `.widgetBackground(Palette.bg)`; the accessory views use a clear container (or `AccessoryWidgetBackground()` for the circle) so the wallpaper shows through as the platform expects.

They also use system fonts rather than the app's monospace, to sit properly under the system clock.

Each widget keeps a single `kind` and routes by `widgetFamily`, so **existing Home Screen placements are untouched** — no one loses a configured widget. The new file lands in the synchronized folder group, so no project-file surgery was needed this time.

## Also here

One docs commit recording that the share extension shipped in #310 is now **device-verified**: it appears in the share sheet, the confirmation sheet shows, and the pre-filled Add sheet is waiting on next launch. The spec still listed all of that as outstanding. It now separates what a normal share exercises (passed) from four edge cases it does not touch, so a passing main path stops implying the whole list is covered.

## Verification

CI green. From the build log: `WidgetAccessoryViews.swift` compiled for arm64 and x86_64 with **zero errors and zero warnings** beyond the two pre-existing ones (the `Splash` asset-catalog warning and the `appintentsmetadataprocessor` note).

That compile is a meaningful check here, not just a formality: `.accessoryCircular`, `.accessoryRectangular`, `Gauge`, and `AccessoryWidgetBackground` are all iOS 16 symbols, so a silently reverted deployment target would have failed this file loudly rather than passing quietly.

**Not verified: how any of it looks.** CI compiles but never renders, and Lock Screen widgets are unusually design-sensitive — they composite against arbitrary wallpapers in a single desaturated tone. Worth checking on device:

1. Add all three to the Lock Screen (long-press → Customise → the widget row under the clock).
2. Next milestone circular with a 3-digit day count — `minimumScaleFactor(0.6)` is meant to cover it.
3. Current chapter circular — does the progress ring read at that size?
4. Inline variants truncate aggressively next to the clock; a long milestone title may not survive.
5. A busy or light wallpaper, which is the real test of vibrant rendering.

If a family does not earn its place, dropping it is a one-line change.

## Note on scope

`CONTRIBUTING.md` asks for one logical change per PR. This is the widget change plus a docs commit about the previously merged share extension; they are bundled because the docs commit is a two-line status correction, not separate work. Happy to split if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_