### PR TITLE
ci: add an Android build gate

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,64 @@
+name: Android build
+
+# Verifies the Android app still compiles after web or native changes — the
+# Android twin of ios.yml. Build-only: assembleDebug, no signing, no emulator,
+# no upload. The Kotlin/Java in android/ had no compile coverage at all before
+# this; a broken plugin or widget could only surface on someone's machine.
+#
+# Scoped to changes that can affect the Android build so ordinary web-only PRs
+# don't spend the (cheap, but not free) gradle run.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'android/**'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'capacitor.config.js'
+      - '.github/workflows/android.yml'
+  pull_request:
+    paths:
+      - 'android/**'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'capacitor.config.js'
+      - '.github/workflows/android.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          # AGP 8.13 / Gradle 9.3 build fine on 21; 17 is the floor.
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Capacitor 8's CLI requires Node >= 22.
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web assets
+        run: npm run build
+
+      - name: Sync Capacitor Android
+        run: npx cap sync android
+
+      - name: Build Android app (debug, no signing)
+        run: cd android && ./gradlew assembleDebug --no-daemon


### PR DESCRIPTION
## What

The Android twin of `ios.yml`: `assembleDebug` on ubuntu-latest, no signing, no emulator, path-filtered so web-only PRs don't spend the run. JDK 21 for AGP 8.13 / Gradle 9.3.

## Why now

`android/` carries 15+ Kotlin files (widgets, tile, SSE client) plus the Java plugins and `MainActivity`, with **no compile coverage at all** — `docker.yml` and `ios.yml` never touch it, so a broken plugin could only surface on someone's machine.

The immediate motivation is the same one that justified the dayGLANCE iOS gate: the next slice (#320, native media pickers) adds Kotlin that would otherwise ship compile-unverified. That PR stacks on this branch so its pushes run this workflow.

## Verification

The workflow's own first run on this branch is the verification — it builds current `main`'s Android code, which is known-good from local builds, so a failure here would indicate a workflow bug rather than a code bug. Checked before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_