### PR TITLE
Secure credential storage: Keystore/Keychain SecureStore on both platforms

### DIFF
--- a/android/app/src/main/java/com/lifeglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lifeglance/app/MainActivity.java
@@ -29,6 +29,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(WebDavHttpPlugin.class);
         registerPlugin(VaultSsePlugin.class);
         registerPlugin(MediaPickerPlugin.class);
+        registerPlugin(SecureStorePlugin.class);
         super.onCreate(savedInstanceState);
         handleWidgetIntent(getIntent());
         handleShareIntent(getIntent());

--- a/android/app/src/main/java/com/lifeglance/app/SecureStorePlugin.java
+++ b/android/app/src/main/java/com/lifeglance/app/SecureStorePlugin.java
@@ -1,0 +1,177 @@
+package com.lifeglance.app;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+// Keystore-backed secret storage for sync/vault/intents credentials. Values
+// are AES-GCM ciphertext in a private SharedPreferences file; the AES key
+// lives in the Android Keystore (non-exportable, hardware-backed where the
+// device supports it), so the ciphertext is useless off-device. That failure
+// mode is deliberate: prefs restored or transferred to another device won't
+// decrypt, get() reports the entry as absent, and the app asks the user to
+// re-enter credentials rather than failing cryptically.
+//
+// Ported from lastGLANCE's SecureStorePlugin.java (issue #210 there); keep
+// the two in sync when fixing bugs in either.
+//
+// Registered in MainActivity; consumed by src/native/secureStore.js, which
+// leaves callers on their existing storage where the plugin is absent.
+@CapacitorPlugin(name = "SecureStore")
+public class SecureStorePlugin extends Plugin {
+
+    private static final String PREFS = "lifeglance_secure_store";
+    private static final String KEY_ALIAS = "lifeglance_secure_store";
+    private static final String ANDROID_KEYSTORE = "AndroidKeyStore";
+    // GCM with the Keystore-generated IV, 128-bit tag. Stored value format is
+    // "v1:" + base64(iv) + ":" + base64(ciphertext).
+    private static final int GCM_TAG_BITS = 128;
+    private static final String FORMAT_PREFIX = "v1:";
+
+    @PluginMethod
+    public void get(PluginCall call) {
+        String key = call.getString("key");
+        if (key == null || key.isEmpty()) {
+            call.reject("missing key");
+            return;
+        }
+        String stored = prefs().getString(key, null);
+        JSObject ret = new JSObject();
+        if (stored == null) {
+            ret.put("value", (String) null);
+            call.resolve(ret);
+            return;
+        }
+        String plain = decrypt(stored);
+        if (plain == null) {
+            // Undecryptable (restored ciphertext, invalidated key). The Keystore
+            // key is non-exportable, so this can never recover — drop the entry
+            // so the caller sees a clean "absent" and a later set() starts fresh.
+            prefs().edit().remove(key).apply();
+        }
+        ret.put("value", plain);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void set(PluginCall call) {
+        String key = call.getString("key");
+        String value = call.getString("value");
+        if (key == null || key.isEmpty() || value == null) {
+            call.reject("missing key or value");
+            return;
+        }
+        String stored = encrypt(value);
+        if (stored == null) {
+            // One retry with a fresh key covers the rare corrupted-alias state
+            // (e.g. a partially restored Keystore). Existing entries were already
+            // undecryptable in that state, so rotating the key loses nothing.
+            deleteKeyQuietly();
+            stored = encrypt(value);
+        }
+        if (stored == null) {
+            call.reject("encrypt failed");
+            return;
+        }
+        prefs().edit().putString(key, stored).apply();
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void delete(PluginCall call) {
+        String key = call.getString("key");
+        if (key == null || key.isEmpty()) {
+            call.reject("missing key");
+            return;
+        }
+        prefs().edit().remove(key).apply();
+        call.resolve();
+    }
+
+    private SharedPreferences prefs() {
+        return getContext().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    // ── Keystore-backed AES-GCM ───────────────────────────────────────────────
+
+    private String encrypt(String plaintext) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            // The Keystore must generate the IV: keys are created with
+            // randomized encryption required (the secure default), and passing
+            // a caller-provided IV at encrypt time throws
+            // InvalidAlgorithmParameterException ("Caller-provided IV not
+            // permitted") — which made every set() fail and presented as wiped
+            // sync settings in lastGLANCE's 2.1.0 release candidate.
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey());
+            byte[] iv = cipher.getIV();
+            byte[] ct = cipher.doFinal(plaintext.getBytes("UTF-8"));
+            return FORMAT_PREFIX
+                + Base64.encodeToString(iv, Base64.NO_WRAP)
+                + ":"
+                + Base64.encodeToString(ct, Base64.NO_WRAP);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String decrypt(String stored) {
+        try {
+            if (!stored.startsWith(FORMAT_PREFIX)) return null;
+            String[] parts = stored.substring(FORMAT_PREFIX.length()).split(":", 2);
+            if (parts.length != 2) return null;
+            byte[] iv = Base64.decode(parts[0], Base64.NO_WRAP);
+            byte[] ct = Base64.decode(parts[1], Base64.NO_WRAP);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            return new String(cipher.doFinal(ct), "UTF-8");
+        } catch (Exception e) {
+            // Bad tag / invalidated or missing key / malformed entry — all map to
+            // "absent" (see get()).
+            return null;
+        }
+    }
+
+    private SecretKey getOrCreateKey() throws Exception {
+        KeyStore ks = KeyStore.getInstance(ANDROID_KEYSTORE);
+        ks.load(null);
+        KeyStore.Entry entry = ks.getEntry(KEY_ALIAS, null);
+        if (entry instanceof KeyStore.SecretKeyEntry) {
+            return ((KeyStore.SecretKeyEntry) entry).getSecretKey();
+        }
+        KeyGenerator kg = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE);
+        kg.init(new KeyGenParameterSpec.Builder(KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            // No user-auth binding: these credentials are read at boot for
+            // background-capable sync, before any biometric prompt could show.
+            .build());
+        return kg.generateKey();
+    }
+
+    private void deleteKeyQuietly() {
+        try {
+            KeyStore ks = KeyStore.getInstance(ANDROID_KEYSTORE);
+            ks.load(null);
+            ks.deleteEntry(KEY_ALIAS);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/docs/secure-store-device-verification.md
+++ b/docs/secure-store-device-verification.md
@@ -1,0 +1,143 @@
+# SecureStore device verification
+
+Manual pass for the secure credential storage work (Keystore-backed on
+Android, Keychain-backed on iOS). Run it on real hardware before the
+TestFlight submission — none of this is CI-checkable, because the crypto under
+test lives in the OS. The unit suite already covers the migration *logic*
+(`src/sync/secureConfigShim.test.js`, `src/sync/nativeKeyHooks.test.js`) and
+the web/PWA no-op path; this script covers everything else.
+
+## Background needed to follow this script
+
+Three secrets are in scope, and where they live after this change:
+
+| Secret | Before | After (native shells) |
+|---|---|---|
+| WebDAV app password | `localStorage` `lifeglance-cloud-sync-config` (+ a copy in `lifeglance-intents-config`) | SecureStore, same key names |
+| GLANCEvault device token | `localStorage` `lifeglance-cloud-sync-config` (`vaultToken` field) | SecureStore, same key name |
+| Sync encryption keys (file-tier sync key + DB root key) | IndexedDB `lifeglance-crypto` / `lifeglance-crypto-db` | SecureStore, entries `crypto.sync-key` / `crypto.db-root-key` |
+
+"SecureStore" is the app-local plugin: on Android, AES-GCM ciphertext in the
+private prefs file `lifeglance_secure_store` with the key in the Android
+Keystore; on iOS, Keychain items under service `lifeglance_secure_store` with
+`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
+
+Deliberately NOT migrated (known residual): the intents/blob root keys in
+IndexedDB `lifeglance-intents-crypto`. They are non-extractable `CryptoKey`s
+that JS cannot export; do not report their presence in IndexedDB as a failure.
+
+**Inspecting WebView storage.** With the device connected and the app
+debuggable, open `chrome://inspect` (Android WebView) or Safari →
+Develop → <device> (iOS WKWebView), attach to the app, and in the console run:
+
+```js
+localStorage.getItem('lifeglance-cloud-sync-config')
+localStorage.getItem('lifeglance-intents-config')
+localStorage.getItem('lifeglance-db-sync-config')
+indexedDB.databases().then(dbs => console.log(dbs.map(d => d.name)))
+```
+
+For the IndexedDB checks, `lifeglance-crypto` / `lifeglance-crypto-db` may
+still *exist* as empty databases; what must be absent is the key records —
+verify via the Application/Storage tab of the inspector, stores `keys`
+(record `sync-key`) and `db-root-keys` (record `db-root-key`).
+
+> Release builds may not be inspectable. Run storage checks on a debug build
+> of the same commit; run the reboot/backup scenarios on whichever build you
+> intend to ship.
+
+## 1. Fresh install — both platforms
+
+Do once on Android, once on iOS.
+
+1. Uninstall any existing build (Android: also verify no restored prefs —
+   uninstall, reboot, reinstall).
+2. Install this build, complete onboarding.
+3. Configure WebDAV sync with a real server + app password, enable encryption
+   with a passphrase. Configure GLANCEvault with URL, device token, account
+   id, passphrase. Let a sync complete.
+4. Inspect WebView storage (console commands above). **Pass:** all three
+   `localStorage` reads through the *inspector on the running app* return the
+   config JSON (they're served from the shim's cache), BUT after force-killing
+   the app and re-inspecting before it repopulates — or more simply, on
+   Android, pulling the app's data dir (`run-as com.lifeglance.app` on a
+   debug build) — the real `localStorage` backing store contains none of the
+   three keys, and the `sync-key` / `db-root-key` IndexedDB records are
+   absent.
+5. Android only: confirm `shared_prefs/lifeglance_secure_store.xml` exists
+   and every value starts with `v1:` (ciphertext, not plaintext).
+6. Kill and relaunch the app. **Pass:** sync still works, no passphrase
+   re-prompt, no re-entry of credentials.
+
+## 2. Upgrade migration — Android only (real user base)
+
+1. Install the **previous release** (v3.2.0 / current Play build). Configure
+   WebDAV + vault + passphrase as above; let a sync complete. Verify via
+   inspector that credentials are in plaintext `localStorage` (pre-change
+   state).
+2. Install this build **over it** (`adb install -r`, or Play internal track
+   update).
+3. Launch once, let it settle, then inspect. **Pass:**
+   - the three `localStorage` keys are gone from the real backing store;
+   - `lifeglance_secure_store.xml` holds `v1:` ciphertext entries for them;
+   - the `sync-key` and `db-root-key` IndexedDB records are gone (note: the
+     IndexedDB half migrates lazily on first key *use* — trigger a sync and,
+     if encryption was configured, an encrypted upload before checking);
+   - **the user was never prompted** to re-enter the password, token, or
+     passphrase, and sync completes normally.
+4. Kill/relaunch again. **Pass:** still no prompts.
+
+## 3. Failed migration leaves originals intact — Android
+
+Simulating a Keystore failure on stock hardware is impractical; this scenario
+is covered by unit tests with a rejecting/lying fake plugin
+(`secureConfigShim.test.js`: "failing native layer" and "read-back verify"
+cases). On device, do the cheap proxy check instead:
+
+1. On the upgraded install from §2, airplane-mode the device, force-kill and
+   relaunch several times in a row. **Pass:** credentials survive every
+   relaunch (the migration is idempotent and never in a state where both
+   copies are gone).
+
+## 4. Web / PWA unchanged
+
+Covered in CI: the full suite passes unmodified, and the shim/hooks are
+no-ops where the plugin is absent. On a browser, sanity-check that sync still
+configures and syncs; credentials remain in `localStorage` there by design.
+
+## 5. Backup-restore to different hardware — iOS, two devices
+
+Intended consequence of `ThisDeviceOnly`: credentials must NOT travel.
+
+1. On iPhone A (configured as in §1), take an iCloud or encrypted local
+   backup.
+2. Restore that backup onto iPhone B. Launch lifeGLANCE.
+3. **Pass:** the app treats sync as not configured (Keychain items were not
+   restored; the shim reads absent). The user is asked to set up credentials
+   afresh — re-entering server, password/token, and passphrase. No crash, no
+   cryptic sync error loop.
+4. Note for support scripts: because both tiers share one config object, the
+   *whole* sync setup (server URL, folder, account id) is re-entered on the
+   new device, not just the secrets. This is expected.
+
+## 6. Reboot, then background sync before first unlock — iOS
+
+Validates AfterFirstUnlock over WhenUnlocked: sync and the vault SSE reader
+may run while the device is locked-but-booted.
+
+1. On a configured iPhone, enable vault sync with SSE working (make a change
+   from another device and see it arrive).
+2. Reboot the iPhone. **Unlock it once** (AfterFirstUnlock requires one
+   unlock per boot), then lock it and leave it locked.
+3. From another device, make a synced change; if background refresh is
+   granted, wait for a background wake (or trigger one via Xcode's simulate
+   background fetch on a dev build).
+4. **Pass:** the locked-but-unlocked-once device processes the change (visible
+   immediately on next foreground, with no passphrase/credential prompt and
+   no Keychain `errSecInteractionNotAllowed` in the console logs).
+
+## Recording results
+
+For each section note device model, OS version, app build number, and
+pass/fail. Any failure in §2 is a release blocker: it means an existing
+Android user would lose working credentials on upgrade.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0DA92D762FECE9F200F56B1C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA92D752FECE9F200F56B1C /* MainViewController.swift */; };
 		0DB5E10D2FED010000F56B1C /* LifeGlanceShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0DC7A1112FED030000F56B1C /* SpotlightPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */; };
+		0DC7A2212FED040000F56B1C /* SecureStorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A2202FED040000F56B1C /* SecureStorePlugin.swift */; };
 		0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */; };
 		7B5F62012E3D110100D5E3A1 /* VaultSseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */; };
 		7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */; };
@@ -71,6 +72,7 @@
 		0DA92D752FECE9F200F56B1C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		0DB5E1022FED010000F56B1C /* LifeGlanceShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeGlanceShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightPlugin.swift; sourceTree = "<group>"; };
+		0DC7A2202FED040000F56B1C /* SecureStorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStorePlugin.swift; sourceTree = "<group>"; };
 		0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMilestoneIntent.swift; sourceTree = "<group>"; };
 		7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSseClient.swift; sourceTree = "<group>"; };
 		7B5F62022E3D110100D5E3A1 /* VaultSsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSsePlugin.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				0DC7A1102FED030000F56B1C /* SpotlightPlugin.swift */,
+				0DC7A2202FED040000F56B1C /* SecureStorePlugin.swift */,
 				0DC7A1002FED020000F56B1C /* AddMilestoneIntent.swift */,
 				0DA92D752FECE9F200F56B1C /* MainViewController.swift */,
 				7B5F62002E3D110100D5E3A1 /* VaultSseClient.swift */,
@@ -410,6 +413,7 @@
 				7B5F62032E3D110100D5E3A1 /* VaultSsePlugin.swift in Sources */,
 				0DC7A1012FED020000F56B1C /* AddMilestoneIntent.swift in Sources */,
 				0DC7A1112FED030000F56B1C /* SpotlightPlugin.swift in Sources */,
+				0DC7A2212FED040000F56B1C /* SecureStorePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/MainViewController.swift
+++ b/ios/App/App/MainViewController.swift
@@ -12,5 +12,6 @@ class MainViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(WidgetBridgePlugin())
         bridge?.registerPluginInstance(VaultSsePlugin())
         bridge?.registerPluginInstance(SpotlightPlugin())
+        bridge?.registerPluginInstance(SecureStorePlugin())
     }
 }

--- a/ios/App/App/SecureStorePlugin.swift
+++ b/ios/App/App/SecureStorePlugin.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Capacitor
+import Security
+
+// Keychain-backed secret storage for sync/vault/intents credentials — the iOS
+// counterpart of SecureStorePlugin.java. Same JS interface
+// (src/native/secureStore.js: get/set/delete), same contract: secrets are no
+// longer plaintext-at-rest in WebView storage, and material that cannot be
+// read on THIS device reports as absent, so the app falls back to asking for
+// credentials again rather than failing cryptically.
+//
+// Where Android builds that contract by hand (AES-GCM ciphertext in prefs, key
+// in the Android Keystore), the iOS Keychain provides it directly:
+// kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly stores the item encrypted
+// under device-bound keys, unreadable in any backup restored to different
+// hardware — the same "useless off-device" property the Android comment
+// promises. AfterFirstUnlock (not WhenUnlocked) because sync and the vault SSE
+// reader can run while the device is locked-but-booted; first-unlock is the
+// standard bar for network-credential material.
+//
+// Ported from lastGLANCE's SecureStorePlugin.swift (issue #210 there); keep
+// the two in sync when fixing bugs in either.
+//
+// Registered in MainViewController.capacitorDidLoad() — app-local plugins
+// are never auto-discovered on iOS.
+@objc(SecureStorePlugin)
+public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
+
+    public let identifier = "SecureStorePlugin"
+    public let jsName = "SecureStore"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "get", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "set", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "delete", returnType: CAPPluginReturnPromise),
+    ]
+
+    // Same namespace the Android prefs file uses; account = the caller's key.
+    private let service = "lifeglance_secure_store"
+
+    private func baseQuery(for key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    @objc func get(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        var query = baseQuery(for: key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess,
+           let data = result as? Data,
+           let value = String(data: data, encoding: .utf8) {
+            call.resolve(["value": value])
+        } else {
+            // Absent, undecodable, or unreadable on this device: all report as
+            // null — the contract's "ask for credentials again" path.
+            call.resolve(["value": NSNull()])
+        }
+    }
+
+    @objc func set(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        guard let value = call.getString("value") else {
+            call.reject("missing value")
+            return
+        }
+        let data = Data(value.utf8)
+
+        // Update-then-add: SecItemUpdate cannot create and SecItemAdd cannot
+        // replace, so the standard upsert is a try of each.
+        let update: [String: Any] = [kSecValueData as String: data]
+        var status = SecItemUpdate(baseQuery(for: key) as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = baseQuery(for: key)
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            status = SecItemAdd(add as CFDictionary, nil)
+        }
+        if status == errSecSuccess {
+            call.resolve()
+        } else {
+            // Loud, unlike get: a write that silently vanished would strand the
+            // credentials in the localStorage the shim is migrating away from.
+            call.reject("keychain write failed (\(status))")
+        }
+    }
+
+    @objc func delete(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        let status = SecItemDelete(baseQuery(for: key) as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            call.resolve()
+        } else {
+            call.reject("keychain delete failed (\(status))")
+        }
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { initDB, dbGetAll, dbGetAllChapters } from './data/db'
 import { backfillMediaIds } from './data/milestones'
 import { initSyncEngine, getSyncEngine } from './sync/engine'
 import { initDbSyncEngine, getDbSyncEngine } from './sync/dbSync'
+import { FILE_CRYPTO_CONFIG } from './sync/cryptoConfig.js'
 import { combineTierErrors } from './sync/status'
 import { useVaultEventStream } from './hooks/useVaultEventStream'
 import { drainIntentsNow } from './hooks/useIntentPoller'
@@ -174,7 +175,9 @@ export default function App() {
         // only appears when the key genuinely isn't stored (first setup or
         // new device), not on every page load.
         import('@glance-apps/sync').then(({ initSessionKey }) => {
-          initSessionKey({ cryptoDBName: 'lifeglance-crypto' })
+          // Shared file-tier crypto config: carries the SecureStore key hooks
+          // on native shells (either/or with IndexedDB — see cryptoConfig.js).
+          initSessionKey({ ...FILE_CRYPTO_CONFIG })
         })
       })
       .catch((err) => {

--- a/src/components/sync/CloudSyncModal.jsx
+++ b/src/components/sync/CloudSyncModal.jsx
@@ -7,6 +7,7 @@ import { getDbSyncEngine } from '../../sync/dbSync.js'
 import { verifyVaultCredentials, runVaultSetup, disableVault, VAULT_OUTCOME } from '../../sync/vaultSetup'
 import { resolveWebdavBase } from '../../sync/webdav'
 import { isNativePlatform, nativeRequest } from '../../sync/nativeHttp'
+import { FILE_CRYPTO_CONFIG } from '../../sync/cryptoConfig.js'
 import { runMediaBackfill } from '../../blobs/mediaBackfill'
 
 // Maps a vault verify/setup outcome kind to its distinct, translatable message.
@@ -223,7 +224,9 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
       const folderChanged = folder !== (existingConfig?.folder ?? 'GLANCE/lifeglance')
 
       if (encrypt) {
-        const cryptoConfig = { cryptoDBName: 'lifeglance-crypto' }
+        // Shared file-tier crypto config: carries the SecureStore key hooks on
+        // native shells (either/or with IndexedDB — see cryptoConfig.js).
+        const cryptoConfig = { ...FILE_CRYPTO_CONFIG }
         if (passphrase) {
           const { setupEncryptionKey } = await import('@glance-apps/sync')
           await setupEncryptionKey(passphrase, cryptoConfig)
@@ -243,7 +246,7 @@ export default function CloudSyncModal({ syncStatus, syncError, syncHalted, last
         await activeEngine?.upload()
       } else {
         const { clearEncryptionKey } = await import('@glance-apps/sync')
-        await clearEncryptionKey({ cryptoDBName: 'lifeglance-crypto' })
+        await clearEncryptionKey({ ...FILE_CRYPTO_CONFIG })
         engine?.setConfig({ ...(engine.getConfig() ?? {}), ...baseConfig, encryptionEnabled: false })
         const activeEngine = folderChanged ? reinitSyncEngine() : engine
         activeEngine?.upload().catch(console.error)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,15 @@ import App from './App'
 import './index.css'
 import { ready as i18nReady } from './i18n'
 import { applyTheme, getTheme } from './utils/theme'
+import { hydrateSecureConfig, installSecureConfigShim } from './sync/secureConfigShim'
+
+// On native shells, route credential-bearing localStorage keys through the
+// SecureStore before ANYTHING can read or write them. Install must precede the
+// first secret-key access; no imported module reads those keys at module scope
+// (all reads happen inside components/effects, post-mount), so installing here
+// — before mount is gated below — is early enough. On web/PWA both calls are
+// no-ops.
+installSecureConfigShim()
 
 // Reflect the saved theme (the inline script in index.html also does this early
 // to avoid a flash; this keeps things correct if that script is ever stripped).
@@ -21,7 +30,12 @@ function mount() {
 // before first paint — otherwise non-English users see the UI flash in English
 // and swap a moment later. A failed load still mounts (in English) rather than
 // leaving a blank screen.
-i18nReady.then(mount, (error) => {
+//
+// Secure-config hydration ALSO gates the first paint: the sync engines and the
+// intents transport read their config synchronously during mount, and a miss
+// would present as "sync not configured". hydrateSecureConfig never rejects
+// (per-key failures degrade to the pre-migration status quo internally).
+Promise.all([i18nReady, hydrateSecureConfig()]).then(mount, (error) => {
   console.error('Translations failed to load; continuing in English:', error)
   mount()
 })

--- a/src/native/secureStore.js
+++ b/src/native/secureStore.js
@@ -1,0 +1,42 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native bridge to hardware-backed secret storage, so credentials are no
+// longer plaintext-at-rest in WebView storage. Both shells implement the same
+// three-method interface with the same contract — material that cannot be
+// read on THIS device reports as absent, and the app falls back to asking for
+// credentials again:
+//  - Android (SecureStorePlugin.java): AES-GCM ciphertext in private prefs,
+//    key in the Android Keystore.
+//  - iOS (SecureStorePlugin.swift): Keychain items stored with
+//    AfterFirstUnlockThisDeviceOnly, encrypted under device-bound keys.
+// On web/PWA callers keep their existing storage.
+//
+// Ported from lastGLANCE (src/native/secureStore.ts); keep the two in sync
+// when fixing bugs in either.
+const SecureStore = registerPlugin('SecureStore')
+
+// The shim and key hooks must only engage where the plugin actually exists —
+// anywhere else the fallback is the status quo (localStorage / IndexedDB).
+//
+// Capability gate, not platform gate: isPluginAvailable() is the same old-shell
+// guard mediaPicker.js and vaultSse.js use, and it covers the shipped-dead-
+// plugin case (a class written but never registered — see the warning comment
+// in MainViewController.swift). lastGLANCE gates on isNativeShell() without
+// probing, which would install the shim and then silently lose every write if
+// registration were ever missed. Never feature-detect via `!!SecureStore.get`:
+// registerPlugin returns a Proxy whose property reads are always truthy on iOS.
+export const isSecureStoreAvailable =
+  Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('SecureStore')
+
+export async function secureGet(key) {
+  const res = await SecureStore.get({ key })
+  return res.value ?? null
+}
+
+export async function secureSet(key, value) {
+  await SecureStore.set({ key, value })
+}
+
+export async function secureDelete(key) {
+  await SecureStore.delete({ key })
+}

--- a/src/sync/cryptoConfig.js
+++ b/src/sync/cryptoConfig.js
@@ -1,0 +1,18 @@
+import { DB_ROOT_KEY_HOOKS, FILE_SYNC_KEY_HOOKS } from './nativeKeyHooks.js'
+
+// The ONLY sanctioned crypto configs for `@glance-apps/sync` calls. Every call
+// that takes a `cryptoDBName` — createSyncEngine, createDbSyncEngine,
+// setupEncryptionKey / initSessionKey / clearEncryptionKey (file tier),
+// setupDbRootKey (DB tier) — must spread one of these instead of inlining the
+// literal. The native key hooks are either/or with IndexedDB inside the
+// package (no fallback), so a call site that passes a bare
+// `{ cryptoDBName: 'lifeglance-crypto' }` on a native shell writes its key to
+// IndexedDB while every hooked call site reads the SecureStore: the symptom is
+// a forced passphrase re-prompt (dayGLANCE's shared-slot bug wearing a new
+// hat). Where no SecureStore plugin exists (web/PWA) the hook objects are
+// empty and these are exactly the old literals.
+//
+// Two distinct configs because the file tier and the DB tier bind the same
+// package hook names to different SecureStore slots — see nativeKeyHooks.js.
+export const FILE_CRYPTO_CONFIG = { cryptoDBName: 'lifeglance-crypto', ...FILE_SYNC_KEY_HOOKS }
+export const DB_CRYPTO_CONFIG = { cryptoDBName: 'lifeglance-crypto', ...DB_ROOT_KEY_HOOKS }

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -21,6 +21,7 @@ import { registerDirtyTarget } from './dirty.js'
 import { dbGetAll, dbGetAllChapters } from '../data/db.js'
 import { loadCategories } from '../utils/colors.js'
 import { loadVaultIntentsRootKey, setupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
+import { DB_CRYPTO_CONFIG } from './cryptoConfig.js'
 import { flushOutbox, isVaultIntentsActive } from '../lib/intentsTransport.js'
 
 const CONFIG_KEY     = 'lifeglance-cloud-sync-config'
@@ -151,7 +152,11 @@ export const initDbSyncEngine = (opts = {}) => {
     vaultToken: vaultConfig.vaultToken,
     accountId:  vaultConfig.accountId,
     deviceId:   ensureDeviceId(),
-    cryptoDBName: opts.cryptoDBName ?? 'lifeglance-crypto',
+    // DB-tier crypto config: cryptoDBName plus, on native shells, the
+    // SecureStore key hooks (either/or with IndexedDB — see cryptoConfig.js).
+    // An explicit opts.cryptoDBName (tests) still wins.
+    ...DB_CRYPTO_CONFIG,
+    ...(opts.cryptoDBName ? { cryptoDBName: opts.cryptoDBName } : {}),
     vaultClient: opts.vaultClient,
     fetchImpl: opts.fetchImpl,
 

--- a/src/sync/engine.js
+++ b/src/sync/engine.js
@@ -1,6 +1,7 @@
 import { createSyncEngine } from '@glance-apps/sync';
 import { buildPayload, buildBackupPayload, mergePayloads, makeApplyPayload } from './adapter.js';
 import { isNativePlatform, nativeWebdavFetch } from './nativeHttp.js';
+import { FILE_CRYPTO_CONFIG } from './cryptoConfig.js';
 
 let engine = null;
 // The construction params (ref/setter closures) from App.jsx, kept so the
@@ -27,7 +28,10 @@ const buildEngine = ({ milestonesRef, chaptersRef, setMilestones, setChapters,
 
   return createSyncEngine({
     storageKeyPrefix: 'lifeglance',
-    cryptoDBName: 'lifeglance-crypto',
+    // cryptoDBName plus, on native shells, the SecureStore key hooks — the
+    // hooks are either/or with IndexedDB, so every crypto call site must use
+    // the shared config (see cryptoConfig.js).
+    ...FILE_CRYPTO_CONFIG,
     autoBackupDBName: 'lifeglance-auto-backups',
     syncFilename: 'lifeglance-sync.json',
     appFolderName,

--- a/src/sync/nativeKeyHooks.js
+++ b/src/sync/nativeKeyHooks.js
@@ -1,0 +1,145 @@
+import { isSecureStoreAvailable, secureDelete, secureGet, secureSet } from '../native/secureStore.js'
+
+// SecureStore-backed implementations of the `nativeGetSyncKey` /
+// `nativeStoreSyncKey` hooks that `@glance-apps/sync` ships for exactly this
+// purpose and that the app has so far passed as null. With the hooks present
+// the package stops using its `lifeglance-crypto*` IndexedDB databases — the
+// two records it kept there are extractable raw key bytes (`rawKey` for the
+// file-sync key, `rootBytes` for the DB root key), the most sensitive
+// artifacts in WebView storage.
+//
+// The package treats the hooks as either/or with IndexedDB (no fallback), so
+// each getter carries its own one-time legacy migration: read the old record,
+// re-encode it as the exact base64 blob the package's native path expects,
+// store it in the SecureStore, then delete the IndexedDB copy (leaving it
+// would defeat the point — the bytes are extractable where they sit).
+//
+// Two separately-bound hook pairs are required. The file tier and the DB tier
+// use the SAME hook names in the package (`initSessionKey` vs `initDbRootKey`
+// both call `nativeGetSyncKey`), so a single shared pair would make both
+// tiers read and clobber one SecureStore entry — dayGLANCE's shared-slot
+// passphrase re-prompt bug. FILE_SYNC_KEY_HOOKS binds to 'crypto.sync-key',
+// DB_ROOT_KEY_HOOKS to 'crypto.db-root-key' (same slot names as lastGLANCE).
+//
+// Where no SecureStore plugin exists (web/PWA) both exports are empty objects:
+// spread into a config they contribute nothing, the package sees no hooks, and
+// IndexedDB behavior is unchanged.
+//
+// Ported from lastGLANCE (src/sync/nativeKeyHooks.ts); keep the two in sync
+// when fixing bugs in either.
+
+// Read one record from a legacy crypto DB without creating stores. Opening
+// versionless never triggers an upgrade, so a missing store just reads null.
+function readLegacyRecord(dbName, storeName, id) {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(dbName)
+      req.onerror = () => resolve(null)
+      req.onsuccess = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.close()
+          resolve(null)
+          return
+        }
+        const get = db.transaction(storeName, 'readonly').objectStore(storeName).get(id)
+        get.onerror = () => { db.close(); resolve(null) }
+        get.onsuccess = () => { db.close(); resolve(get.result ?? null) }
+      }
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+function deleteLegacyRecord(dbName, storeName, id) {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(dbName)
+      req.onerror = () => resolve()
+      req.onsuccess = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.close()
+          resolve()
+          return
+        }
+        const tx = db.transaction(storeName, 'readwrite')
+        tx.objectStore(storeName).delete(id)
+        tx.oncomplete = () => { db.close(); resolve() }
+        tx.onerror = () => { db.close(); resolve() }
+      }
+    } catch {
+      resolve()
+    }
+  })
+}
+
+// number[] | ArrayBuffer | TypedArray → plain number[] for the JSON blob.
+function toByteArray(v) {
+  if (Array.isArray(v)) return v
+  if (v instanceof ArrayBuffer) return Array.from(new Uint8Array(v))
+  if (ArrayBuffer.isView(v)) return Array.from(new Uint8Array(v.buffer, v.byteOffset, v.byteLength))
+  return []
+}
+
+function makeHooks(storeKey, legacy, recordToBlob) {
+  if (!isSecureStoreAvailable) return {}
+  return {
+    nativeGetSyncKey: async () => {
+      try {
+        const existing = await secureGet(storeKey)
+        if (existing !== null) return existing
+      } catch {
+        // SecureStore read failed — fall through to the legacy record so a
+        // native fault degrades to pre-migration behavior, not a re-prompt.
+      }
+      const record = await readLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      if (!record) return null
+      const blob = recordToBlob(record)
+      if (!blob) return null
+      const b64 = btoa(JSON.stringify(blob))
+      try {
+        await secureSet(storeKey, b64)
+        await deleteLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      } catch {
+        // Secure write failed: keep the legacy record and still return the
+        // key so this session works; the migration retries next boot. Never
+        // let a broken native layer present as a lost encryption key.
+      }
+      return b64
+    },
+    nativeStoreSyncKey: (b64) => {
+      // The package calls this fire-and-forget (null means "clear").
+      void (b64 === null ? secureDelete(storeKey) : secureSet(storeKey, b64)).catch(() => {
+        // Failed persist: the in-memory session key still works; next boot
+        // falls back to the passphrase prompt (fail-safe).
+      })
+    },
+  }
+}
+
+// File-tier sync key: record { rawKey: ArrayBuffer, salt: number[] } in
+// lifeglance-crypto/keys, blob shape { rawKey: number[], salt: number[] }.
+export const FILE_SYNC_KEY_HOOKS = makeHooks(
+  'crypto.sync-key',
+  { dbName: 'lifeglance-crypto', storeName: 'keys', id: 'sync-key' },
+  (record) => {
+    const rawKey = toByteArray(record.rawKey)
+    const salt = toByteArray(record.salt)
+    return rawKey.length && salt.length ? { rawKey, salt } : null
+  },
+)
+
+// DB-tier root key: record { rootBytes: number[], salt: number[] } in
+// lifeglance-crypto-db/db-root-keys (the package derives the `-db` DB name
+// from cryptoDBName), blob shape { rootBytes, salt }.
+export const DB_ROOT_KEY_HOOKS = makeHooks(
+  'crypto.db-root-key',
+  { dbName: 'lifeglance-crypto-db', storeName: 'db-root-keys', id: 'db-root-key' },
+  (record) => {
+    const rootBytes = toByteArray(record.rootBytes)
+    const salt = toByteArray(record.salt)
+    return rootBytes.length && salt.length ? { rootBytes, salt } : null
+  },
+)

--- a/src/sync/nativeKeyHooks.test.js
+++ b/src/sync/nativeKeyHooks.test.js
@@ -1,0 +1,136 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+
+const nativeStore = new Map()
+const broken = { value: false }
+vi.mock('../native/secureStore.js', () => ({
+  isSecureStoreAvailable: true,
+  secureGet: vi.fn(async (key) => {
+    if (broken.value) throw new Error('native failure')
+    return nativeStore.has(key) ? nativeStore.get(key) : null
+  }),
+  secureSet: vi.fn(async (key, value) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.set(key, value)
+  }),
+  secureDelete: vi.fn(async (key) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.delete(key)
+  }),
+}))
+
+import { FILE_SYNC_KEY_HOOKS, DB_ROOT_KEY_HOOKS } from './nativeKeyHooks.js'
+
+// Seed a legacy crypto DB the way @glance-apps/sync laid it out.
+function seedLegacyDb(dbName, storeName, record) {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1)
+    req.onupgradeneeded = () => req.result.createObjectStore(storeName, { keyPath: 'id' })
+    req.onerror = () => reject(req.error)
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction(storeName, 'readwrite')
+      tx.objectStore(storeName).put(record)
+      tx.oncomplete = () => { db.close(); resolve() }
+      tx.onerror = () => { db.close(); reject(tx.error) }
+    }
+  })
+}
+
+function readLegacy(dbName, storeName, id) {
+  return new Promise((resolve) => {
+    const req = indexedDB.open(dbName)
+    req.onsuccess = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(storeName)) { db.close(); resolve(null); return }
+      const get = db.transaction(storeName, 'readonly').objectStore(storeName).get(id)
+      get.onsuccess = () => { db.close(); resolve(get.result ?? null) }
+      get.onerror = () => { db.close(); resolve(null) }
+    }
+    req.onerror = () => resolve(null)
+  })
+}
+
+describe('nativeKeyHooks', () => {
+  beforeEach(() => {
+    nativeStore.clear()
+    broken.value = false
+    // Fresh IndexedDB universe per test.
+    globalThis.indexedDB = new IDBFactory()
+  })
+
+  it('returns null when neither store has a key', async () => {
+    expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()).toBeNull()
+  })
+
+  it('round-trips through the store hook', async () => {
+    const blob = btoa(JSON.stringify({ rawKey: [1, 2, 3], salt: [4, 5, 6] }))
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey(blob)
+    await vi.waitFor(async () => {
+      expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()).toBe(blob)
+    })
+  })
+
+  it('store(null) clears the entry (package clear semantics)', async () => {
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey(btoa('{"rawKey":[1],"salt":[2]}'))
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey(null)
+    await vi.waitFor(async () => {
+      expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()).toBeNull()
+    })
+  })
+
+  it('migrates the legacy file-sync key record (ArrayBuffer rawKey) and deletes it', async () => {
+    const rawKey = new Uint8Array([9, 8, 7, 6]).buffer
+    await seedLegacyDb('lifeglance-crypto', 'keys', { id: 'sync-key', rawKey, salt: [1, 2] })
+
+    const blob = await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()
+    expect(blob).not.toBeNull()
+    expect(JSON.parse(atob(blob))).toEqual({ rawKey: [9, 8, 7, 6], salt: [1, 2] })
+    // Migrated into the secure store, wiped from IndexedDB (risk note: the
+    // legacy record is extractable raw bytes — it must not survive).
+    expect(nativeStore.get('crypto.sync-key')).toBe(blob)
+    expect(await readLegacy('lifeglance-crypto', 'keys', 'sync-key')).toBeNull()
+  })
+
+  it('migrates the legacy DB root key record and deletes it', async () => {
+    await seedLegacyDb('lifeglance-crypto-db', 'db-root-keys', { id: 'db-root-key', rootBytes: [5, 5], salt: [6, 6] })
+
+    const blob = await DB_ROOT_KEY_HOOKS.nativeGetSyncKey()
+    expect(JSON.parse(atob(blob))).toEqual({ rootBytes: [5, 5], salt: [6, 6] })
+    expect(nativeStore.get('crypto.db-root-key')).toBe(blob)
+    expect(await readLegacy('lifeglance-crypto-db', 'db-root-keys', 'db-root-key')).toBeNull()
+  })
+
+  it('file and db tiers use distinct secure-store entries', async () => {
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey(btoa(JSON.stringify({ rawKey: [1], salt: [1] })))
+    DB_ROOT_KEY_HOOKS.nativeStoreSyncKey(btoa(JSON.stringify({ rootBytes: [2], salt: [2] })))
+    await vi.waitFor(() => {
+      expect(nativeStore.size).toBe(2)
+    })
+    const file = JSON.parse(atob(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()))
+    const dbRoot = JSON.parse(atob(await DB_ROOT_KEY_HOOKS.nativeGetSyncKey()))
+    expect(file.rawKey).toEqual([1])
+    expect(dbRoot.rootBytes).toEqual([2])
+  })
+
+  it('a failing native layer still returns the legacy key and keeps the record for retry', async () => {
+    // Regression companion to lastGLANCE's 2.1.0 rc Keystore bug: a broken
+    // SecureStore must not present as a lost encryption key (passphrase
+    // re-prompt).
+    await seedLegacyDb('lifeglance-crypto', 'keys', { id: 'sync-key', rawKey: [3, 1, 4], salt: [1, 5] })
+    broken.value = true
+
+    const blob = await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()
+    expect(JSON.parse(atob(blob))).toEqual({ rawKey: [3, 1, 4], salt: [1, 5] })
+    // Legacy record survives for the next boot's migration retry.
+    expect(await readLegacy('lifeglance-crypto', 'keys', 'sync-key')).not.toBeNull()
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('a malformed legacy record reads as absent (fail-safe)', async () => {
+    await seedLegacyDb('lifeglance-crypto', 'keys', { id: 'sync-key', wrongField: true })
+    expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey()).toBeNull()
+    expect(nativeStore.size).toBe(0)
+  })
+})

--- a/src/sync/secureConfigShim.js
+++ b/src/sync/secureConfigShim.js
@@ -1,0 +1,155 @@
+import { isSecureStoreAvailable, secureDelete, secureGet, secureSet } from '../native/secureStore.js'
+
+// Keeps credential-bearing config out of localStorage on the native shells
+// without touching any of the call sites that read it synchronously —
+// including `@glance-apps/sync`, whose engine hard-codes
+// `localStorage.getItem(...)` for its config key with no storage injection
+// point. The only way its reads can hit a secure backend is to interpose on
+// Storage itself, so that is exactly (and only) what this does:
+//
+// - `installSecureConfigShim()` patches Storage.prototype get/set/removeItem.
+//   For an allow-list of secret keys on `window.localStorage`, reads are served
+//   from an in-memory session cache and writes go to the cache plus a
+//   write-through to the native SecureStore. Every other key, and everything on
+//   sessionStorage, passes through untouched.
+// - `hydrateSecureConfig()` runs once at boot, before React renders (and
+//   therefore before the sync engine's first read): it migrates any legacy
+//   plaintext value out of real localStorage into the SecureStore (one-time,
+//   idempotent), then seeds the cache from the SecureStore.
+//
+// Known limits, deliberate: property-style access (`localStorage['k']`),
+// enumeration (`length`/`key(i)`) and `clear()` are not intercepted — no
+// consumer of these keys uses them (engine and app code use the method API
+// throughout). Where no SecureStore plugin exists (web/PWA) neither function
+// does anything, so behavior there is byte-for-byte the status quo.
+//
+// Ported from lastGLANCE (src/sync/secureConfigShim.ts); keep the two in sync
+// when fixing bugs in either. One deliberate deviation: the plaintext
+// migration here verifies by read-back before deleting the original (see
+// hydrateSecureConfig), where lastGLANCE trusts the resolved write.
+
+// Every localStorage key whose value contains a credential. The engine-owned
+// names are `${storageKeyPrefix}-cloud-sync-config` / `-db-sync-config` with
+// prefix 'lifeglance' (see engine.js / dbSync.js); they exist nowhere as
+// importable constants, so they are spelled out here. Unlike lastGLANCE there
+// is no separate vault-config key: the GLANCEvault token lives inside
+// lifeglance-cloud-sync-config (vaultSetup.js merges both tiers there).
+const SECRET_KEYS = new Set([
+  'lifeglance-cloud-sync-config', // WebDAV password + appPassword + vaultToken (both tiers)
+  'lifeglance-db-sync-config', // engine-owned twin, normally empty — covered so it can never leak
+  'lifeglance-intents-config', // WebDAV password, second copy (intents transport webdavPass)
+])
+
+const cache = new Map()
+let installed = false
+
+// In-flight write-throughs, so a caller that is about to tear the page down
+// can wait for the native side to actually have the credentials. lifeGLANCE
+// currently re-inits engines in place rather than reloading, but the flush
+// stays: its absence is the kind of thing discovered by a lost write.
+const pending = new Set()
+
+function track(p) {
+  const guarded = p.catch(() => {
+    // Native write failed: the cache still serves this session, and the worst
+    // case on next boot is the fail-safe — the user re-enters credentials.
+  })
+  pending.add(guarded)
+  void guarded.finally(() => pending.delete(guarded))
+}
+
+export function flushSecureWrites() {
+  return Promise.all([...pending]).then(() => undefined)
+}
+
+// Original Storage.prototype methods, captured at install time. Hydration uses
+// these to reach the real localStorage beneath the shim.
+let origGetItem
+let origSetItem
+let origRemoveItem
+
+export function installSecureConfigShim() {
+  if (!isSecureStoreAvailable || installed) return
+  installed = true
+
+  const proto = Storage.prototype
+  origGetItem = proto.getItem
+  origSetItem = proto.setItem
+  origRemoveItem = proto.removeItem
+
+  proto.getItem = function (key) {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      return cache.has(key) ? cache.get(key) : null
+    }
+    return origGetItem.call(this, key)
+  }
+
+  proto.setItem = function (key, value) {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      const str = String(value)
+      cache.set(key, str)
+      track(secureSet(key, str))
+      return
+    }
+    origSetItem.call(this, key, value)
+  }
+
+  proto.removeItem = function (key) {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      cache.delete(key)
+      track(secureDelete(key))
+      return
+    }
+    origRemoveItem.call(this, key)
+  }
+}
+
+// Boot-time hydration. Must complete before the first render (main.jsx awaits
+// it): the sync engines and intents transport read these keys synchronously
+// during mount, and a miss would present as "sync not configured".
+export async function hydrateSecureConfig() {
+  if (!installed) return
+  for (const key of SECRET_KEYS) {
+    try {
+      // Migrate legacy plaintext first. If a plaintext copy exists it is the
+      // newest write (pre-shim builds wrote here), so it wins over any secure
+      // copy; removal makes the migration one-time. The cache is seeded BEFORE
+      // the secure write and the plaintext is removed only AFTER it is
+      // verified: a native failure must present as "still works like before,
+      // migrates next boot", never as wiped settings (lastGLANCE's 2.1.0 rc
+      // bug — a Keystore rejection made every write fail, and the shim
+      // shadowed the intact plaintext with an empty cache).
+      const legacy = origGetItem.call(window.localStorage, key)
+      if (legacy !== null) {
+        cache.set(key, legacy)
+        await secureSet(key, legacy)
+        // Deliberate deviation from lastGLANCE, which trusts the resolved
+        // write: read the value back before deleting the only other copy.
+        // This is the one place where a native layer that lies about success
+        // costs a user their WebDAV password and possibly their passphrase.
+        const readBack = await secureGet(key)
+        if (readBack === legacy) {
+          origRemoveItem.call(window.localStorage, key)
+        }
+        continue
+      }
+      const value = await secureGet(key)
+      if (value !== null) cache.set(key, value)
+    } catch {
+      // SecureStore unavailable for this key. With legacy plaintext present
+      // the cache is already seeded above, so the app behaves exactly as
+      // pre-migration; without it there is genuinely nothing to serve.
+    }
+  }
+}
+
+// Test-only: undo the prototype patch and clear module state.
+export function uninstallSecureConfigShimForTests() {
+  if (!installed) return
+  Storage.prototype.getItem = origGetItem
+  Storage.prototype.setItem = origSetItem
+  Storage.prototype.removeItem = origRemoveItem
+  cache.clear()
+  pending.clear()
+  installed = false
+}

--- a/src/sync/secureConfigShim.test.js
+++ b/src/sync/secureConfigShim.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// In-memory stand-in for the native SecureStore plugin. `availability` is
+// mutable so individual tests can exercise the no-plugin no-op path, `broken`
+// simulates a native layer whose calls all reject (lastGLANCE's 2.1.0 rc
+// Keystore bug) to pin down the fail-open behavior, and `lying` simulates a
+// write that resolves successfully without persisting — the case the
+// read-back-before-delete deviation exists for.
+const nativeStore = new Map()
+const availability = { value: true }
+const broken = { value: false }
+const lying = { value: false }
+vi.mock('../native/secureStore.js', () => ({
+  get isSecureStoreAvailable() { return availability.value },
+  secureGet: vi.fn(async (key) => {
+    if (broken.value) throw new Error('native failure')
+    return nativeStore.has(key) ? nativeStore.get(key) : null
+  }),
+  secureSet: vi.fn(async (key, value) => {
+    if (broken.value) throw new Error('native failure')
+    if (lying.value) return // resolves, stores nothing
+    nativeStore.set(key, value)
+  }),
+  secureDelete: vi.fn(async (key) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.delete(key)
+  }),
+}))
+
+// The vitest environment is node: no Storage / window / localStorage. The shim
+// patches Storage.prototype and distinguishes localStorage from sessionStorage
+// by identity, so the fixture must model both on a real prototype chain.
+class FakeStorage {
+  constructor() { this.store = new Map() }
+  getItem(k) { return this.store.has(k) ? this.store.get(k) : null }
+  setItem(k, v) { this.store.set(k, String(v)) }
+  removeItem(k) { this.store.delete(k) }
+  clear() { this.store.clear() }
+  key(i) { return Array.from(this.store.keys())[i] ?? null }
+  get length() { return this.store.size }
+}
+
+const SECRET_KEY = 'lifeglance-cloud-sync-config'
+
+let shim
+
+describe('secureConfigShim', () => {
+  beforeEach(async () => {
+    globalThis.Storage = FakeStorage
+    globalThis.localStorage = new FakeStorage()
+    globalThis.sessionStorage = new FakeStorage()
+    globalThis.window = globalThis
+    nativeStore.clear()
+    availability.value = true
+    broken.value = false
+    lying.value = false
+    vi.resetModules()
+    shim = await import('./secureConfigShim.js')
+  })
+
+  afterEach(() => {
+    shim.uninstallSecureConfigShimForTests()
+  })
+
+  it('passes non-secret keys through to real localStorage', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem('lifeglance-theme', 'dark')
+    expect(localStorage.getItem('lifeglance-theme')).toBe('dark')
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('serves secret keys from the cache and writes through to the native store', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    const cfg = JSON.stringify({ enabled: true, appPassword: 'hunter2', vaultToken: 'tok' })
+    localStorage.setItem(SECRET_KEY, cfg)
+    // Synchronous read-back straight from the cache — this is the contract the
+    // sync engine's synchronous config reads depend on.
+    expect(localStorage.getItem(SECRET_KEY)).toBe(cfg)
+    await shim.flushSecureWrites()
+    expect(nativeStore.get(SECRET_KEY)).toBe(cfg)
+    // The real localStorage must never have seen the value.
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+  })
+
+  it('removeItem clears both cache and native store', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem(SECRET_KEY, 'v')
+    localStorage.removeItem(SECRET_KEY)
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+    await shim.flushSecureWrites()
+    expect(nativeStore.has(SECRET_KEY)).toBe(false)
+  })
+
+  it('migrates legacy plaintext out of localStorage on hydrate', async () => {
+    const legacy = JSON.stringify({ webdavPass: 'pw_legacy' })
+    localStorage.setItem('lifeglance-intents-config', legacy)
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    // Served from the cache, present in the native store, gone from disk.
+    expect(localStorage.getItem('lifeglance-intents-config')).toBe(legacy)
+    expect(nativeStore.get('lifeglance-intents-config')).toBe(legacy)
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem('lifeglance-intents-config')).toBeNull()
+  })
+
+  it('hydrates previously stored secrets from the native store', async () => {
+    nativeStore.set('lifeglance-intents-config', '{"webdavPass":"pw"}')
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    expect(localStorage.getItem('lifeglance-intents-config')).toBe('{"webdavPass":"pw"}')
+  })
+
+  it('a wiped native store (device transfer) reads as absent', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+  })
+
+  it('does not touch sessionStorage', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    sessionStorage.setItem(SECRET_KEY, 'session-value')
+    expect(sessionStorage.getItem(SECRET_KEY)).toBe('session-value')
+    await shim.flushSecureWrites()
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('a failing native layer still serves legacy settings and keeps the plaintext for retry', async () => {
+    // Regression pinned in lastGLANCE: the 2.1.0 rc Keystore bug made every
+    // secureSet reject, and hydration left the cache empty while the shim
+    // shadowed the intact plaintext — presenting as wiped sync settings.
+    const legacy = JSON.stringify({ enabled: true, appPassword: 'hunter2' })
+    localStorage.setItem(SECRET_KEY, legacy)
+    broken.value = true
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    // Settings must still be readable through the shim...
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
+    // ...and the plaintext must survive for the next boot's retry.
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('a native write that resolves without persisting keeps the plaintext (read-back verify)', async () => {
+    // Deliberate deviation from lastGLANCE: the migration reads the value back
+    // before deleting the only other copy, so a native layer that lies about
+    // success cannot cost the user their WebDAV password.
+    const legacy = JSON.stringify({ enabled: true, appPassword: 'hunter2' })
+    localStorage.setItem(SECRET_KEY, legacy)
+    lying.value = true
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    // Still served this session, and the plaintext survives for the retry.
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
+  })
+
+  it('is a no-op when the secure store is unavailable (web / PWA / old shell)', async () => {
+    availability.value = false
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem(SECRET_KEY, 'plain')
+    // Without the shim installed, behavior is the status quo: plain localStorage.
+    expect(localStorage.getItem(SECRET_KEY)).toBe('plain')
+    expect(nativeStore.size).toBe(0)
+  })
+})

--- a/src/sync/vaultSetup.js
+++ b/src/sync/vaultSetup.js
@@ -28,9 +28,9 @@ import {
 import { setupVaultIntentsRootKey as defaultSetupVaultIntentsRootKey } from '../lib/intentsKeyStore.js'
 import { reinitDbSyncEngine as defaultReinit, getDbSyncEngine, resetVaultSyncState as defaultResetVaultSyncState, clearCredentialHalt as defaultClearCredentialHalt } from './dbSync.js'
 import { nativeVaultFetchImpl } from './nativeVaultFetch.js'
+import { DB_CRYPTO_CONFIG } from './cryptoConfig.js'
 
-const CONFIG_KEY    = 'lifeglance-cloud-sync-config'
-const CRYPTO_DBNAME = 'lifeglance-crypto'
+const CONFIG_KEY = 'lifeglance-cloud-sync-config'
 
 // Outcome kinds. 'success' and 'uninitialized' permit save/activate; the rest
 // hard-fail and block it. Each maps to a distinct, translatable message in the UI.
@@ -135,7 +135,7 @@ export async function runVaultSetup({ vaultUrl, vaultToken, accountId, passphras
   // passphrase is set so the engine derives + establishes the salt on first sync.
   ;(deps.setSyncPassphrase ?? defaultSetSyncPassphrase)(passphrase)
   if (outcome.kind === VAULT_OUTCOME.SUCCESS) {
-    await (deps.setupDbRootKey ?? defaultSetupDbRootKey)(passphrase, outcome.salt, { cryptoDBName: CRYPTO_DBNAME })
+    await (deps.setupDbRootKey ?? defaultSetupDbRootKey)(passphrase, outcome.salt, { ...DB_CRYPTO_CONFIG })
     await (deps.setupVaultIntentsRootKey ?? defaultSetupVaultIntentsRootKey)(passphrase, outcome.salt)
   }
 


### PR DESCRIPTION
Ports lastGLANCE's secure-storage stack (its v2.1.0 Android / v2.5.0 iOS work) into lifeGLANCE, both platforms in one piece: native `SecureStorePlugin` on each shell, the `secureConfigShim` Storage interposition, the `nativeKeyHooks` for `@glance-apps/sync`'s key material, and the one-time migrations. Blocks v3.3.0 by design — that release creates iOS users, and landing this first means iOS never has a plaintext-credential generation.

## What is and is not secured (the honest claim)

All **three named secrets** move out of plaintext WebView storage on the native shells:

| Secret | Was | Now |
|---|---|---|
| WebDAV app password | plaintext `localStorage` (`lifeglance-cloud-sync-config`, plus a copy in `lifeglance-intents-config`) | SecureStore (Keystore-wrapped AES-GCM prefs on Android; Keychain `AfterFirstUnlockThisDeviceOnly` on iOS) |
| GLANCEvault device token | plaintext `localStorage` (`vaultToken` in the same config object) | SecureStore, same |
| Sync encryption keys (file-tier sync key + DB root key cache) | extractable raw bytes in IndexedDB `lifeglance-crypto` / `lifeglance-crypto-db` | SecureStore slots `crypto.sync-key` / `crypto.db-root-key` |

**Residual, stated so privacy copy doesn't overclaim:** the intents/blob root keys in IndexedDB `lifeglance-intents-crypto` are **not** moved. `@glance-apps/intents` derives them as non-extractable `CryptoKey`s, which JavaScript cannot export to any secure store. Non-extractability blocks script exfiltration, but the serialized material still sits in the IDB backing files on disk — forensic and backup exposure for those keys narrows rather than closes. lastGLANCE's finished implementation has the identical residual (`vaultIntentsKeyStore.ts` and its WebDAV twin), and its issue-#210 comments slightly overstate coverage ("no longer plaintext-at-rest in WebView storage"). Fixing it means changing derivation or re-deriving from the passphrase at setup — a change to *what* is stored, out of scope here; flagged as a **suite-wide follow-up applying to lastGLANCE too**. The web/PWA path is untouched by design.

## Hook wiring evidence

The `nativeGetSyncKey`/`nativeStoreSyncKey` hooks are either/or with IndexedDB inside the package — one missed call site writes a key to IndexedDB while the engine reads the SecureStore (dayGLANCE's forced passphrase re-prompt bug wearing a new hat). All crypto call sites now flow through two exported constants, `FILE_CRYPTO_CONFIG` / `DB_CRYPTO_CONFIG` (`src/sync/cryptoConfig.js`), keeping the two separately-bound hook pairs (`crypto.sync-key` / `crypto.db-root-key` — the per-slot lesson). The sweep, run at HEAD of this branch:

```
$ grep -rn "cryptoDBName" src --include='*.js' --include='*.jsx' | grep -v '\.test\.'
src/sync/dbSync.js:124: * @param {string} [opts.cryptoDBName]
src/sync/dbSync.js:155:    // DB-tier crypto config: cryptoDBName plus, on native shells, the
src/sync/dbSync.js:157:    // An explicit opts.cryptoDBName (tests) still wins.
src/sync/dbSync.js:159:    ...(opts.cryptoDBName ? { cryptoDBName: opts.cryptoDBName } : {}),
src/sync/cryptoConfig.js:4:// that takes a `cryptoDBName` — createSyncEngine, createDbSyncEngine,
src/sync/cryptoConfig.js:9:// `{ cryptoDBName: 'lifeglance-crypto' }` on a native shell writes its key to
src/sync/cryptoConfig.js:17:export const FILE_CRYPTO_CONFIG = { cryptoDBName: 'lifeglance-crypto', ...FILE_SYNC_KEY_HOOKS }
src/sync/cryptoConfig.js:18:export const DB_CRYPTO_CONFIG = { cryptoDBName: 'lifeglance-crypto', ...DB_ROOT_KEY_HOOKS }
src/sync/engine.js:31:    // cryptoDBName plus, on native shells, the SecureStore key hooks — the
src/sync/nativeKeyHooks.js:136:// from cryptoDBName), blob shape { rootBytes, salt }.

$ grep -rn "import('@glance-apps/sync')" src --include='*.js' --include='*.jsx' | grep -v '\.test\.'
src/components/sync/SyncPassphraseModal.jsx:24:      const { setSyncPassphrase } = await import('@glance-apps/sync')
src/components/sync/CloudSyncModal.jsx:231:          const { setupEncryptionKey } = await import('@glance-apps/sync')
src/components/sync/CloudSyncModal.jsx:234:          const { initSessionKey } = await import('@glance-apps/sync')
src/components/sync/CloudSyncModal.jsx:248:        const { clearEncryptionKey } = await import('@glance-apps/sync')
src/components/sync/CloudSyncModal.jsx:314:      const { getSyncPassphrase } = await import('@glance-apps/sync')
src/App.jsx:177:        import('@glance-apps/sync').then(({ initSessionKey }) => {
```

Reading of the sweep: the only remaining production `cryptoDBName` literals are the two canonical definitions in `cryptoConfig.js`, the test-only override passthrough in `dbSync.js`, and comments. All five previously-inlined sites (`engine.js`, `dbSync.js`, `vaultSetup.js`, `CloudSyncModal.jsx` ×3 dynamic imports, `App.jsx`) now spread a constant. The two dynamic imports not touched (`setSyncPassphrase`, `getSyncPassphrase`) are in-memory session-passphrase accessors that take no crypto config — verified against the package source (`crypto.js:17`). All three file-tier entry points (`initSessionKey`, `setupEncryptionKey`, `clearEncryptionKey`) branch on the hooks, including the clear path.

## Migration

Ordering ports verbatim from lastGLANCE (it is the load-bearing part): plaintext wins over any secure copy, cache seeded **before** the secure write, plaintext deleted only **after** the write is verified — so a failed migration degrades to exactly pre-migration behaviour and retries next boot, never leaving zero copies. Android's shipped user base is what this protects; iOS is net-new and the same platform-neutral code no-ops on a fresh install. The IndexedDB key migration is lazy (on first key use) with the same delete-only-after-success ordering.

**One deliberate deviation from the reference:** on the localStorage migration path, the value is **read back** from the SecureStore and compared before the plaintext original is deleted — lastGLANCE trusts the resolved write. This is the one place where a native layer that lies about success would cost a user their WebDAV password and possibly their passphrase; three lines of insurance, covered by a dedicated unit test (a "lying" fake plugin whose `set` resolves without persisting). The difference from lastGLANCE is deliberate, not drift, and is marked as such in the shim's header comment.

## lastGLANCE follow-up: latent gate bug, reported not fixed

lifeGLANCE gates on capability — `Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('SecureStore')` — matching its `mediaPicker`/`vaultSse` idiom and avoiding the iOS Proxy-truthy trap by construction. **lastGLANCE gates on `isNativeShell()` with no plugin probe** (`src/native/secureStore.ts:25`), which is a real latent bug there: if plugin registration were ever missed (the shipped-dead-plugin case its own `MainViewController` comment warns about), the shim would still install, shadow localStorage, and silently lose every credential write. Not fixed here per scope; should be a lastGLANCE issue. (Its shim comments also still say "Android-only", stale since its iOS port.)

## Support note: device-bound loss covers the whole sync setup

Both tiers' secrets share one config object (`lifeglance-cloud-sync-config`), so on a backup restored to different hardware the intended `ThisDeviceOnly` / Keystore-invalidation behaviour surfaces as the **entire** sync configuration (server URL, folder, account id — not just the credentials) needing re-entry. Expected, and noted in the device script for support scripts; not worth restructuring the config to avoid.

## Verification

- **CI:** 814 tests pass (48 files), including the ported shim + hooks suites (18 tests: migration end-to-end, failed-migration fail-safe with a rejecting fake plugin, read-back verify with a lying one, per-slot separation, web no-op). Lint warning count unchanged from `main`; production build succeeds. The suite passing unmodified is the evidence for "web/PWA untouched".
- **Device pass (required before TestFlight):** scripted step-by-step in [`docs/secure-store-device-verification.md`](docs/secure-store-device-verification.md) — fresh install per platform, Android upgrade migration over v3.2.0, backup-restore to a second iOS device (`ThisDeviceOnly`), and reboot-then-background-sync before first unlock (AfterFirstUnlock). Written to be followed without re-deriving context.
- **Unverified in this environment:** the `ios/App/App.xcodeproj/project.pbxproj` edit adding `SecureStorePlugin.swift` was made by hand (no Xcode here) and is unverified until the first Xcode build — same caveat as the billing package port. Entries mirror `SpotlightPlugin.swift` in all four sections (PBXBuildFile, PBXFileReference, group children, Sources phase) with fresh UUIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptm8ZFhbrxuCPaaHH61AE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptm8ZFhbrxuCPaaHH61AE6)_