### PR TITLE
Adopt @glance-apps/sync 2.0.0: enforcement on the push-on-write path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@capacitor/share": "8.0.1",
         "@glance-apps/billing": "0.2.2",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.10.0",
+        "@glance-apps/sync": "2.0.0",
         "date-fns": "^3.6.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -2291,9 +2291,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.10.0.tgz",
-      "integrity": "sha512-/OCQZPm/dsv6OmOMdXj8gjmbKR9F/eXaJdr/8BR7Rs04ScxaSdw1ozSu5cejfLyziMHaelcBecaeKVK8wvmF8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-2.0.0.tgz",
+      "integrity": "sha512-i6IpNo6DrMd20/aAkjWIEcPEofB3Z1G2sxn+nO1YWRSp9uKJuUCW5d805bgFIVhptmNN9h/ZcKyswdJ4PWXWNg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@capacitor/share": "8.0.1",
     "@glance-apps/billing": "0.2.2",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.10.0",
+    "@glance-apps/sync": "2.0.0",
     "date-fns": "^3.6.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/sync/dbSync.js
+++ b/src/sync/dbSync.js
@@ -14,7 +14,7 @@
 // React); the refresh reloads React state so the UI reflects merged rows. That
 // is a state bridge, not a cursor bridge.
 
-import { createDbSyncEngine, getSyncPassphrase } from '@glance-apps/sync'
+import { createDbSyncEngine, getSyncPassphrase, isSuppressedError } from '@glance-apps/sync'
 import { makeDbAdapter } from './dbAdapter.js'
 import { makeRealStore } from './dbStore.js'
 import { registerDirtyTarget } from './dirty.js'
@@ -160,6 +160,27 @@ export const initDbSyncEngine = (opts = {}) => {
     vaultClient: opts.vaultClient,
     fetchImpl: opts.fetchImpl,
 
+    // Cursor durability contract (@glance-apps/sync 2.0.0). DECLARED, not
+    // inherited: 2.0.0 flipped the default to 'end-of-pull', so saying nothing
+    // here would silently give up 1.10.0's mid-pagination resume and re-open the
+    // convergence bug that release fixed — a large backlog on a flaky connection
+    // re-downloading from the start on every failure instead of resuming from
+    // the last good page. That regression presents as a network problem, not as
+    // a config gap, so it must be stated rather than assumed.
+    //
+    // 'per-page' is the correct mode for lifeGLANCE because our apply IS durable
+    // on return: applyRemoteEntity goes through dbAdapter straight into
+    // IDB/localStorage, with no per-cycle mirror that a later failure could
+    // discard. A persisted cursor is therefore always behind committed state.
+    // The default flipped because that is not true of every caller (a
+    // commit-only-on-success composer loses rows under 'per-page'), not because
+    // per-page is wrong for the callers it fits.
+    //
+    // An unrecognised value is REFUSED at construction — 'perPage', 'per_page'
+    // and 'PER-PAGE' all throw naming every valid mode — so a typo here fails
+    // loudly instead of quietly restoring the unsafe path.
+    pullCursorCommit: 'per-page',
+
     getLocalEntity:        adapter.getLocalEntity,
     applyRemoteEntity:     adapter.applyRemoteEntity,
     applyRemoteDelete:     adapter.applyRemoteDelete,
@@ -274,13 +295,25 @@ export const initDbSyncEngine = (opts = {}) => {
   // here too — a backgrounded first write can establish the salt before any
   // full sync does.
   //
-  // Honour the sync 1.10 credential halt here as well: pushDirtyRows is a raw
-  // primitive with no halt guard, so without this check every local edit on a
-  // halted device would fire one doomed (401) batch request. The halt is
-  // terminal by design — the cycle stops, and so should push-on-write. Rows
-  // stay marked dirty, so everything pushes once access is restored.
+  // NO APP-SIDE GUARD (sync 2.0.0). This used to carry its own
+  // isCredentialHalted() check, because pushDirtyRows was a raw primitive with
+  // no protections and push-on-write therefore bypassed all of them. 2.0.0's
+  // Phase 4a moved enforcement DOWN into the primitives: pushDirtyRows now
+  // refuses while the credential halt stands, refuses while the push backoff
+  // window is open, and opens/escalates/clears that window itself. The app-side
+  // guard became redundant, and keeping it would only mean two places deciding
+  // the same thing.
+  //
+  // What lifeGLANCE gains here it never had: push-on-write calls pushDirtyRows
+  // directly, so backoff, quota suppression and the credential halt now apply to
+  // every local edit, not just to the 60s cadence cycle.
+  //
+  // Both refusals arrive as a THROW rather than a return value (see
+  // pushDebounced): a halt throws CREDENTIAL_INVALID with halted:true, an open
+  // window throws SYNC_SUPPRESSED. Neither makes a network call, and neither
+  // clears the dirty set — rows stay marked and push once the halt is lifted or
+  // the window lapses.
   const pushNow = async () => {
-    if (engine.isCredentialHalted?.()) return { written: 0, deleted: 0, halted: true }
     await seedSnapshot()
     const r = await engine.pushDirtyRows()
     await bootstrapIntentsRootKey()
@@ -288,7 +321,18 @@ export const initDbSyncEngine = (opts = {}) => {
   }
   const pushDebounced = (ms = 4000) => {
     clearTimeout(_pushTimer)
-    _pushTimer = setTimeout(() => { pushNow().catch(err => console.warn('[dbsync] push failed', err)) }, ms)
+    _pushTimer = setTimeout(() => {
+      pushNow().catch(err => {
+        // Two of these are the engine DELIBERATELY declining, not a failure:
+        // SYNC_SUPPRESSED (an open backoff window — the next cadence cycle
+        // retries) and the credential halt (terminal, and it has its own UI path
+        // via the cycle's onError). Logging either as "push failed" would make a
+        // deliberately stopped device look like it is failing continuously — on
+        // a halted device, once per keystroke-triggered write.
+        if (isSuppressedError(err) || err?.halted) return
+        console.warn('[dbsync] push failed', err)
+      })
+    }, ms)
   }
 
   // Register the dirty target so EVERY local write (not just milestone/chapter

--- a/src/sync/dbSync.test.js
+++ b/src/sync/dbSync.test.js
@@ -10,9 +10,22 @@
 //
 // markDirty is driven through the real data layer (addMilestone etc.), proving
 // the explicit call sites are wired.
+//
+// @glance-apps/sync 2.0.0 added four more, all about the push-on-write path
+// (pushNow calls pushDirtyRows directly, so it inherits the primitives' own
+// enforcement now instead of bypassing it):
+//   • the credential halt refuses the push — same behaviour as before the
+//     app-side guard was deleted, reported through a throw rather than a return;
+//   • an open push backoff window refuses the push (NEW — lifeGLANCE never had
+//     backoff on push-on-write at all);
+//   • the declared 'per-page' pull cursor advances between pages and resumes a
+//     failed pull from the last good one;
+//   • the standing-backoff state and copy the Cloud Sync modal will render from
+//     a push-on-write failure.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { IDBFactory } from 'fake-indexeddb'
+import { describeBackoff, backoffStatusText } from './backoffStatus.js'
 
 // Minimal localStorage for the node test environment (fake-indexeddb supplies
 // IndexedDB only). The app's bundles/config live in localStorage.
@@ -31,7 +44,7 @@ function makeMemVault() {
   const rows = new Map()
   let seq = 0
   const salts = new Map()
-  return {
+  const v = {
     async batch(app, { rows: upserts }) {
       for (const r of upserts) { seq += 1; rows.set(r.entityId, { entityId: r.entityId, envelope: r.envelope, deleted: false, seq }) }
       return { written: upserts.length, maxSeq: seq }
@@ -41,9 +54,15 @@ function makeMemVault() {
       rows.set(entityId, { entityId, envelope: prev?.envelope, deleted: true, seq })
       return { seq }
     },
+    // `pageSize` lets a test force real pagination (several round trips in one
+    // pull), which is what the cursor-durability tests below need: a mode that
+    // only ever sees a single page would pass under every pullCursorCommit
+    // value and prove nothing.
+    pageSize: Infinity,
     async list(app, { since }) {
       const out = [...rows.values()].filter(r => r.seq > since).sort((a, b) => a.seq - b.seq)
-      return { rows: out, hasMore: false }
+      const page = out.slice(0, v.pageSize)
+      return { rows: page, hasMore: out.length > page.length }
     },
     async getRow(app, entityId) { return rows.get(entityId) ?? null },
     async device() { return { updated: true } },
@@ -51,6 +70,7 @@ function makeMemVault() {
     async putSalt(accountId, salt) { if (!salts.has(accountId)) salts.set(accountId, salt); return salts.get(accountId) },
     _rows: rows,
   }
+  return v
 }
 
 const VAULT_CFG = { vaultEnabled: true, vaultUrl: 'http://vault.test', vaultToken: 'tok', accountId: 'acct-1' }
@@ -62,9 +82,12 @@ async function freshModules() {
   const db = await import('../data/db.js')
   await db.initDB()
   const milestones = await import('../data/milestones.js')
-  const { initDbSyncEngine, getDbSyncEngine, readVaultConfig } = await import('./dbSync.js')
-  const { setSyncPassphrase, setupDbRootKey } = await import('@glance-apps/sync')
-  return { db, milestones, initDbSyncEngine, getDbSyncEngine, readVaultConfig, setSyncPassphrase, setupDbRootKey }
+  const { initDbSyncEngine, getDbSyncEngine, readVaultConfig, clearCredentialHalt } = await import('./dbSync.js')
+  const { setSyncPassphrase, setupDbRootKey, isSuppressedError } = await import('@glance-apps/sync')
+  return {
+    db, milestones, initDbSyncEngine, getDbSyncEngine, readVaultConfig, clearCredentialHalt,
+    setSyncPassphrase, setupDbRootKey, isSuppressedError,
+  }
 }
 
 describe('Stage 2 Part B — DB sync engine wiring', () => {
@@ -182,10 +205,25 @@ describe('Stage 2 Part B — DB sync engine wiring', () => {
     expect(fired).toBeGreaterThan(0)
   })
 
-  // The sync 1.10 credential halt must gate push-on-write too: pushDirtyRows is
-  // a raw primitive with no halt guard, so pushNow checks the halt itself.
-  // Local edits stay dirty and push once access is restored via recovery.
-  it('push-on-write goes silent under the sync 1.10 credential halt', async () => {
+  // The credential halt must gate push-on-write. THE BEHAVIOUR ASSERTED HERE IS
+  // UNCHANGED — a halted device makes no push request and keeps its rows dirty —
+  // but the REPORTING CHANNEL MOVED in @glance-apps/sync 2.0.0, so this test had
+  // to move with it.
+  //
+  // Before 2.0.0, pushDirtyRows was a raw primitive with no halt guard, so
+  // pushNow carried its own isCredentialHalted() check and RETURNED
+  // {written: 0, deleted: 0, halted: true} — a shape invented by that app-side
+  // guard, not by the engine. 2.0.0 moved enforcement into the primitive, the
+  // guard was deleted as redundant, and the engine THROWS instead: a coded
+  // CREDENTIAL_INVALID error with halted:true (halted marks it as raised from
+  // stored halt state rather than a fresh server rejection, so the halt's
+  // timestamp is not rewritten on every refused call).
+  //
+  // So the old assertion did not break because the behaviour changed. It broke
+  // because it was asserting the guard's return value rather than the engine's
+  // enforcement. The two load-bearing assertions — no network attempt, rows left
+  // dirty — are identical and still here.
+  it('push-on-write goes silent under the credential halt', async () => {
     const m = await freshModules()
     localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
     const vault = makeMemVault()
@@ -213,8 +251,269 @@ describe('Stage 2 Part B — DB sync engine wiring', () => {
 
     reject = false                        // server would accept again; the halt is terminal anyway
     const before = batchCalls
-    const res = await dbSync.pushNow()
+    await expect(dbSync.pushNow()).rejects.toMatchObject({ code: 'CREDENTIAL_INVALID', halted: true })
     expect(batchCalls).toBe(before)       // no network attempt from push-on-write
-    expect(res).toEqual({ written: 0, deleted: 0, halted: true })
+    // Rows are NOT consumed by a refused push: they stay dirty and upload once
+    // access is restored via recovery.
+    expect(JSON.parse(localStorage.getItem('lifeglance-db-sync-dirty')).length).toBeGreaterThan(0)
+
+    // NEGATIVE CONTROL (in-suite, vacuity check). The assertions above must fail
+    // when the halt is absent — otherwise "no network attempt" would pass for a
+    // push that simply had nothing to send. Clearing the halt key is the only
+    // difference; the same pushNow then reaches the network and succeeds.
+    m.clearCredentialHalt()
+    expect(dbSync.engine.isCredentialHalted()).toBe(false)
+    const res = await dbSync.pushNow()
+    expect(batchCalls).toBeGreaterThan(before)   // the request the halt was suppressing
+    expect(res.written).toBeGreaterThan(0)
+  })
+
+  // NEW IN 2.0.0, AND THE REASON THIS BUMP IS MORE THAN A VERSION NUMBER.
+  // pushDirtyRows now refuses to run while the push backoff window is open,
+  // rejecting with a typed SYNC_SUPPRESSED *before any network call*. lifeGLANCE
+  // never had this on the push-on-write path: pushNow calls the primitive
+  // directly, so before 2.0.0 every debounced local edit went out regardless of
+  // how recently a push had failed.
+  it('push-on-write respects an open push backoff window', async () => {
+    const m = await freshModules()
+    localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+    const vault = makeMemVault()
+    m.setSyncPassphrase('pw')
+    await m.setupDbRootKey('pw', new Uint8Array(16).fill(11), { cryptoDBName: 'lifeglance-crypto' })
+
+    let batchCalls = 0
+    let failNext = true
+    const realBatch = vault.batch
+    vault.batch = async (app, payload) => {
+      batchCalls += 1
+      if (failNext) {
+        const err = new Error('fetch failed')
+        err.code = 'NETWORK_ERROR'
+        throw err
+      }
+      return realBatch(app, payload)
+    }
+
+    const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+    await m.milestones.addMilestone({ title: 'First write', date: new Date('2022-01-01') })
+
+    // A failed push-on-write now OPENS the push window itself (the primitive
+    // owns the ladder, not just the cycle).
+    await expect(dbSync.pushNow()).rejects.toBeTruthy()
+    const window = dbSync.engine.getBackoffState().push
+    expect(window.until).toBeGreaterThan(Date.now())
+    expect(window.reason).toBe('transport')
+
+    // A second local edit while the window stands is REFUSED before the network.
+    failNext = false                        // the server would accept now; the window still says no
+    const before = batchCalls
+    await m.milestones.addMilestone({ title: 'Second write', date: new Date('2022-02-02') })
+    const err = await dbSync.pushNow().then(() => null, e => e)
+    expect(m.isSuppressedError(err)).toBe(true)
+    expect(err.direction).toBe('push')
+    expect(err.retryAt).toBeGreaterThan(Date.now())
+    expect(batchCalls).toBe(before)         // nothing went out
+    // Suppression changes WHEN rows are retried, never WHETHER: both writes are
+    // still dirty, and a suppressed call must not extend the window that
+    // suppressed it (otherwise an open window feeds itself).
+    expect(JSON.parse(localStorage.getItem('lifeglance-db-sync-dirty')).length).toBeGreaterThan(1)
+    expect(dbSync.engine.getBackoffState().push.strikes).toBe(window.strikes)
+
+    // NEGATIVE CONTROL (in-suite, vacuity check). With the window lapsed, the
+    // very same pushNow reaches the network — so "nothing went out" above is
+    // the gate refusing, not an empty dirty set or a broken vault stub. Only
+    // Date.now is moved (the engine's isOpen() reads it); no fake timers, which
+    // would interfere with the real crypto in the push path.
+    const realNow = Date.now
+    Date.now = () => realNow.call(Date) + (err.retryInMs + 1000)
+    try {
+      const res = await dbSync.pushNow()
+      expect(batchCalls).toBeGreaterThan(before)
+      expect(res.written).toBeGreaterThan(0)
+    } finally {
+      Date.now = realNow
+    }
+  })
+
+  // The cursor durability contract (2.0.0 Phase 4b). lifeGLANCE DECLARES
+  // 'per-page'; the package default is now 'end-of-pull'. These two tests are
+  // the ones that would fail if the declaration were ever dropped — which is the
+  // whole point of writing them, since the regression otherwise presents as a
+  // network problem rather than a config gap.
+  describe('pull cursor durability — the declared per-page mode', () => {
+    it('advances the cursor per page across a multi-page pull, not only at the end', async () => {
+      const m = await freshModules()
+      localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+      const vault = makeMemVault()
+      m.setSyncPassphrase('pw')
+      await m.setupDbRootKey('pw', new Uint8Array(16).fill(13), { cryptoDBName: 'lifeglance-crypto' })
+
+      // Seed 9 rows on a writer device, then read them back on a fresh one.
+      const writer = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+      for (let i = 1; i <= 9; i++) {
+        await m.milestones.addMilestone({ title: `Row ${i}`, date: new Date(`2018-0${(i % 9) + 1}-01`) })
+      }
+      await writer.pushNow()
+
+      const r = await freshModules()
+      localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+      localStorage.setItem('lifeglance-db-sync-seeded', '1')  // reader has nothing of its own to push
+      r.setSyncPassphrase('pw')
+      await r.setupDbRootKey('pw', new Uint8Array(16).fill(13), { cryptoDBName: 'lifeglance-crypto' })
+
+      // Page the vault so one pull needs several round trips, and record the
+      // persisted cursor as it stands at the START of each page request.
+      vault.pageSize = 3
+      const cursorAtEachPage = []
+      const realList = vault.list
+      vault.list = async (app, args) => {
+        cursorAtEachPage.push(Number(localStorage.getItem('lifeglance-db-sync-hwm') || 0))
+        return realList.call(vault, app, args)
+      }
+
+      const reader = r.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+      await reader.engine.pullRemoteChanges()
+
+      // Under 'per-page' the cursor moves BETWEEN pages. Under the 2.0.0 default
+      // this array would be all zeroes — which is exactly the assertion that
+      // catches a dropped declaration.
+      expect(cursorAtEachPage.length).toBeGreaterThan(1)
+      expect(cursorAtEachPage[0]).toBe(0)
+      expect(cursorAtEachPage[1]).toBeGreaterThan(0)
+      expect(cursorAtEachPage.at(-1)).toBeGreaterThan(cursorAtEachPage[1] - 1)
+      vault.list = realList
+    })
+
+    it('resumes from the last good page after a mid-pagination failure', async () => {
+      const m = await freshModules()
+      localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+      const vault = makeMemVault()
+      m.setSyncPassphrase('pw')
+      await m.setupDbRootKey('pw', new Uint8Array(16).fill(17), { cryptoDBName: 'lifeglance-crypto' })
+
+      const writer = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+      for (let i = 1; i <= 9; i++) {
+        await m.milestones.addMilestone({ title: `Row ${i}`, date: new Date(`2017-0${(i % 9) + 1}-01`) })
+      }
+      await writer.pushNow()
+
+      const r = await freshModules()
+      localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+      localStorage.setItem('lifeglance-db-sync-seeded', '1')
+      r.setSyncPassphrase('pw')
+      await r.setupDbRootKey('pw', new Uint8Array(16).fill(17), { cryptoDBName: 'lifeglance-crypto' })
+
+      vault.pageSize = 3
+      let listCalls = 0
+      const realList = vault.list
+      vault.list = async (app, args) => {
+        listCalls += 1
+        if (listCalls === 3) {                       // die mid-pagination
+          const err = new Error('connection lost')
+          err.code = 'NETWORK_ERROR'
+          throw err
+        }
+        return realList.call(vault, app, args)
+      }
+
+      const reader = r.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+      await expect(reader.engine.pullRemoteChanges()).rejects.toBeTruthy()
+
+      // The pages that DID land are committed: the cursor sits past them rather
+      // than back at the start. Under 'end-of-pull' this would still be 0 and the
+      // retry would re-download the whole backlog — the convergence bug 1.10.0
+      // fixed and the 2.0.0 default silently reintroduces.
+      const resumeFrom = Number(localStorage.getItem('lifeglance-db-sync-hwm') || 0)
+      expect(resumeFrom).toBeGreaterThan(0)
+
+      // The failed pull ALSO opened the pull backoff window — 2.0.0 gates both
+      // primitives, so an immediate retry is refused before any network call.
+      // That is correct and is asserted elsewhere for the push; here it just
+      // means the resume has to wait the window out, so move Date.now past it
+      // (the engine's isOpen() reads it) rather than using fake timers, which
+      // would interfere with the real crypto in the pull path.
+      const pullWindow = reader.engine.getBackoffState().pull
+      expect(pullWindow.until).toBeGreaterThan(Date.now())
+      const realNow = Date.now
+      Date.now = () => realNow.call(Date) + (pullWindow.until - realNow.call(Date)) + 1000
+
+      // The retry asks the server to continue from there, not from zero.
+      const sinceValues = []
+      vault.list = async (app, args) => { sinceValues.push(args.since); return realList.call(vault, app, args) }
+      try {
+        await reader.engine.pullRemoteChanges()
+      } finally {
+        Date.now = realNow
+        vault.list = realList
+      }
+      expect(sinceValues[0]).toBe(resumeFrom)
+    })
+  })
+
+  // WHAT THE CLOUD SYNC MODAL WILL SHOW, from a push-on-write failure.
+  //
+  // This state is NEW. Before 2.0.0 only the cadence cycle could open a backoff
+  // window, so the modal's standing-backoff banner (issue #307) never had a
+  // push-on-write failure as its source. Now it does.
+  //
+  // SCOPE OF THIS TEST, stated rather than implied: it drives a REAL engine to a
+  // real push-on-write failure and runs the resulting getBackoffState() through
+  // the exact pipeline CloudSyncModal.jsx uses (describeBackoff →
+  // backoffStatusText) against the real en/sync.json strings. It verifies the
+  // STATE and the COPY. It does NOT mount the component — this repo has no
+  // React testing library and tests run in a node environment — so it is not a
+  // render test. The banner itself is unchanged code shipped in v3.3.0; only its
+  // input source is new. Confirming it paints is one look at a device.
+  describe('standing backoff in the Cloud Sync modal, from a push-on-write failure', () => {
+    const enStrings = (key, opts) => ({
+      backoffTransport: `Can't reach the sync server. Retrying in ${opts?.seconds}s.`,
+      backoffAuth: 'The sync server rejected the sign-in. Next retry in about an hour. Check your device token in sync settings.',
+      backoffRetrying: 'Retrying on the next sync…',
+    }[key])
+
+    const failingPush = async (fill, makeError) => {
+      const m = await freshModules()
+      localStorage.setItem('lifeglance-cloud-sync-config', JSON.stringify(VAULT_CFG))
+      const vault = makeMemVault()
+      m.setSyncPassphrase('pw')
+      await m.setupDbRootKey('pw', new Uint8Array(16).fill(fill), { cryptoDBName: 'lifeglance-crypto' })
+      vault.batch = async () => { throw makeError() }
+      const dbSync = m.initDbSyncEngine({ vaultConfig: VAULT_CFG, vaultClient: vault })
+      await m.milestones.addMilestone({ title: 'Write that cannot land', date: new Date('2023-03-03') })
+      await dbSync.pushNow().catch(() => {})
+      return dbSync.engine.getBackoffState()
+    }
+
+    it('a transport failure renders the counting-down banner', async () => {
+      const state = await failingPush(21, () => Object.assign(new Error('fetch failed'), { code: 'NETWORK_ERROR' }))
+      const d = describeBackoff(state, Date.now())
+      expect(d).toMatchObject({ reason: 'transport', side: 'push' })
+      expect(d.secondsLeft).toBeGreaterThan(0)
+      expect(backoffStatusText(enStrings, d)).toMatch(/^Can't reach the sync server\. Retrying in \d+s\.$/)
+
+      // Once the window lapses (the engine clears it only on a SUCCEEDING cycle),
+      // the banner stays put and says so rather than vanishing while sync is
+      // still unproven.
+      const lapsed = describeBackoff(state, d.until + 1000)
+      expect(lapsed.secondsLeft).toBe(0)
+      expect(backoffStatusText(enStrings, lapsed)).toBe('Retrying on the next sync…')
+    })
+
+    it('a 401 renders the flat-hour auth banner, which names the actionable fix', async () => {
+      const state = await failingPush(22, () => Object.assign(new Error('invalid device token'), { code: 'AUTH_FAILURE', status: 401 }))
+      const d = describeBackoff(state, Date.now())
+      expect(d.reason).toBe('auth')
+      expect(backoffStatusText(enStrings, d)).toContain('Check your device token in sync settings')
+    })
+
+    it('a quota failure stays out of the banner and keeps its own descriptor', async () => {
+      const state = await failingPush(23, () => Object.assign(new Error('over quota'), {
+        code: 'QUOTA_EXCEEDED', quota: { quota: 'rows', limit: 100, used: 100, requested: 1 },
+      }))
+      // Excluded by design: the engine re-surfaces QUOTA_EXCEEDED with its
+      // descriptor on every cycle, so a second banner would double-report.
+      expect(describeBackoff(state, Date.now())).toBeNull()
+      expect(state.push.reason).toBe('quota')
+    })
   })
 })


### PR DESCRIPTION
Bumps `@glance-apps/sync` 1.10.0 → 2.0.0, declares `pullCursorCommit: 'per-page'`, and deletes `pushNow`'s now-redundant credential-halt guard.

**Tests 814 → 820. Lint 0 errors (27 pre-existing warnings, unchanged). Build green.**

---

## The negative control, first — because it is the evidence this PR actually rests on

Deleting the app-side halt guard is safe **only if** the engine is what refuses the push. An in-suite test cannot establish that: with 2.0.0 installed, a passing test proves *something* refuses, not *what*. So the two tests were run against **1.10.0 with the app-side guard already deleted** — the exact state this PR would be in if the enforcement were not really there.

Both fail, and they fail in the two different ways that matter.

**Halt test on 1.10.0, guard deleted:**

```
AssertionError: promise resolved "{ written: 5, deleted: +0, maxSeq: 6 }" instead of rejecting
 ❯ await expect(dbSync.pushNow()).rejects.toMatchObject({ code: 'CREDENTIAL_INVALID', halted: true })
```

The halted device **pushed 5 rows to the server**. Not refused, not throttled — the doomed batch the guard existed to prevent, going out on a device the server has already rejected. This is what the deletion would cost without 2.0.0 underneath it.

**Backoff-window test on 1.10.0, guard deleted:**

```
AssertionError: expected 0 to be greater than 1788111577711
 ❯ expect(window.until).toBeGreaterThan(Date.now())
```

Fails at the *first* assertion: `until: 0`. A failed push-on-write on 1.10.0 opens no window at all, because the primitive carried no ladder. There is nothing to respect, which is the point.

Both pass on 2.0.0 with no app-side guard. The enforcement is the engine's.

Each test also carries an in-suite vacuity check (clear the halt / move `Date.now` past `retryAt` → the same `pushNow` reaches the network and succeeds), so "nothing went out" is never passing on an empty dirty set.

## Why the cursor mode is declared

2.0.0 flipped the default to `'end-of-pull'`. Saying nothing would silently give up 1.10.0's mid-pagination resume. Nine rows, page size three, failure on the third page:

| mode | cursor at each page request | after the failure | next pull restarts from |
|---|---|---|---|
| `'end-of-pull'` (new default) | `0, 0, 0` | **0** | **seq 0 — full re-download** |
| `'per-page'` (declared here) | `0, 3, 6` | **6** | **seq 6 — resumes** |

That is the convergence bug 1.10.0 fixed, and it would come back as a *network* problem weeks after the bump, not as a config gap. One line prevents it.

`'per-page'` is correct for lifeGLANCE because `applyRemoteEntity` goes through `dbAdapter` straight into IDB/localStorage — durable on return, no per-cycle mirror a later failure could discard, so a persisted cursor is always behind committed state. The default flipped because that is not true of every caller, not because per-page is wrong for the ones it fits.

Typos are refused at construction rather than defaulted: `'perPage'`, `'per_page'` and `'PER-PAGE'` each throw naming every valid mode.

## The deleted guard, and why the test change is not a behaviour change

`pushNow` carried `if (engine.isCredentialHalted?.()) return { written: 0, deleted: 0, halted: true }`. That is exactly what Phase 4a moved into `pushDirtyRows`, so it went.

`dbSync.test.js` asserted that `{written: 0, deleted: 0, halted: true}` shape — **invented by the guard, not by the engine**. The engine does not return; it throws `CREDENTIAL_INVALID` with `halted: true` (the flag marks a refusal raised from *stored* halt state rather than a fresh server rejection, so the halt's timestamp is not rewritten on every refused call).

So the old assertion did not break because behaviour changed. It broke because it was asserting the guard's return value rather than the engine's enforcement. The test now asserts the throw. **The two load-bearing assertions are identical and still there: no network attempt, rows left dirty.** Called out in the test comment as well as here.

## What `pushNow` does on a suppressed push

Nothing, and it says nothing. It keeps propagating — the tests want to see the throw, and the debounce is the right place to decide what is worth reporting. Rows stay dirty; the 60s cadence cycle picks them up. lifeGLANCE has no retry ladder of its own, so the compounding-brakes hazard the 2.0.0 notes warn about does not apply.

## The one addition beyond the bump, the config line and the deletion

```js
if (isSuppressedError(err) || err?.halted) return
console.warn('[dbsync] push failed', err)
```

Two lines in `pushDebounced`'s catch. **Changes no behaviour — console output only.** Without it, every keystroke-triggered write on a halted device logs `[dbsync] push failed CREDENTIAL_INVALID` where today it logs silence, making a deliberately stopped device look like it is failing continuously. `err.halted` is the worse of the two cases and is why it is in there alongside `isSuppressedError`.

## The new modal state — no copy change

A failed `pushNow` now opens the push window, so the Cloud Sync modal's standing-backoff banner (#307) will start showing backoff from push-on-write, which never happened before. Verified against a real engine driven to a real push-on-write failure, run through the exact pipeline the modal uses:

| push-on-write failure | banner renders |
|---|---|
| transport | `Can't reach the sync server. Retrying in 30s.` (counts down) |
| 401 | `The sync server rejected the sign-in. … Check your device token in sync settings.` |
| window lapsed | `Retrying on the next sync…` |
| quota | nothing — excluded by design, quota has its own standing display |

The copy never mentions which side or what triggered the window, so a push-on-write window reads identically to a cadence one. **No copy change needed.**

One genuinely new appearance, and it reads correctly: the amber banner can now show with **no red error banner above it**, because a push-on-write failure opens the window without setting `vaultError`. That is exactly what `backoffStatus.js` was built for — confirmed that `surfaceStandingWindow` re-emits `onError` for quota only, so transport and auth windows stay deliberately quiet on the cycle and the banner is the only truthful source.

**Stated rather than implied:** this verifies the backoff *state* and the *strings*. It does **not** mount `CloudSyncModal` — the repo has no React testing library and tests run in a node environment. The banner is unchanged code shipped in v3.3.0 with only its input source new. If a visual check is ever wanted, it is one look at a device. Nothing in this PR needs a real GLANCEvault server.

## A gain worth naming, so it does not read as a regression later

Today a revoked credential seen only by push-on-write sets **no halt at all**, because the raw primitive did not set one. After this bump it does — so the next cycle surfaces the halt instead of the device pushing doomed 401 batches until a cadence cycle happens to run.

The halt still reaches the user by the same route it always did: push-on-write sets the state, the next cadence cycle's `pushDirtyRows` throws, the cycle routes it through `applyCredentialRejection` → `onError(msg, 'CREDENTIAL_INVALID', hard=true)` → `App.jsx` `vaultError.hard` → `combineTierErrors` → red banner. The guard never surfaced it; deleting it moves nothing user-visible.

## What lifeGLANCE gains that it never had

**Enforcement on the push-on-write path.** `pushNow` calls `pushDirtyRows()` directly, so before this bump every debounced local edit bypassed backoff, quota suppression and the credential halt — all three lived only in `dbSyncCycle`. A device that had just failed a push would send the next edit straight back at the same server. Now it does not, and that is the reason this is more than a version number.

## Regression guards

- **Cursor behaviour unchanged from today** — that is what declaring `'per-page'` is for; the table above is the proof.
- **`pushNow` still pushes on the normal path** — the three pre-existing push-on-write tests are untouched and green.
- **The credential halt still reaches the user** — traced end to end above.
- **Existing users see no change in normal operation** — no config migration, no storage-key change, no cursor movement.

## Scope

Skips **1.11.0** (intents transport, device-wide 429 brake, write-loop detector) and **1.12.0**. The 429 brake arrives regardless because it is module-scope; adopting the package's intents transport is a separate decision, since lifeGLANCE keeps its own in `src/lib/intentsTransport.js`.

Not built: the `pushNow` guard previously queued as future work — it is unnecessary now, which is the point.

## Files

| File | Change |
|---|---|
| `package.json` / lock | `@glance-apps/sync` 1.10.0 → 2.0.0 |
| `src/sync/dbSync.js` | +1 `pullCursorCommit: 'per-page'`; −1 the halt guard; +2 the debounce catch branch; import `isSuppressedError` |
| `src/sync/dbSync.test.js` | halt test rewritten to the thrown shape; new tests for the suppressed push, per-page cursor advance, mid-pagination resume, and the modal's backoff state and copy |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj7y9wwcUS6w7fq7d5MXyh)_