### PR TITLE
onboarding: shrink-wrap the language picker to the current name

### DIFF
--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -21,8 +21,8 @@ function SkipIcon() {
   )
 }
 
-// Globe, same line-icon style. Sits beside the language select, which is
-// dressed as another corner link (see .onboarding-language-select).
+// Globe, same line-icon style. Sits beside the language picker's inline
+// variant, which shrink-wraps to the current language's name.
 function GlobeIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
@@ -81,7 +81,7 @@ export default function Onboarding({ onComplete }) {
         <div className="onboarding-corner">
           <span className="onboarding-link onboarding-language">
             <GlobeIcon />
-            <LanguagePicker className="onboarding-language-select" aria-label={ts('language')} />
+            <LanguagePicker inline aria-label={ts('language')} />
           </span>
           <span className="onboarding-sep" aria-hidden="true" />
           <ThemeToggle />

--- a/src/components/settings/LanguagePicker.jsx
+++ b/src/components/settings/LanguagePicker.jsx
@@ -5,14 +5,22 @@ import { nativeLanguageName } from '../../utils/languageName'
 
 // Languages listed under their own names (see nativeLanguageName): someone who
 // cannot read the current UI language has to be able to recognise theirs.
-export default function LanguagePicker({ className, id, 'aria-label': ariaLabel }) {
+//
+// `inline` shrink-wraps the control to the current name. A select's intrinsic
+// width is that of its WIDEST option ("Português (Portugal)"), which strands
+// half a line of empty space after a short name like "english" when the
+// control sits inline with other text. The inline variant renders the name as
+// a plain span and stacks the real select on top at opacity 0, so the native
+// dropdown still opens from the same spot and keyboard/AT behaviour is the
+// select's own.
+export default function LanguagePicker({ className, id, 'aria-label': ariaLabel, inline = false }) {
   const { i18n } = useTranslation()
   // Same resolver the detector uses, so the option shown always matches the
   // language actually rendering. A select whose value matches no option
   // silently displays its first entry instead.
   const value = resolveLanguage(i18n.resolvedLanguage || i18n.language)
 
-  return (
+  const select = (
     <select
       id={id}
       aria-label={ariaLabel}
@@ -26,5 +34,14 @@ export default function LanguagePicker({ className, id, 'aria-label': ariaLabel 
         </option>
       ))}
     </select>
+  )
+
+  if (!inline) return select
+
+  return (
+    <span className="language-picker-inline">
+      <span aria-hidden="true">{nativeLanguageName(value)}</span>
+      {select}
+    </span>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -457,20 +457,26 @@ button, input, select, textarea {
 }
 /* the language select, dressed as another corner link: the wrapper span
    carries the icon + .onboarding-link styling (color, font, lowercase,
-   hover); the select inherits all of it and sheds its native chrome */
-.onboarding-language-select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: none;
+   hover). LanguagePicker's inline variant shows the current name as plain
+   text (so the control is exactly as wide as the name, not as wide as the
+   longest option) and stacks the real select on top, invisible but live. */
+.language-picker-inline {
+  position: relative;
+  display: inline-flex;
+}
+.language-picker-inline > select {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
   border: none;
   padding: 0;
-  color: inherit;
   font: inherit;
-  letter-spacing: inherit;
-  text-transform: inherit;
   cursor: pointer;
   color-scheme: dark;
 }
+.onboarding-language:focus-within { color: var(--text-dim); }
 
 /* ─── Timeline Preview Strip (onboarding) ──────────────────────────────────── */
 .timeline-preview {


### PR DESCRIPTION
Fixes the spacing bug in #329's onboarding corner: "english" sat at the left of half a line of dead space before the separator.

## Root cause

A `<select>`'s intrinsic width is that of its **widest option** — here "Português (Portugal)" — not the selected one. Stripping the native chrome hid the arrow but kept that width, so short names stranded empty space.

## Fix

`LanguagePicker` gains an **`inline` variant**: the current language's name renders as a plain span (exactly as wide as its text), and the real select is stacked on top at `opacity: 0` — the native dropdown still opens from the same spot, keyboard and assistive-tech behaviour stays the select's own (same `aria-label`), and focus is made visible via `:focus-within` on the wrapper. The settings picker is untouched (`inline` defaults off), and the name/value still come from the same resolver, so nothing can drift.

Corner now renders `🌐 english │ ☀ theme │ » skip` with even spacing (screenshots in session, both the en and pt-PT states).

## Verification

- Headless Chromium: the control's bounding width now **equals the visible label's width to the pixel** (51.6 px vs 51.6 px; previously the widest-option width), plus all 12 prior corner checks still pass — order, lowercase inheritance, nine options, live repaint to pt-PT, aria-label re-translation, persistence across reload, and the theme toggle / skip neighbours unaffected.
- `npm test`: 796 passing; lint 0 errors (same 27 pre-existing warnings); build clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL64JjTmHux5YYskWzJuHd)_