### PR TITLE
iOS: add an "Add milestone" App Intent for Siri and Shortcuts

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0DA92D722FECC30800F56B1C /* WidgetBridgePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */; };
 		0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D752FECE9F200F56B1C /* MainViewController.swift */; };
 		0DB5E10D2FED010000F56B1C /* LifeGlanceShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */; };
 		7B5F62012E3D110100D5E3A1 /* VaultSseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */; };
 		7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
@@ -66,6 +67,7 @@
 		0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBridgePlugin.swift; sourceTree = "<group>"; };
 		0DA92D752FECE9F200F56B1C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeGlanceShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMilestoneIntent.swift; sourceTree = "<group>"; };
 		7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSseClient.swift; sourceTree = "<group>"; };
 		7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSsePlugin.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 		504EC3061FED79650016851F /* App */ = {
 			isa = PBXGroup;
 			children = (
+				0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */,
 				0DA92D752FECE9F200F56B1C /* MainViewController.swift */,
 				7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */,
 				7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */,
@@ -361,6 +364,7 @@
 				0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */,
 				7B5F62012E3D110100D5E3A1 /* VaultSseClient.swift in Sources */,
 				7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */,
+				0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/AddMilestoneIntent.swift
+++ b/ios/App/App/AddMilestoneIntent.swift
@@ -1,0 +1,53 @@
+import AppIntents
+import Foundation
+
+// "Add milestone" App Intent — the minimal iOS automation surface described in
+// docs/lifeglance-native-roadmap.md: declare the one intent and stop there. No
+// parameterized intents, no Shortcuts chaining. The asymmetry with Android is
+// deliberate (Tasker already speaks the intent surface declared for app-to-app
+// interop there, so depth is nearly free; on iOS equivalent depth means
+// hand-building parameterized Shortcuts surfaces).
+//
+// This reuses the Quick Add widget's contract rather than inventing a second one:
+// write "new" to the App Group's pending_action key, which
+// WidgetBridgePlugin.consumeLaunchTarget() hands to the web layer, which opens
+// the Add-milestone sheet (TimelineView, `target.action === 'new'`). Same path a
+// Quick Add widget tap takes, so there is one code path to keep working.
+//
+// iOS 16+, which the project now targets, so no availability gating.
+struct AddMilestoneIntent: AppIntent {
+    static var title: LocalizedStringResource = "Add Milestone"
+    static var description = IntentDescription(
+        "Opens lifeGLANCE with a new milestone ready to fill in."
+    )
+
+    // The Add sheet is web UI inside the app, so there is nothing meaningful this
+    // intent could do headlessly — it always brings the app forward.
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        // Constants rather than string literals: a typo here would fail silently,
+        // with the app simply opening to the timeline and no sheet.
+        UserDefaults(suiteName: WidgetStore.appGroupId)?
+            .set("new", forKey: WidgetStore.keyPendingAction)
+        return .result()
+    }
+}
+
+// Surfaces the intent to Siri and the Shortcuts app without the user having to
+// assemble a shortcut first. Phrases must interpolate .applicationName — the API
+// requires the app name in every phrase.
+struct LifeGlanceAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AddMilestoneIntent(),
+            phrases: [
+                "Add a milestone in \(.applicationName)",
+                "New milestone in \(.applicationName)",
+                "Add a \(.applicationName) milestone",
+            ],
+            shortTitle: "Add milestone",
+            systemImageName: "plus.circle"
+        )
+    }
+}


### PR DESCRIPTION
> **Stacked on #314.** Base is `claude/ios-native-features-dbh8yh`, not `main`, because App Intents needs iOS 16 and that deployment-target bump lives in #314. Targeting `main` would produce a PR that does not compile. GitHub will retarget this to `main` automatically once #314 merges. Review #314 first; the diff here is one Swift file plus its project entries.

## What and why

The roadmap's minimal iOS automation surface: declare one intent, stop there. No parameterized intents, no Shortcuts chaining.

The asymmetry with Android is deliberate and already recorded in `lifeglance-native-roadmap.md`. On Android, Tasker speaks the intent surface declared for app-to-app interop, so automation depth is close to free. On iOS there is no equivalent, so the same depth means hand-building parameterized Shortcuts surfaces. Different ecosystems, different depths.

## How it works

`AddMilestoneIntent` **reuses the Quick Add widget's existing contract** rather than inventing a second one:

```
intent → pending_action = "new" (App Group)
       → WidgetBridgePlugin.consumeLaunchTarget()
       → TimelineView: target.action === 'new'
       → Add-milestone sheet
```

That is the exact path a Quick Add widget tap already takes, so there is one code path to keep working rather than two, and no new web-layer or bridge changes at all.

Details worth noting:

- It uses `WidgetStore.appGroupId` / `.keyPendingAction` rather than string literals. A typo there fails silently — the app just opens with no sheet — so the constants are load-bearing, not cosmetic.
- `openAppWhenRun = true`, because the Add sheet is web UI inside the app. There is nothing meaningful this intent could do headlessly.
- `LifeGlanceAppShortcuts` surfaces it to Siri and the Shortcuts app so it works without the user assembling a shortcut first. Phrases interpolate `.applicationName`, which the API requires.

## Project wiring

Unlike the widgets, which use a `PBXFileSystemSynchronizedRootGroup` and pick up new files automatically, the App target is a classic `PBXGroup`. So this needed the four usual entries — `PBXFileReference`, `PBXBuildFile`, group child, Sources phase — modelled on the existing `VaultSseClient.swift` wiring. Validated before pushing: all IDs resolve, each new ID defined exactly once, braces and parens balanced.

## Verification

CI compiles it. One nice side effect: the App target previously logged `appintentsmetadataprocessor: Metadata extraction skipped. No AppIntents.framework dependency found` on every build. That warning should now be gone, because there is finally an intent to extract — which doubles as evidence the intent was actually seen by the toolchain rather than merely compiled.

**Not device-tested.** Two things worth checking:

1. Ask Siri "Add a milestone in lifeGLANCE", and check the action appears in the Shortcuts app. A missing entry usually means the shortcut provider was not registered, which compiles fine.
2. **Cold launch specifically.** `perform()` writes to the App Group, and `TimelineView` drains on mount. A `UserDefaults` write should complete long before the web layer boots, so the ordering should hold, but if it ever loses that race the symptom is the app opening to the timeline with no sheet. Warm launch is safer — the drain also runs on `visibilitychange`.

If the cold-launch race does turn out to be real, the fix is a small bridge notification rather than a redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_