### PR TITLE
Release 3.3.1: version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifeglance",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifeglance",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifeglance",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump only — `package.json` + lock, three lines. Same shape as the 3.3.0 release commit.

`package.json` is the single version source: `android/app/build.gradle` derives `versionName`/`versionCode` from it at build time, and `scripts/sync-ios-version.mjs` carries `MARKETING_VERSION` to every iOS target during `build:ios`. Release notes go on the GitHub Release for the v3.3.1 tag.

## What is in the release

The v3.3.0 tag sits at `de91d99`, so everything between it and here is one PR:

| | |
|---|---|
| `e70868a` | Adopt `@glance-apps/sync` 2.0.0 (#333) |
| `5f9e132` | this version bump |

Touching `package.json`, `package-lock.json`, `src/sync/dbSync.js`, `src/sync/dbSync.test.js` — nothing else rides along.

## Why patch and not minor

No new feature and nothing added to the UI. This is a correctness fix: the debounced push-on-write calls `pushDirtyRows()` directly, so it bypassed backoff, quota suppression and the credential halt — all three lived only in `dbSyncCycle`. A device that had just failed a push would send the next local edit straight back at the same server. `@glance-apps/sync` 2.0.0 moves enforcement into the primitives, so push-on-write now inherits all three.

The dependency's own major bump is about *its* callers' contract, not this app's. Patch releases are the established pattern here (v2.6.1, v2.6.2, v2.6.3, v3.0.1).

## User-visible change

One, and it is the correctness fix showing honestly rather than a new feature: the Cloud Sync modal's standing-backoff banner can now appear from a push-on-write failure, where previously only the 60s cadence cycle could open a window. Existing banner, existing copy (verified against the real strings — no copy change was needed), new trigger. Normal operation is unchanged: no config migration, no storage-key change, no cursor movement.

## Verification

- 820 tests / 48 files pass
- lint 0 errors (27 pre-existing warnings, unchanged)
- `npm run build` green
- Android `versionCode` derivation checked: 3.3.1 → `30301000`, above 3.3.0's `30300000`, and minor/patch stay under the 100 limit `build.gradle` assumes

## After merge

Tag `v3.3.1` at the merge commit and publish the GitHub Release. Happy to draft the release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj7y9wwcUS6w7fq7d5MXyh)_