### PR TITLE
settings: language picker

### DIFF
--- a/src/components/settings/LanguagePicker.jsx
+++ b/src/components/settings/LanguagePicker.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { languages, resolveLanguage } from '../../locales'
+import { nativeLanguageName } from '../../utils/languageName'
+
+// Languages listed under their own names (see nativeLanguageName): someone who
+// cannot read the current UI language has to be able to recognise theirs.
+export default function LanguagePicker({ className, id }) {
+  const { i18n } = useTranslation()
+  // Same resolver the detector uses, so the option shown always matches the
+  // language actually rendering. A select whose value matches no option
+  // silently displays its first entry instead.
+  const value = resolveLanguage(i18n.resolvedLanguage || i18n.language)
+
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      className={className}
+    >
+      {languages.map((lng) => (
+        <option key={lng} value={lng}>
+          {nativeLanguageName(lng)}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -5,6 +5,7 @@ import { isMuted, setMuted } from '../../utils/audio'
 import { THEMES, getTheme, setTheme } from '../../utils/theme'
 import { dateFieldOrder, monthNames } from '../../utils/dates'
 import IntegrationSettings from '../dayglance/IntegrationSettings'
+import LanguagePicker from './LanguagePicker'
 
 const TEXT_SIZES_ALL = ['small', 'normal', 'big', 'bigger']
 const TEXT_SIZE_LABELS = {
@@ -225,6 +226,12 @@ export default function SettingsModal({
         {/* ── Display ───────────────────────────────────────────────────── */}
         <div className="settings-section">
           <div className="settings-label">{t('displayLabel')}</div>
+          <div className="settings-idle-timeout">
+            <span className="settings-toggle-label">
+              <label htmlFor="settings-language">{t('language')}</label>
+            </span>
+            <LanguagePicker id="settings-language" className="settings-select" />
+          </div>
           <div className="settings-idle-timeout">
             <span className="settings-toggle-label">{t('themeLabel')}</span>
             <div className="zoom-tabs">

--- a/src/index.css
+++ b/src/index.css
@@ -1877,7 +1877,8 @@ button, input, select, textarea {
   gap: 0.4rem;
   flex-wrap: wrap;
 }
-.settings-birthday-input {
+.settings-birthday-input,
+.settings-select {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: 3px;
@@ -1887,7 +1888,8 @@ button, input, select, textarea {
   padding: 0.3rem 0.5rem;
   color-scheme: dark;
 }
-select.settings-birthday-input {
+select.settings-birthday-input,
+select.settings-select {
   cursor: pointer;
 }
 

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "Textgröße",
   "textSizeUnavailable": "Textgrößeneinstellung auf kleinen Bildschirmen nicht verfügbar",
   "displayLabel": "Anzeige",
+  "language": "Sprache",
   "themeLabel": "Design",
   "theme_dark": "Dunkel",
   "theme_light": "Hell",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "text size",
   "textSizeUnavailable": "text size adjustment unavailable on short screens",
   "displayLabel": "display",
+  "language": "Language",
   "themeLabel": "Theme",
   "theme_dark": "Dark",
   "theme_light": "Light",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "tamaño del texto",
   "textSizeUnavailable": "ajuste de tamaño de texto no disponible en pantallas pequeñas",
   "displayLabel": "pantalla",
+  "language": "Idioma",
   "themeLabel": "Tema",
   "theme_dark": "Oscuro",
   "theme_light": "Claro",

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "taille du texte",
   "textSizeUnavailable": "réglage de la taille du texte indisponible sur les écrans courts",
   "displayLabel": "affichage",
+  "language": "Langue",
   "themeLabel": "Thème",
   "theme_dark": "Sombre",
   "theme_light": "Clair",

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "dimensione testo",
   "textSizeUnavailable": "impostazione dimensione testo non disponibile su schermi piccoli",
   "displayLabel": "schermo",
+  "language": "Lingua",
   "themeLabel": "Tema",
   "theme_dark": "Scuro",
   "theme_light": "Chiaro",

--- a/src/locales/pt/settings.json
+++ b/src/locales/pt/settings.json
@@ -3,6 +3,7 @@
   "textSizeLabel": "tamanho do texto",
   "textSizeUnavailable": "configuração de tamanho de texto indisponível em telas pequenas",
   "displayLabel": "tela",
+  "language": "Idioma",
   "themeLabel": "Tema",
   "theme_dark": "Escuro",
   "theme_light": "Claro",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -7,6 +7,7 @@
   "textSizeBigger": "特大",
   "textSizeUnavailable": "此设定不适用于小屏幕",
   "displayLabel": "显示",
+  "language": "语言",
   "themeLabel": "外观",
   "theme_dark": "深色模式",
   "theme_light": "浅色模式",

--- a/src/locales/zh-HK/settings.json
+++ b/src/locales/zh-HK/settings.json
@@ -7,6 +7,7 @@
   "textSizeBigger": "特大",
   "textSizeUnavailable": "此設定不適用於小屏幕",
   "displayLabel": "顯示",
+  "language": "語言",
   "themeLabel": "外觀",
   "theme_dark": "深色模式",
   "theme_light": "淺色模式",

--- a/src/utils/languageName.js
+++ b/src/utils/languageName.js
@@ -1,0 +1,28 @@
+/**
+ * The language's own name for itself, derived from the tag rather than a table
+ * that would have to be kept in step with the locale directory.
+ *
+ * Intl returns these lowercase in several languages ("français", "português"),
+ * which is right mid-sentence but reads as a typo in a standalone list, so the
+ * first letter is uppercased in the language's own casing rules.
+ *
+ * 'standard' composes regional variants as "language (Region)" — the default
+ * 'dialect' mode picks ICU-version-dependent dialect names ("português
+ * europeu") that break the parenthetical pattern. 'short' keeps every name the
+ * same except the region: zh-HK's official long form 中文（中國香港特別行政區）
+ * becomes 中文（香港）.
+ */
+export function nativeLanguageName(tag) {
+  try {
+    const name = new Intl.DisplayNames([tag], {
+      type: 'language',
+      languageDisplay: 'standard',
+      style: 'short',
+    }).of(tag)
+    // Intl echoes the input back when it has no name for the tag.
+    if (!name || name === tag) return tag
+    return name.charAt(0).toLocaleUpperCase(tag) + name.slice(1)
+  } catch {
+    return tag
+  }
+}

--- a/src/utils/languageName.test.js
+++ b/src/utils/languageName.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { nativeLanguageName } from './languageName.js'
+import { languages } from '../locales.js'
+
+describe('nativeLanguageName', () => {
+  // The point of the picker: someone who cannot read the current UI language
+  // has to recognise their own. Each name is therefore in its own language,
+  // not the active one — and uppercased in its own casing rules, since Intl
+  // returns several of these lowercase ("français", "português").
+  it.each([
+    ['de', 'Deutsch'],
+    ['en', 'English'],
+    ['es', 'Español'],
+    ['fr', 'Français'],
+    ['it', 'Italiano'],
+    ['pt', 'Português'],
+    ['zh-CN', '中文（中国）'],
+    // The 'short' style: the default region name for zh-HK is the official
+    // 中國香港特別行政區, far too long for a select option.
+    ['zh-HK', '中文（香港）'],
+  ])('names %s in its own language', (tag, expected) => {
+    expect(nativeLanguageName(tag)).toBe(expected)
+  })
+
+  it('covers every shipped language', () => {
+    for (const lng of languages) {
+      const name = nativeLanguageName(lng)
+      expect(name, `${lng} has no display name`).toBeTypeOf('string')
+      expect(name, `${lng} fell back to the raw tag`).not.toBe(lng)
+    }
+  })
+
+  // Both Chinese locales (and later both Portuguese ones) must stay
+  // distinguishable — a regression to base-language names would render two
+  // identical options.
+  it('gives every shipped language a distinct name', () => {
+    const names = languages.map(nativeLanguageName)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('falls back to the tag rather than throwing on an unknown one', () => {
+    expect(nativeLanguageName('zz')).toBe('zz')
+    expect(nativeLanguageName(undefined)).toBe(undefined)
+  })
+})


### PR DESCRIPTION
Ports dayGLANCE's LanguagePicker (dayGLANCE#1396). **PR 2 of 4**, stacked on #323 — the diff shown here is only the picker; merge #323 first and this retargets to `main`.

There was previously no way to override the detected language. This adds a select to the settings **Display** section, one shared component.

## Design (per dayGLANCE#1396)

- **Native names, no table**: options come from `Intl.DisplayNames` keyed on the locale tag, so a new locale directory appears in the picker with zero wiring — the same derive-from-disk principle as `src/locales.js`. Someone who can't read the current UI language can still recognise their own.
- **Casing**: Intl returns several names lowercase ("français", "português") — right mid-sentence, a typo in a standalone list — so the first letter is uppercased with `toLocaleUpperCase(tag)`, i.e. in that language's own casing rules.
- **`languageDisplay: 'standard'`** keeps regional variants in the "language (Region)" shape rather than ICU-version-dependent dialect names ("português europeu"), which matters once the pt split lands in PR 4.
- **One deviation from the dayGLANCE component — `style: 'short'`**: dayGLANCE ships only Latin-script locales; here the default region name for zh-HK is the official 中國香港特別行政區, absurdly long for a select option. `'short'` renders 中文（香港） and changes no other language's name (verified: de/en/es/fr/it/pt identical in both styles).
- **Value goes through `resolveLanguage()`** — the exact function the detector uses (introduced in #323) — so the option shown always matches the language actually rendering. A `<select>` whose value matches no option silently displays its first entry; without the resolver, a user carrying the aliased `zh-TW` tag would see the picker claim one language while another rendered.
- **Persistence** rides i18next's existing localStorage cache; no new storage.
- `nativeLanguageName` lives in `src/utils/languageName.js` (not in the component file) so `react-refresh/only-export-components` stays quiet — the one lint difference from dayGLANCE's layout.
- New `settings:language` label key translated in all eight locales (Sprache / Idioma / Langue / Lingua / Idioma / 语言 / 語言).

## Verification

- `npm test`: 630 passing (619 from PR 1 + 11 new for `nativeLanguageName`, including a distinct-names assertion so two locales can never render identical options)
- `npm run lint`: 0 errors, same 27 pre-existing warnings as `main`
- `npm run build`: clean, chunk layout unchanged from #323
- Headless Chromium against `vite preview`: all eight options render their native names; value starts at `en`; selecting 中文（中国） repaints the open modal live (title → 设置), updates localStorage, and survives reload; a stored `zh-TW` displays as 中文（香港）, matching what actually renders; the row label itself translates (語言).

## Translation quality

No native-speaker review is available. The only new human-language content is the eight one-word "Language" labels, which are dictionary-stable; the language names themselves come from ICU, not from us.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL64JjTmHux5YYskWzJuHd)_