### PR TITLE
iOS: index milestones into Core Spotlight

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0DA92D722FECC30800F56B1C /* WidgetBridgePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */; };
 		0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D752FECE9F200F56B1C /* MainViewController.swift */; };
 		0DB5E10D2FED010000F56B1C /* LifeGlanceShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0DC7A1112FED030000F56B1C /* SpotlightPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */; };
 		0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */; };
 		7B5F62012E3D110100D5E3A1 /* VaultSseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */; };
 		7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */; };
@@ -67,6 +68,7 @@
 		0DA92D712FECC30800F56B1C /* WidgetBridgePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBridgePlugin.swift; sourceTree = "<group>"; };
 		0DA92D752FECE9F200F56B1C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeGlanceShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightPlugin.swift; sourceTree = "<group>"; };
 		0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMilestoneIntent.swift; sourceTree = "<group>"; };
 		7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSseClient.swift; sourceTree = "<group>"; };
 		7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSsePlugin.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 		504EC3061FED79650016851F /* App */ = {
 			isa = PBXGroup;
 			children = (
+				0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */,
 				0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */,
 				0DA92D752FECE9F200F56B1C /* MainViewController.swift */,
 				7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */,
@@ -365,6 +368,7 @@
 				7B5F62012E3D110100D5E3A1 /* VaultSseClient.swift in Sources */,
 				7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */,
 				0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */,
+				0DC7A1112FED030000F56B1C /* SpotlightPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Capacitor
+import CoreSpotlight
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -65,6 +66,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        // A tapped Spotlight result (indexed by SpotlightPlugin) arrives as this
+        // activity type with the milestone id as its unique identifier. Stash it
+        // as pending_target — the exact contract a widget tap uses — and the web
+        // layer pans to and opens that milestone on resume. Literals rather than
+        // WidgetStore, keeping this file self-contained like the deep-link
+        // handler above.
+        if userActivity.activityType == CSSearchableItemActionType,
+           let id = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
+            UserDefaults(suiteName: "group.com.lifeglance")?.set(id, forKey: "pending_target")
+        }
         // Called when the app was launched with an activity, including Universal Links.
         // Feel free to add additional processing here, but if you want the App API to support
         // tracking app url opens, make sure to keep this call

--- a/ios/App/App/SpotlightPlugin.swift
+++ b/ios/App/App/SpotlightPlugin.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Capacitor
+import CoreSpotlight
+
+// Core Spotlight indexing for milestones: system search into a life timeline.
+//
+// The web layer pushes the full searchable set (src/native/spotlightBridge.js →
+// buildSpotlightIndex) on the same debounced flush that feeds the widget
+// snapshot. This is deliberately NOT the widget projection — that one is a
+// bounded summary, and Spotlight needs every milestone — and nothing extra is
+// written to the App Group: CSSearchableIndex itself is the store, and indexing
+// happens in the app process, so no extension is involved.
+//
+// Each push replaces the whole domain (delete by domainIdentifier, then insert).
+// Idempotent and simple; at a few hundred text-only items there is nothing to
+// gain from diffing. The JS side already skips pushes whose payload is unchanged.
+//
+// The index is on-device only (CSSearchableIndex does not sync), which is the
+// right default for a local-first app. Visibility filtering happens web-side:
+// milestones hidden from the main timeline are never in the payload.
+//
+// Tap-through: a result tap delivers CSSearchableItemActionType via
+// NSUserActivity — handled in AppDelegate, which stashes the item id as
+// pending_target, the exact contract a widget tap uses. The web layer then pans
+// to and opens that milestone with zero new JS.
+@objc(SpotlightPlugin)
+public class SpotlightPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "SpotlightPlugin"
+    public let jsName = "Spotlight"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setIndex", returnType: CAPPluginReturnPromise),
+    ]
+
+    static let domain = "com.lifeglance.milestones"
+
+    private struct IndexItem: Decodable {
+        let id: String
+        let title: String
+        let desc: String?
+    }
+
+    // Replaces the milestone search index with the given items.
+    // json: [{ id, title, desc? }] — desc is the line under the title in results.
+    @objc func setIndex(_ call: CAPPluginCall) {
+        guard let json = call.getString("json"),
+              let data = json.data(using: .utf8),
+              let items = try? JSONDecoder().decode([IndexItem].self, from: data) else {
+            call.reject("Missing or malformed 'json'")
+            return
+        }
+
+        let searchable = items.map { item -> CSSearchableItem in
+            let attrs = CSSearchableItemAttributeSet(contentType: .text)
+            attrs.title = item.title
+            attrs.contentDescription = item.desc
+            let searchableItem = CSSearchableItem(
+                uniqueIdentifier: item.id,
+                domainIdentifier: Self.domain,
+                attributeSet: attrs
+            )
+            // Items expire out of the index after ~a month by default. This
+            // index is fully replaced on every data change, but a device that
+            // simply doesn't open the app for a while must not have its history
+            // quietly fall out of search.
+            searchableItem.expirationDate = Date.distantFuture
+            return searchableItem
+        }
+
+        let index = CSSearchableIndex.default()
+        index.deleteSearchableItems(withDomainIdentifiers: [Self.domain]) { _ in
+            // Delete errors are ignored deliberately: first run has nothing to
+            // delete, and a failed delete followed by a successful insert still
+            // converges because uniqueIdentifiers overwrite.
+            index.indexSearchableItems(searchable) { error in
+                if let error {
+                    call.reject("Spotlight indexing failed: \(error.localizedDescription)")
+                } else {
+                    call.resolve()
+                }
+            }
+        }
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import { useVaultEventStream } from './hooks/useVaultEventStream'
 import { drainIntentsNow } from './hooks/useIntentPoller'
 import { buildWidgetSnapshot } from './utils/widgetSnapshot'
 import { pushWidgetSnapshot } from './native/widgetBridge'
+import { buildSpotlightIndex } from './utils/spotlightIndex'
+import { maybePushSpotlightIndex } from './native/spotlightBridge'
 import { useSubscription } from './billing/billing'
 import PaywallModal from './components/billing/PaywallModal'
 import ReviewerBanner from './components/billing/ReviewerBanner'
@@ -261,6 +263,12 @@ export default function App() {
       try { pins = JSON.parse(localStorage.getItem('lifeglance-pins') || '{}') } catch { /* ignore malformed pins */ }
       pushWidgetSnapshot(
         buildWidgetSnapshot(milestonesRef.current, chaptersRef.current, birthday, new Date(), pins)
+      )
+      // Same trigger discipline feeds Core Spotlight on iOS (no-op elsewhere).
+      // Factory form so the full index is only built where a plugin will take it;
+      // the bridge also skips the push when the payload hasn't changed.
+      maybePushSpotlightIndex(() =>
+        buildSpotlightIndex(milestonesRef.current, chaptersRef.current)
       )
     }
 

--- a/src/native/spotlightBridge.js
+++ b/src/native/spotlightBridge.js
@@ -1,0 +1,30 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Pushes the milestone search index to iOS Core Spotlight (SpotlightPlugin).
+// No-op everywhere else: Android never registers a 'Spotlight' plugin, so the
+// availability probe answers false there and on the web, and an older iOS shell
+// without the plugin degrades the same way.
+const Spotlight = registerPlugin('Spotlight')
+
+// The push is called from the same debounced flush as the widget snapshot, which
+// fires on every data change. Re-indexing is idempotent but not free (delete +
+// reinsert of every item), so skip when nothing changed since the last push.
+let lastPushed = null
+
+// Takes a FACTORY rather than the items so the (visibility-filtered, formatted)
+// payload is never built on platforms that would only throw it away.
+export async function maybePushSpotlightIndex(buildItems) {
+  if (!Capacitor.isNativePlatform() || !Capacitor.isPluginAvailable('Spotlight')) return false
+  try {
+    const json = JSON.stringify(buildItems())
+    if (json === lastPushed) return false
+    await Spotlight.setIndex({ json })
+    lastPushed = json
+    return true
+  } catch (err) {
+    // Never let search indexing disrupt the app; retry happens naturally on the
+    // next data change since lastPushed wasn't updated.
+    console.warn('[spotlight] index push failed:', err)
+    return false
+  }
+}

--- a/src/utils/spotlightIndex.js
+++ b/src/utils/spotlightIndex.js
@@ -1,0 +1,63 @@
+import { applyRecurFilter } from './timeline'
+import { precomputeEndpoints, getMilestoneVisibility } from './visibility'
+
+// Builds the Core Spotlight index payload: one compact entry per searchable
+// milestone, consumed by the iOS Spotlight plugin (src/native/spotlightBridge.js
+// → ios/App/App/SpotlightPlugin.swift).
+//
+// This is deliberately NOT the widget snapshot. That projection is a bounded,
+// widget-shaped summary (next/prev, pins, a ≤20-item strip); Spotlight needs
+// every searchable milestone, so it gets its own full feed rather than growing
+// the snapshot every widget also has to carry.
+//
+// Two rules are inherited from the snapshot builder, for the same reasons:
+//   - Only milestones visible on the main timeline are indexed. System search is
+//     the last place something the user hid should resurface.
+//   - Recurring series collapse to one instance (nearest upcoming, else most
+//     recent past), so a yearly birthday is one search result, not thirty
+//     identical rows.
+
+const MAX_NOTE = 160
+
+// Formats the date at the milestone's own precision, in the device locale —
+// "2019", "June 2019", or "June 12, 2019". Spotlight rows are static text, so
+// unlike widgets there is no relative-label staleness concern.
+function formatForPrecision(iso, precision, locale) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  if (precision === 'year') return String(d.getUTCFullYear())
+  const opts = precision === 'day'
+    ? { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }
+    : { year: 'numeric', month: 'long', timeZone: 'UTC' }
+  try {
+    return d.toLocaleDateString(locale, opts)
+  } catch {
+    return d.toISOString().slice(0, 10)
+  }
+}
+
+/**
+ * @returns {{ id: string, title: string, desc: string }[]} entries for
+ *   CSSearchableItem — `desc` becomes contentDescription (the line under the
+ *   title in search results): the date, plus a note excerpt when there is one.
+ */
+export function buildSpotlightIndex(milestones = [], chapters = [], locale = undefined) {
+  const precomputed = precomputeEndpoints(chapters)
+  const visible = milestones.filter(
+    m => getMilestoneVisibility(m, chapters, precomputed, 'main').visible
+  )
+  const collapsed = applyRecurFilter(visible, 'next')
+
+  return collapsed
+    .filter(m => m.id && m.title)
+    .map(m => {
+      const date = formatForPrecision(m.date, m.date_precision ?? 'day', locale)
+      let note = (m.note || '').replace(/\s+/g, ' ').trim()
+      if (note.length > MAX_NOTE) note = note.slice(0, MAX_NOTE).trim() + '…'
+      return {
+        id: m.id,
+        title: m.title,
+        desc: note ? `${date} · ${note}` : date,
+      }
+    })
+}

--- a/src/utils/spotlightIndex.test.js
+++ b/src/utils/spotlightIndex.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { buildSpotlightIndex } from './spotlightIndex'
+
+// Minimal milestone factory — only the fields the index builder reads.
+function ms(over = {}) {
+  return {
+    id:                     over.id ?? Math.random().toString(36).slice(2),
+    title:                  'untitled',
+    date:                   '2026-01-01T00:00:00Z',
+    date_precision:         'day',
+    category:               'personal',
+    note:                   '',
+    mainTimelineVisibility: 'inherit',
+    recurrence_id:          null,
+    ...over,
+  }
+}
+
+describe('buildSpotlightIndex', () => {
+  it('emits one { id, title, desc } entry per milestone', () => {
+    const items = buildSpotlightIndex([
+      ms({ id: 'a', title: 'Graduated', date: '2019-06-12T00:00:00Z' }),
+    ], [], 'en-US')
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('a')
+    expect(items[0].title).toBe('Graduated')
+    expect(items[0].desc).toBe('June 12, 2019')
+  })
+
+  it('formats the date at the milestone precision', () => {
+    const [year, month, day] = buildSpotlightIndex([
+      ms({ id: 'y', date: '2019-06-12T00:00:00Z', date_precision: 'year' }),
+      ms({ id: 'm', date: '2019-06-12T00:00:00Z', date_precision: 'month' }),
+      ms({ id: 'd', date: '2019-06-12T00:00:00Z', date_precision: 'day' }),
+    ], [], 'en-US')
+    expect(year.desc).toBe('2019')
+    expect(month.desc).toBe('June 2019')
+    expect(day.desc).toBe('June 12, 2019')
+  })
+
+  it('appends a whitespace-collapsed, truncated note excerpt', () => {
+    const [short, long] = buildSpotlightIndex([
+      ms({ id: 's', date_precision: 'year', date: '2020-01-01T00:00:00Z', note: 'a  quick\n note' }),
+      ms({ id: 'l', date_precision: 'year', date: '2020-01-01T00:00:00Z', note: 'x'.repeat(500) }),
+    ], [], 'en-US')
+    expect(short.desc).toBe('2020 · a quick note')
+    expect(long.desc.length).toBeLessThan(200)
+    expect(long.desc.endsWith('…')).toBe(true)
+  })
+
+  it('never indexes milestones hidden from the main timeline', () => {
+    const items = buildSpotlightIndex([
+      ms({ id: 'shown' }),
+      ms({ id: 'hidden', mainTimelineVisibility: 'hidden' }),
+    ], [])
+    expect(items.map(i => i.id)).toEqual(['shown'])
+  })
+
+  it('collapses a recurring series to a single entry', () => {
+    const items = buildSpotlightIndex([
+      ms({ id: 'r1', title: 'Birthday', recurrence_id: 'series', date: '2025-03-01T00:00:00Z' }),
+      ms({ id: 'r2', title: 'Birthday', recurrence_id: 'series', date: '2026-03-01T00:00:00Z' }),
+      ms({ id: 'r3', title: 'Birthday', recurrence_id: 'series', date: '2027-03-01T00:00:00Z' }),
+    ], [])
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('Birthday')
+  })
+
+  it('skips entries without an id or title rather than emitting junk', () => {
+    const items = buildSpotlightIndex([
+      ms({ id: 'ok', title: 'Fine' }),
+      ms({ id: '', title: 'No id' }),
+      ms({ id: 'no-title', title: '' }),
+    ], [])
+    expect(items.map(i => i.id)).toEqual(['ok'])
+  })
+})


### PR DESCRIPTION
## What

System search into a life timeline — the roadmap's "obvious first v1.1 addition". Type a milestone's name into iOS search and it appears with its date and a note excerpt; tapping it opens lifeGLANCE panned to that milestone.

## One roadmap correction, built in rather than argued

The roadmap called this "a read-only consumer of the projection". It is not: the widget snapshot is a bounded summary (next/prev, pins, a ≤20-item strip), and Spotlight needs **every** searchable milestone. So this adds its own feed (`buildSpotlightIndex`) instead of growing the snapshot every widget also has to carry — and nothing extra lands in the App Group, because `CSSearchableIndex` itself is the store and indexing runs in the app process. No extension involved.

The feed inherits the snapshot's two content rules, for the same reasons:

- **Milestones hidden from the main timeline are never indexed.** System search is the last place something the user hid should resurface.
- **Recurring series collapse to one entry**, so a yearly birthday is one search result, not thirty identical rows.

## How the pieces connect

```
data change / app background
  → existing debounced widget flush (App.jsx)          ← unchanged trigger discipline
      → maybePushSpotlightIndex(() => buildSpotlightIndex(…))
          → SpotlightPlugin.setIndex (delete domain, insert all)
tap on a result
  → CSSearchableItemActionType in AppDelegate
      → pending_target (App Group)                     ← the exact widget-tap contract
          → consumeLaunchTarget() → TimelineView pans + opens   (zero new JS)
```

Details that carry weight:

- **The bridge takes a factory and skips unchanged payloads** — the index is never even built on Android/web (plugin probe answers false), and identical pushes don't trigger a delete+reinsert cycle.
- **`expirationDate = .distantFuture` on every item.** By default `CSSearchableItem`s quietly expire out of the index after ~a month; a device that doesn't open the app for a while must not have its history fall out of search. This is the classic Core Spotlight gotcha and it is handled, not discovered later.
- **On-device only.** `CSSearchableIndex` does not sync — the right default for a local-first app.
- Tap-through follows the roadmap's own rule: extend the existing `pending_target` action contract, don't grow a parallel bridge.
- **Cold launch is safe by construction**, not by luck: `App.jsx` sets `setMilestones(all)` and `setScreen('timeline')` in the same then-block, so `TimelineView` cannot mount (and drain `pending_target`) before the milestone list exists. Verified in the boot sequence rather than assumed — an earlier draft of this PR hedged about a cold-launch drop that turns out to be impossible.

## A product default worth knowing about

Indexing is **on by default, with no settings toggle** — milestone titles become visible in system search (after unlock, on-device only). That matches how the roadmap frames the feature and keeps this PR free of settings UI + i18n scope. If an opt-out is wanted, it is a small follow-up: a toggle plus a `deleteAll` plugin method.

## Verification

- 466 tests pass, 6 new: precision formatting (`2019` / `June 2019` / `June 12, 2019`), note truncation, visibility filtering, series collapsing, junk-entry skipping. Lint clean, no new warnings.
- Swift + pbxproj wiring (four entries, modelled on `AddMilestoneIntent.swift`) validated structurally and compiled by CI.

**Needs a device:**

1. Add a milestone, background the app, search its title from the home screen → result with date + note line.
2. Tap the result → app opens panned to that milestone (warm and cold launch).
3. Hide a milestone → it disappears from search on the next data change/background.
4. A recurring series shows once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ