### PR TITLE
Drain the whole share queue without backgrounding the app

### DIFF
--- a/docs/ios-share-extension-spec.md
+++ b/docs/ios-share-extension-spec.md
@@ -330,22 +330,35 @@ passing the above says nothing about them:
 6. The confirmation sheet in *both* light and dark appearance (only the tested
    appearance is known good).
 7. **Queue:** share three items without opening the app in between, then open the
-   app three times (backgrounding between) → all three drafts appear, oldest
-   first, none lost. This is the one guarding against silent data loss, so it is
-   the most worthwhile of the four.
+   app **once** → the first draft appears, and closing it (saved or dismissed)
+   brings up the second, then the third, without backgrounding. This is the one
+   guarding against silent data loss, so it is the most worthwhile of the four.
+   Watch the close/reopen transition between drafts while you are here.
 8. Upgrade path: a share captured by the pre-queue build still surfaces after
    updating to this one. Time-limited — once no install predates the queue, this
    stops being testable and stops mattering.
 
-## Known gap
+## Draining more than one queued share
 
-The app drains **one** queued share per launch/resume, because
-`consumeLaunchTarget()` is called from `TimelineView`'s `visibilitychange`
-handler and the app can only show one Add sheet at a time. Sharing three things
-then opening the app once yields the first draft; the other two wait for the next
-resume. Nothing is lost, but draining the rest as each sheet is dismissed would
-be the better behaviour — a small `TimelineView` change, deliberately not bundled
-with the native fix.
+The native side pops **one** share per `consumeLaunchTarget()`, because the app
+can only show one Add sheet at a time. The queue is therefore drained a step at a
+time rather than all at once.
+
+`TimelineView` advances it on sheet close: opening a share-seeded Add sheet sets
+`drainNextShareRef`, and `closeSheet()` re-runs the launch-target drain, which
+reopens the sheet if another share is waiting and does nothing if not (the bridge
+then returns `null`). Saving and dismissing both route through `closeSheet` —
+`AddMilestoneSheet` calls `onClose()` after a successful save — so either counts
+as a decision about that share and advances the queue.
+
+This previously waited for the next launch/resume, so sharing three things and
+opening the app once yielded only the first draft. Nothing was lost, but the
+remainder sat until the app was backgrounded and foregrounded again.
+
+> Note the sheet closes and reopens between shares rather than swapping its
+> contents in place. That is deliberate — it signals "next one" — but it is the
+> part most worth a second look on device, since a fast close/reopen can read as
+> a flicker.
 
 ## Out of scope
 

--- a/src/components/timeline/TimelineView.jsx
+++ b/src/components/timeline/TimelineView.jsx
@@ -110,6 +110,14 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   const [filter,        setFilter]        = useState(new Set())
   const [addOpen,       setAddOpen]       = useState(false)
   const [shareDraft,    setShareDraft]    = useState(null)
+  // Set when the Add sheet was seeded from a share, so closing it drains the next
+  // queued share. The native side pops one share per consumeLaunchTarget() call
+  // (it can only surface one at a time, since the app shows one Add sheet), so
+  // without this the rest sit until the app is backgrounded and resumed again.
+  const drainNextShareRef = useRef(false)
+  // Lets closeSheet re-run the launch-target drain, which is defined inside the
+  // mount-once effect below.
+  const consumeNextTargetRef = useRef(null)
   const [editTarget,    setEditTarget]    = useState(null)
   const [detail,        setDetail]        = useState(null)
   const [textSize,      setTextSize]      = useState(() => {
@@ -578,6 +586,8 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
         setEditTarget(null)
         setShareDraft(d)
         setAddOpen(true)
+        // More may be queued behind this one; closeSheet drains the next.
+        drainNextShareRef.current = true
         return
       }
       const m = milestonesRef.current.find(x => x.id === target.milestoneId)
@@ -587,6 +597,7 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
       timelineRef.current?.panToMs(new Date(m.date).getTime())
       setDetail(m)
     }
+    consumeNextTargetRef.current = handleTarget
     handleTarget()
     const onShow = () => { if (document.visibilityState === 'visible') handleTarget() }
     document.addEventListener('visibilitychange', onShow)
@@ -1150,7 +1161,16 @@ export default function TimelineView({ milestones, setMilestones, chapters, setC
   }
 
   function openEdit(m)  { setEditTarget(m); setAddOpen(true) }
-  function closeSheet() { setAddOpen(false); setEditTarget(null); setShareDraft(null) }
+  function closeSheet() {
+    setAddOpen(false); setEditTarget(null); setShareDraft(null)
+    // Saved or dismissed, both are a decision about that share — so advance the
+    // queue either way. Reopens the sheet if another share is waiting; does
+    // nothing if not, since consumeLaunchTarget() then returns null.
+    if (drainNextShareRef.current) {
+      drainNextShareRef.current = false
+      consumeNextTargetRef.current?.()
+    }
+  }
 
   // ── Chapter CRUD ─────────────────────────────────────────────────────────────
   function openChapterCreate() { setEditChapter(null); setChapterSheetOpen(true) }


### PR DESCRIPTION
## The gap

Sharing three things and then opening lifeGLANCE once yielded only the **first** draft.

The native side pops one share per `consumeLaunchTarget()` — the app can show one Add sheet at a time — and the only caller was `TimelineView`'s `visibilitychange` handler. So the remaining shares sat until the app was backgrounded and foregrounded again, once per share. Nothing was lost, but nothing indicated the others were waiting either.

This was documented as a known gap when the share queue landed and deliberately left out of that native fix.

## The fix

`closeSheet()` now advances the queue:

- Opening a share-seeded Add sheet sets `drainNextShareRef`
- `closeSheet()` re-runs the launch-target drain, which reopens the sheet if another share is waiting, and does nothing if not (the bridge returns `null`)

**Saving and dismissing both count.** `AddMilestoneSheet` calls `onClose()` after a successful save (`AddMilestoneSheet.jsx:215`) as well as on dismiss, so `closeSheet` is the single funnel and either action is treated as a decision about that share. This matches the equivalent fix already shipped in dayGLANCE #1355.

**Guarded by the ref**, rather than firing on every sheet close. Without that, opening the Add sheet normally and closing it would re-enter the launch-target drain and could consume an unrelated pending widget action.

No native or bridge changes — the contract is unchanged, this just calls it more often.

## One thing worth a look on device

The sheet **closes and reopens** between shares rather than swapping its contents in place. That is deliberate: a clean close/reopen signals "next one" rather than making the sheet appear to mutate under you. But a fast transition can read as a flicker, and that is the part I would want eyes on. If it looks wrong, swapping the draft in place without closing is the alternative.

Noted in the spec so it is a considered choice rather than an accident.

## Verification

Lint clean with **no new warnings** — 27 before and after, and the two in `TimelineView.jsx` are at lines 209/242, nowhere near the touched code. 460 tests pass across 39 files.

**The behaviour itself is untested**: no test covers the share path, so that is a no-regression signal only.

Acceptance test 7 in the spec is updated to match — share three items, open the app **once**, and closing each draft should bring up the next without backgrounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_