### PR TITLE
onboarding: language picker in the corner, beside theme and skip

### DIFF
--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -6,6 +6,7 @@ import Step3Future    from './Step3Future'
 import Step4Reveal    from './Step4Reveal'
 import TimelinePreview from './TimelinePreview'
 import ThemeToggle    from '../ui/ThemeToggle'
+import LanguagePicker from '../settings/LanguagePicker'
 import { addMilestone } from '../../data/milestones'
 import { init as audioInit, startAmbient, stopAmbient } from '../../utils/audio'
 
@@ -20,8 +21,22 @@ function SkipIcon() {
   )
 }
 
+// Globe, same line-icon style. Sits beside the language select, which is
+// dressed as another corner link (see .onboarding-language-select).
+function GlobeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M2 12h20" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  )
+}
+
 export default function Onboarding({ onComplete }) {
   const { t: tc } = useTranslation('common')
+  const { t: ts } = useTranslation('settings')
   const [step, setStep]               = useState(1)
   const [pastMilestone, setPast]      = useState(null)
   const [futureMilestone, setFuture]  = useState(null)
@@ -61,9 +76,14 @@ export default function Onboarding({ onComplete }) {
       {/* Timeline preview strip appears from step 2 onwards */}
       {step >= 2 && <TimelinePreview milestones={previewMilestones} />}
 
-      {/* Theme toggle + skip, fixed in the corner while there's still a step to skip */}
+      {/* Language + theme toggle + skip, fixed in the corner while there's still a step to skip */}
       {step <= 3 && (
         <div className="onboarding-corner">
+          <span className="onboarding-link onboarding-language">
+            <GlobeIcon />
+            <LanguagePicker className="onboarding-language-select" aria-label={ts('language')} />
+          </span>
+          <span className="onboarding-sep" aria-hidden="true" />
           <ThemeToggle />
           <span className="onboarding-sep" aria-hidden="true" />
           <button className="onboarding-link" onClick={finish}>

--- a/src/components/settings/LanguagePicker.jsx
+++ b/src/components/settings/LanguagePicker.jsx
@@ -5,7 +5,7 @@ import { nativeLanguageName } from '../../utils/languageName'
 
 // Languages listed under their own names (see nativeLanguageName): someone who
 // cannot read the current UI language has to be able to recognise theirs.
-export default function LanguagePicker({ className, id }) {
+export default function LanguagePicker({ className, id, 'aria-label': ariaLabel }) {
   const { i18n } = useTranslation()
   // Same resolver the detector uses, so the option shown always matches the
   // language actually rendering. A select whose value matches no option
@@ -15,6 +15,7 @@ export default function LanguagePicker({ className, id }) {
   return (
     <select
       id={id}
+      aria-label={ariaLabel}
       value={value}
       onChange={(e) => i18n.changeLanguage(e.target.value)}
       className={className}

--- a/src/index.css
+++ b/src/index.css
@@ -455,6 +455,22 @@ button, input, select, textarea {
   width: 0.95rem;
   height: 0.95rem;
 }
+/* the language select, dressed as another corner link: the wrapper span
+   carries the icon + .onboarding-link styling (color, font, lowercase,
+   hover); the select inherits all of it and sheds its native chrome */
+.onboarding-language-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+  color-scheme: dark;
+}
 
 /* ─── Timeline Preview Strip (onboarding) ──────────────────────────────────── */
 .timeline-preview {


### PR DESCRIPTION
Adds the language picker to the onboarding corner, next to **theme** and **skip**, in the same style. (Branch restarted from `main` at `de9a4fe` — the previous history on this name is fully merged.)

## Why here

The picker previously lived only in settings — which a first-run user landing in the wrong detected language can't read their way to. The onboarding corner is exactly where they are at that moment.

## How it matches the corner style

- The corner controls are lowercase monospace icon+text links (`.onboarding-link`). The picker is a **globe line-icon** (same stroke/linecap style as the theme and skip icons) beside the **shared `LanguagePicker`** select, wrapped in an `.onboarding-link` span; a new `.onboarding-language-select` rule strips the select's native chrome and inherits everything — font, muted color, lowercase transform, hover — from the wrapper. Rendered result: `🌐 english │ ☀ theme │ » skip`, with a separator identical to the existing one.
- Order is language │ theme │ skip; the whole row keeps the existing `step <= 3` visibility.
- One shared component, unchanged behavior: same resolver-backed value, same nine native-name options, same localStorage persistence — so the corner and settings pickers can never disagree.
- `LanguagePicker` gains an `aria-label` passthrough (the corner select has no visible label); onboarding passes the existing `settings:language` string, so the accessible name is translated and re-translates when the language changes. No new translation keys.

## Verification

- `npm test`: 796 passing; lint 0 errors (same 27 pre-existing warnings); build clean.
- Headless Chromium against `vite preview`: picker renders in the corner in the right order with matching separators and inherited lowercase styling; lists all nine languages; switching to pt-PT repaints the onboarding live (`começar`/`saltar`) and survives reload; the `aria-label` re-translates (Language → Idioma); the theme toggle and skip button still work afterwards. Screenshot attached in session.

No translation-quality caveat this time — no new human-language strings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL64JjTmHux5YYskWzJuHd)_