### PR TITLE
Manage the iOS build number explicitly, across every target

### DIFF
--- a/scripts/sync-ios-version.mjs
+++ b/scripts/sync-ios-version.mjs
@@ -1,5 +1,32 @@
 #!/usr/bin/env node
-// Sync the iOS marketing version (CFBundleShortVersionString) with package.json.
+// Keep the iOS project's version settings consistent across every target.
+//
+// Two separate jobs, because the two numbers answer different questions:
+//
+//   MARKETING_VERSION (CFBundleShortVersionString) is the version users see and
+//   tracks package.json, the iOS analogue of the package.json-derived versionName
+//   in android/app/build.gradle. Always rewritten to match.
+//
+//   CURRENT_PROJECT_VERSION (CFBundleVersion) is the build number. App Store
+//   Connect requires the (marketing version, build number) PAIR to be unique, so
+//   this has to increment per UPLOAD, not per version — which is exactly why it
+//   cannot be derived from package.json: you routinely ship several TestFlight
+//   builds of one version. Set it explicitly:
+//
+//       IOS_BUILD=7 npm run build:ios
+//
+//   With IOS_BUILD unset the build number is left alone, but every target is
+//   checked for agreement. That check is the point of this half of the script:
+//   an app and its extensions MUST ship the same CFBundleVersion or App Store
+//   Connect rejects the upload at validation, and Xcode's General tab edits only
+//   the target you happen to have selected. lifeGLANCE has three targets — App,
+//   LifeGlanceWidgetsExtension and LifeGlanceShare — so bumping the build number
+//   by hand moves one and silently leaves two behind.
+//
+// Mirrors scripts/sync-ios-version.mjs in lastGLANCE; keep the two in step.
+//
+// Usage: node scripts/sync-ios-version.mjs   (run from the repo root)
+
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
@@ -8,12 +35,73 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const version = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version
 const pbxPath = resolve(root, 'ios/App/App.xcodeproj/project.pbxproj')
 
-const pbx = readFileSync(pbxPath, 'utf8')
-const updated = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
+const original = readFileSync(pbxPath, 'utf8')
+let pbx = original
 
-if (updated === pbx) {
-  console.log(`iOS MARKETING_VERSION already ${version} (no change)`)
-} else {
-  writeFileSync(pbxPath, updated)
-  console.log(`iOS MARKETING_VERSION -> ${version}`)
+// --- Marketing version: always tracks package.json -------------------------
+
+pbx = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
+console.log(
+  pbx === original
+    ? `iOS MARKETING_VERSION already ${version} (no change)`
+    : `iOS MARKETING_VERSION -> ${version}`,
+)
+
+// --- Build number: explicit, and identical across every target -------------
+
+const found = [...pbx.matchAll(/CURRENT_PROJECT_VERSION = ([^;]+);/g)].map(m => m[1].trim())
+if (found.length === 0) {
+  console.error('error: no CURRENT_PROJECT_VERSION found in project.pbxproj')
+  process.exit(1)
 }
+
+const requested = process.env.IOS_BUILD?.trim()
+
+if (requested) {
+  // CFBundleVersion is one to three period-separated integers.
+  if (!/^\d+(\.\d+){0,2}$/.test(requested)) {
+    console.error(
+      `error: IOS_BUILD must be one to three period-separated integers, got "${requested}"`,
+    )
+    process.exit(1)
+  }
+
+  // Advisory only. A build number must increase within a marketing version, but
+  // restarting at 1 after a version bump is legitimate, so this cannot be a hard
+  // failure — it just catches the far more common "forgot to increment".
+  const current = [...new Set(found)]
+  if (
+    current.length === 1 &&
+    /^\d+$/.test(current[0]) &&
+    /^\d+$/.test(requested) &&
+    Number(requested) <= Number(current[0])
+  ) {
+    console.warn(
+      `warning: IOS_BUILD ${requested} is not greater than the current ${current[0]}. ` +
+      'App Store Connect rejects a build number it has already seen for this marketing version.',
+    )
+  }
+
+  pbx = pbx.replace(
+    /CURRENT_PROJECT_VERSION = [^;]+;/g,
+    `CURRENT_PROJECT_VERSION = ${requested};`,
+  )
+  console.log(`iOS CURRENT_PROJECT_VERSION -> ${requested} (${found.length} build configs)`)
+} else {
+  const distinct = [...new Set(found)]
+  if (distinct.length > 1) {
+    console.error(
+      `error: CURRENT_PROJECT_VERSION disagrees across targets: ${distinct.join(', ')}.\n` +
+      '       An app and its extensions must ship the same CFBundleVersion or the\n' +
+      '       App Store Connect upload is rejected. Set them all with:\n' +
+      `           IOS_BUILD=<n> npm run build:ios`,
+    )
+    process.exit(1)
+  }
+  console.log(
+    `iOS CURRENT_PROJECT_VERSION is ${distinct[0]} across ${found.length} build configs ` +
+    '(unchanged; set IOS_BUILD to bump)',
+  )
+}
+
+if (pbx !== original) writeFileSync(pbxPath, pbx)


### PR DESCRIPTION
## What

`IOS_BUILD=2 npm run build:ios` now sets the iOS build number, matching what lastGLANCE does.

Ported from lastGLANCE's `scripts/sync-ios-version.mjs` so the two stay in step — only the comment differs, naming this project's targets.

## Why it can't just follow package.json

`build:ios` already synced `MARKETING_VERSION` from `package.json`, but left `CURRENT_PROJECT_VERSION` alone, so the build number could only be changed by hand in Xcode.

These two numbers answer different questions. App Store Connect requires the **(marketing version, build number) pair** to be unique, so the build number increments per *upload*, not per version — shipping several TestFlight builds of one version is the normal case, and deriving it from `package.json` would make that impossible.

## The check is the more valuable half

With `IOS_BUILD` unset nothing is written, but every target is checked for agreement and a mismatch **fails the build**.

An app and its extensions must ship the same `CFBundleVersion` or App Store Connect rejects the upload at validation. Xcode's General tab edits only the target you have selected, and lifeGLANCE now has three — `App`, `LifeGlanceWidgetsExtension`, `LifeGlanceShare` — so bumping the build number by hand moves one and silently leaves two behind. The failure then surfaces at upload time, long after the mistake, with an error that does not obviously point back at it.

Currently all 6 build configs agree at `1`, so this starts from a clean state.

## Behaviour

| Input | Result |
|---|---|
| `IOS_BUILD` unset, all targets agree | reports the value, writes nothing |
| `IOS_BUILD` unset, targets disagree | **exit 1**, naming the conflicting values |
| `IOS_BUILD=2` | sets all 6 configs |
| `IOS_BUILD=2.1` | accepted (CFBundleVersion allows up to three integers) |
| `IOS_BUILD=1.2.3.4` | **exit 1**, invalid format |
| `IOS_BUILD` not greater than current | warns, still applies |

The non-increasing case warns rather than fails on purpose: restarting at `1` after a marketing-version bump is legitimate, so it cannot be a hard error — it just catches the far more common "forgot to increment".

## Verification

Exercised all eight paths locally against the real `project.pbxproj`, including the two that matter:

```
### 7. targets disagree (App bumped, extensions left behind)
      4 CURRENT_PROJECT_VERSION = 2.1;
      2 CURRENT_PROJECT_VERSION = 9;
error: CURRENT_PROJECT_VERSION disagrees across targets: 9, 2.1.
exit=1

### 8. IOS_BUILD repairs the disagreement
iOS CURRENT_PROJECT_VERSION -> 3 (6 build configs)
      6 CURRENT_PROJECT_VERSION = 3;
```

`project.pbxproj` was restored afterwards, so this PR touches only the script.

## Noticed, not fixed here

The checked-in `MARKETING_VERSION` is `3.0.1` while `package.json` is `3.2.0`. Nothing ships wrong — `build:ios` rewrites it every time, which is why the drift went unnoticed — but the committed value is stale. Left alone deliberately to keep this diff to one file; it corrects itself on the next `build:ios`, or can be committed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_