### PR TITLE
android: native media pickers — Photo Picker for images, SAF for audio/video

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,6 +107,12 @@ dependencies {
     // Play Billing bridge (@glance-apps/billing npm package's bundled module)
     implementation project(':glance-apps-billing')
 
+    // PickVisualMedia (the permission-free Android Photo Picker contract) —
+    // used by MediaPickerPlugin. appcompat pulls androidx.activity transitively,
+    // but the contract needs 1.6+, so pin it explicitly rather than relying on
+    // whatever version rides along.
+    implementation "androidx.activity:activity-ktx:1.9.3"
+
     // Home-screen widgets (Jetpack Glance, Kotlin/Compose)
     implementation "androidx.glance:glance-appwidget:$rootProject.ext.glanceVersion"
     implementation "androidx.work:work-runtime-ktx:$rootProject.ext.workManagerVersion"

--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -11,6 +11,7 @@ import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.getcapacitor.BridgeActivity;
 import com.glanceapps.billing.BillingBridgePlugin;
+import com.lifeglance.app.media.MediaPickerPlugin;
 import com.lifeglance.app.sse.VaultSsePlugin;
 import com.lifeglance.app.widget.WidgetData;
 
@@ -27,6 +28,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(BillingBridgePlugin.class);
         registerPlugin(WebDavHttpPlugin.class);
         registerPlugin(VaultSsePlugin.class);
+        registerPlugin(MediaPickerPlugin.class);
         super.onCreate(savedInstanceState);
         handleWidgetIntent(getIntent());
         handleShareIntent(getIntent());

--- a/android/app/src/main/java/com/lifeglance/app/media/MediaPickerPlugin.kt
+++ b/android/app/src/main/java/com/lifeglance/app/media/MediaPickerPlugin.kt
@@ -1,0 +1,125 @@
+package com.lifeglance.app.media
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.ActivityCallback
+import com.getcapacitor.annotation.CapacitorPlugin
+import java.io.File
+
+/**
+ * Native media pickers for milestone attachments. Two methods, two system UIs,
+ * zero permissions:
+ *
+ *   pickPhoto()  — the Android Photo Picker ([PickVisualMedia], image-only).
+ *                  No READ_MEDIA_IMAGES, no permission prompt; the system runs
+ *                  the picker in its own process and grants access to only the
+ *                  chosen item. The contract itself falls back to an
+ *                  ACTION_OPEN_DOCUMENT image chooser on devices without the
+ *                  backported picker, so minSdk 24 is fine.
+ *
+ *   pickMedia()  — SAF ACTION_OPEN_DOCUMENT filtered to audio + video. The
+ *                  Photo Picker is visual-only, and the web layer's "attach
+ *                  media" field accepts either kind in one tap, so one SAF
+ *                  dialog covering both is the only single-dialog answer. Also
+ *                  permission-free.
+ *
+ * Both resolve `{ path, name, mimeType }` after copying the item's bytes into
+ * app-owned cache — the content-URI grant is temporary and scoped, so the copy
+ * happens immediately, on a background thread (video can be large). The web
+ * layer turns `path` into a fetchable URL via Capacitor.convertFileSrc() and
+ * reads it straight into a Blob → IndexedDB, exactly like a file-input File.
+ * A cancelled picker resolves `{ cancelled: true }` rather than rejecting,
+ * since cancelling is a normal outcome, not an error.
+ *
+ * The existing web storage path is unchanged; it just receives bytes from a
+ * nicer picker (src/native/mediaPicker.js is the JS half).
+ */
+@CapacitorPlugin(name = "MediaPicker")
+class MediaPickerPlugin : Plugin() {
+
+    @PluginMethod
+    fun pickPhoto(call: PluginCall) {
+        val intent = PickVisualMedia().createIntent(
+            context,
+            PickVisualMediaRequest(PickVisualMedia.ImageOnly)
+        )
+        startActivityForResult(call, intent, "pickerResult")
+    }
+
+    @PluginMethod
+    fun pickMedia(call: PluginCall) {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+            putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("audio/*", "video/*"))
+        }
+        startActivityForResult(call, intent, "pickerResult")
+    }
+
+    // Shared result handler: both pickers deliver a single content URI (or none).
+    @ActivityCallback
+    private fun pickerResult(call: PluginCall?, result: ActivityResult) {
+        if (call == null) return
+        val uri = result.data?.data
+        if (uri == null) {
+            val ret = JSObject()
+            ret.put("cancelled", true)
+            call.resolve(ret)
+            return
+        }
+        // Copy off the main thread; openInputStream + a video-sized copy would
+        // jank or ANR the UI otherwise.
+        Thread {
+            try {
+                val copied = copyToCache(uri)
+                val ret = JSObject()
+                ret.put("path", copied.file.absolutePath)
+                ret.put("name", copied.name)
+                ret.put("mimeType", copied.mimeType)
+                call.resolve(ret)
+            } catch (e: Exception) {
+                call.reject("Failed to read the selected item: ${e.message}")
+            }
+        }.start()
+    }
+
+    private class CopiedItem(val file: File, val name: String, val mimeType: String)
+
+    // Copies the content URI's bytes into cache/picked_media/, returning the
+    // file plus the item's display name and MIME type. The directory is cleared
+    // first: only one pick is ever in flight, the previous file has long since
+    // been read into IndexedDB, and clearing here keeps stale multi-hundred-MB
+    // videos from accumulating (the OS may also clear cacheDir under pressure,
+    // which is fine — by then the bytes live in IndexedDB).
+    private fun copyToCache(uri: Uri): CopiedItem {
+        val resolver = context.contentResolver
+
+        var name = "picked"
+        resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { c ->
+            if (c.moveToFirst() && !c.isNull(0)) name = c.getString(0)
+        }
+        // The name becomes a filename; strip separators so it can't escape the dir.
+        name = name.replace('/', '_').replace('\\', '_')
+
+        val mimeType = resolver.getType(uri) ?: "application/octet-stream"
+
+        val dir = File(context.cacheDir, "picked_media")
+        dir.deleteRecursively()
+        dir.mkdirs()
+
+        val out = File(dir, name)
+        resolver.openInputStream(uri)?.use { input ->
+            out.outputStream().use { output -> input.copyTo(output) }
+        } ?: throw IllegalStateException("content resolver returned no stream")
+
+        return CopiedItem(out, name, mimeType)
+    }
+}

--- a/src/components/milestone/AddMilestoneSheet.jsx
+++ b/src/components/milestone/AddMilestoneSheet.jsx
@@ -5,6 +5,7 @@ import { buildDateFromParts, dateFieldOrder, monthNames } from '../../utils/date
 import { dbGetPhoto } from '../../data/db'
 import { getMilestoneVisibility } from '../../utils/visibility'
 import { isIntegrationEnabled } from '../../lib/intentsTransport.js'
+import { pickPhotoNative, pickMediaNative } from '../../native/mediaPicker'
 
 export default function AddMilestoneSheet({ onSave, onClose, existing, draft = null, categories = DEFAULT_CATEGORIES, chapters = [], visibilityPrecomputed = { endpointChapterNames: new Map() }, drilledChapter = null }) {
   const { t } = useTranslation('milestone')
@@ -171,6 +172,31 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
     setPhotoObjectUrl(null)
     setPhotoRemoved(true)
     if (photoRef.current) photoRef.current.value = ''
+  }
+
+  function handleMediaSelect(file) {
+    if (!file) return
+    setMediaFile(file)
+    setMediaRemoved(false)
+    setMediaObjectUrl(URL.createObjectURL(file))
+  }
+
+  // Attach buttons go native-first: on Android the photo button opens the
+  // permission-free system Photo Picker and the media button a SAF audio/video
+  // chooser (see src/native/mediaPicker.js). Everywhere else — web, iOS, an
+  // older APK without the plugin — the pick resolves null and the hidden
+  // <input type="file"> takes over, so nothing changes off Android. A native
+  // { cancelled } means the user closed the picker: do nothing, don't reopen.
+  async function openPhotoPicker() {
+    const picked = await pickPhotoNative()
+    if (picked === null) { photoRef.current?.click(); return }
+    if (picked.file) handlePhotoSelect(picked.file)
+  }
+
+  async function openMediaPicker() {
+    const picked = await pickMediaNative()
+    if (picked === null) { mediaRef.current?.click(); return }
+    if (picked.file) handleMediaSelect(picked.file)
   }
 
   async function handleSubmit(e) {
@@ -450,7 +476,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
             <div className="audio-attached-row">
               <span className="audio-attached-label">{t('photoAttached')}</span>
               <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
-                onClick={() => photoRef.current?.click()}>
+                onClick={openPhotoPicker}>
                 {tc('replace')}
               </button>
               <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
@@ -461,7 +487,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
           ) : (
             <button type="button" className="btn"
               style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem', alignSelf: 'flex-start' }}
-              onClick={() => photoRef.current?.click()}>
+              onClick={openPhotoPicker}>
               {t('attachPhoto')}
             </button>
           )}
@@ -496,7 +522,7 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
                 {existing.media_type === 'video' ? t('videoAttached') : t('audioAttached')}
               </span>
               <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
-                onClick={() => mediaRef.current?.click()}>
+                onClick={openMediaPicker}>
                 {tc('replace')}
               </button>
               <button type="button" className="btn-ghost" style={{ fontSize: '0.72rem' }}
@@ -507,20 +533,14 @@ export default function AddMilestoneSheet({ onSave, onClose, existing, draft = n
           ) : (
             <button type="button" className="btn"
               style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem', alignSelf: 'flex-start' }}
-              onClick={() => mediaRef.current?.click()}>
+              onClick={openMediaPicker}>
               {t('attachMedia')}
             </button>
           )}
           <input
             ref={mediaRef} type="file" accept="audio/*,video/*"
             style={{ display: 'none' }}
-            onChange={e => {
-              const file = e.target.files[0]
-              if (!file) return
-              setMediaFile(file)
-              setMediaRemoved(false)
-              setMediaObjectUrl(URL.createObjectURL(file))
-            }}
+            onChange={e => handleMediaSelect(e.target.files[0])}
           />
         </div>
 

--- a/src/native/mediaPicker.js
+++ b/src/native/mediaPicker.js
@@ -1,0 +1,39 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native media pickers (Android MediaPickerPlugin). pickPhoto uses the
+// permission-free Android Photo Picker; pickMedia uses a SAF open-document
+// dialog filtered to audio/video. Both return the picked bytes as a File, so
+// callers hand it to the exact code path a <input type="file"> selection takes —
+// the storage path doesn't know the difference.
+//
+// Return contract, chosen so the caller can distinguish "no native picker here"
+// from "user changed their mind":
+//   { file }            picked — pass to the existing file handler
+//   { cancelled: true } user dismissed the native picker — do nothing
+//   null                native path unavailable or failed — fall back to the
+//                       hidden <input>, so web/iOS/old-APK behaviour is unchanged
+const MediaPicker = registerPlugin('MediaPicker')
+
+async function pick(method) {
+  // isPluginAvailable is the old-APK guard: a shell built before the plugin
+  // existed answers false and the caller falls back to the file input.
+  if (!Capacitor.isNativePlatform() || !Capacitor.isPluginAvailable('MediaPicker')) return null
+  try {
+    const res = await MediaPicker[method]()
+    if (!res || res.cancelled) return { cancelled: true }
+    // convertFileSrc turns the app-cache path into a same-origin URL the
+    // WebView can fetch — bytes cross the bridge as a stream, not base64.
+    const url = Capacitor.convertFileSrc(res.path)
+    const blob = await fetch(url).then(r => {
+      if (!r.ok) throw new Error(`fetch of picked file returned ${r.status}`)
+      return r.blob()
+    })
+    return { file: new File([blob], res.name || 'attachment', { type: res.mimeType || blob.type || '' }) }
+  } catch (err) {
+    console.warn(`[mediaPicker] native ${method} failed; falling back to file input:`, err)
+    return null
+  }
+}
+
+export const pickPhotoNative = () => pick('pickPhoto')
+export const pickMediaNative = () => pick('pickMedia')


### PR DESCRIPTION
> **Stacked on #319.** Base is `claude/android-build-gate` so this branch's pushes run the new Android workflow, which is what compile-verifies the Kotlin here. GitHub retargets to `main` automatically when #319 merges.

## What

The roadmap's #1 slice — and its SAF companion, since they turn out to be one logical change (both halves of "replace the WebView file chooser with native pickers", one plugin, one JS touchpoint):

| Attach button | Picker | Why |
|---|---|---|
| Photo | Android Photo Picker (`PickVisualMedia`, image-only) | The marquee win: no `READ_MEDIA_IMAGES`, no permission prompt, system-process picker that grants access to only the chosen item |
| Media (audio/video) | SAF `ACTION_OPEN_DOCUMENT` filtered to `audio/*` + `video/*` | The Photo Picker is visual-only, and this field accepts either kind in one tap — one SAF dialog covering both is the only single-dialog answer. Also permission-free |

`PickVisualMedia` falls back internally to an image-filtered document chooser on devices without the backported picker, so minSdk 24 is unaffected.

## How it works

**Native** (`MediaPickerPlugin.kt`): fires the picker via Capacitor's `startActivityForResult`, then copies the item's bytes into `cache/picked_media/` immediately — the content-URI grant is temporary and scoped — off the main thread, since video can be large. Resolves `{ path, name, mimeType }`; a cancelled picker resolves `{ cancelled: true }` rather than rejecting, because changing your mind is not an error. The cache dir is cleared on each new pick so stale multi-hundred-MB videos don't accumulate.

**JS** (`src/native/mediaPicker.js`): fetches the file via `Capacitor.convertFileSrc()` — **streamed, not base64**, which is the ~33% inflation the roadmap note warns about for video — wraps the blob in a `File`, and hands it to the exact handlers a `<input type="file">` selection uses. **The storage path is untouched**; it just receives bytes from a nicer picker.

**Fallback contract**, so nothing changes off Android:

```
{ file }            picked → existing handler
{ cancelled: true } user dismissed → do nothing
null                web / iOS / older APK without the plugin / any failure
                    → the hidden <input> takes over, exactly as today
```

The old-APK case rides on `Capacitor.isPluginAvailable('MediaPicker')`, the same degrade pattern `VaultSsePlugin` documents.

The media input's inline `onChange` is extracted to `handleMediaSelect` so the native and input paths share one handler, mirroring the existing `handlePhotoSelect`.

`androidx.activity:activity-ktx` pinned at 1.9.3 — appcompat pulls `androidx.activity` transitively, but `PickVisualMedia` needs 1.6+.

## Verification

- Lint clean, no new warnings; 460 tests pass (nothing covers the picker path — no-regression signal only).
- Kotlin compile-verified by the Android gate this stacks on (checked in the run for this branch's push, not assumed).

**Not device-tested.** Worth checking:

1. Photo button opens the system Photo Picker with **no permission prompt**; picked image previews and saves as before.
2. Media button opens a document chooser showing audio and video; both kinds import.
3. A large video imports without freezing the UI (the copy is off-main-thread; the fetch is streamed).
4. Cancelling either picker does nothing — no fallback chooser reopens.
5. Web build unchanged: buttons still open the plain file inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_