### PR TITLE
Release 3.3.0: version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` (and the two lockfile version fields) from 3.2.0 to 3.3.0 — the same two-file shape as the 3.1.0 bump. `package.json` is the single version source: `android/app/build.gradle` derives `versionName`/`versionCode` from it at build time, and `scripts/sync-ios-version.mjs` carries `MARKETING_VERSION` to every iOS target during `build:ios`, so nothing native needs touching here.

Covers everything since the `v3.2.0` tag (PRs #313–#331): the localization stack (picker, pt-BR/pt-PT split, native-surface translations, onboarding picker), iOS Lock Screen widgets + iOS 16 target, the Siri/Shortcuts Add-milestone intent, Core Spotlight indexing, Android native media pickers, full share-queue drain, SecureStore credential storage, and the Android/iOS CI build gates.

Release notes for the GitHub Release (`v3.3.0` tag) and the Play Store listing are in the session; the release itself follows the usual flow after this merges (tag, notes, `lifeglance.apk` asset).

814 tests passing, lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL64JjTmHux5YYskWzJuHd)_