### PR TITLE
ios: register SpotlightPlugin — the index never had a bridge to cross

### DIFF
--- a/ios/App/App/MainViewController.swift
+++ b/ios/App/App/MainViewController.swift
@@ -1,9 +1,16 @@
 import UIKit
 import Capacitor
 
+// Registration here is the ONLY thing that makes an app-target plugin exist to
+// the web layer. A plugin missing from this list still compiles, still passes
+// CI, and Capacitor.isPluginAvailable() simply answers false — which JS bridges
+// treat as "feature not present" and silently no-op. That is how Spotlight
+// indexing shipped dead the first time: the class was written, compiled, and
+// never registered.
 class MainViewController: CAPBridgeViewController {
     override func capacitorDidLoad() {
         bridge?.registerPluginInstance(WidgetBridgePlugin())
         bridge?.registerPluginInstance(VaultSsePlugin())
+        bridge?.registerPluginInstance(SpotlightPlugin())
     }
 }

--- a/ios/App/App/WidgetBridgePlugin.swift
+++ b/ios/App/App/WidgetBridgePlugin.swift
@@ -6,8 +6,13 @@ import WidgetKit
 // The web app pushes a render-ready snapshot here; it is written to the App Group
 // container that the widget extension reads, and the widgets are reloaded.
 //
-// Capacitor auto-discovers plugins conforming to CAPBridgedPlugin; jsName must match
-// registerPlugin('WidgetBridge') in src/native/widgetBridge.js.
+// NOT auto-discovered: app-target plugins must be registered in
+// MainViewController.capacitorDidLoad(), or isPluginAvailable() answers false
+// and the JS side silently no-ops. jsName must match registerPlugin('WidgetBridge')
+// in src/native/widgetBridge.js. (An earlier comment here claimed Capacitor
+// auto-discovers CAPBridgedPlugin conformers; it does not for app-embedded
+// plugins, and that claim is exactly how SpotlightPlugin first shipped
+// unregistered and dead.)
 @objc(WidgetBridgePlugin)
 public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "WidgetBridgePlugin"


### PR DESCRIPTION
## The bug

Spotlight search (#321) shipped dead: no results on device. Every piece of the chain existed and compiled — the plugin class, the JS bridge, the feed, the tap-through — but **the plugin was never registered with the Capacitor bridge**. So:

```
Capacitor.isPluginAvailable('Spotlight')  → false
maybePushSpotlightIndex()                 → no-ops, by design
CSSearchableIndex                         → never receives a single item
```

No error anywhere, because the JS fallback treats "plugin absent" as "feature not present on this platform" — correct for Android and the web, silently wrong on iOS.

## Root cause, honestly

iOS app-target plugins in this project are registered **manually** in `MainViewController.capacitorDidLoad()` — that's how `WidgetBridgePlugin` and `VaultSsePlugin` work. I wrote `SpotlightPlugin` against a comment in `WidgetBridgePlugin.swift` claiming Capacitor "auto-discovers plugins conforming to CAPBridgedPlugin", which is not true for app-embedded plugins — and never opened `MainViewController.swift`, the one iOS file that mattered.

The platform asymmetry made it easy to miss: Android registers in `MainActivity.onCreate` (where `MediaPickerPlugin` **was** registered, which is why the pickers from the same overnight batch work), iOS in `MainViewController`. One of the two was done.

## The fix

Three lines of substance and two corrected comments:

- `bridge?.registerPluginInstance(SpotlightPlugin())` in `capacitorDidLoad()`
- The false "auto-discovers" claim in `WidgetBridgePlugin.swift` replaced with the truth and a pointer to `MainViewController` — that comment is the actual origin of this bug, so it's fixed at the source
- A note on `MainViewController` itself: registration is the *only* thing that makes an app-target plugin exist to the web layer, and omission is invisible to the compiler and to CI

## Why CI couldn't catch this

Registration absence is a runtime property: the class compiles, the app builds, `Metadata`-style build-log evidence doesn't exist for Capacitor plugins the way it does for App Intents. The only automated check that would catch it is a launched-app test asserting `isPluginAvailable`, which no CI here runs. Same failure family as dayGLANCE's unregistered `AppShortcutsProvider` — "compiles but was never wired in" — and the second time this session the gap between *compiles* and *registered* has bitten.

## Verify on device

Same steps as #321, which should now pass: add a milestone, background the app, search its title → result appears; tap it → app opens panned to that milestone. If it still shows nothing after this fix, the next suspect is the flush never firing before you search — backgrounding the app once after a data change forces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoHEnp7EQMN4X2NxzpffLJ)_