### PR TITLE
Make the sideload build identifiable, and verifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ A native Android app is available on Google Play and as a direct APK download. T
 [**Get it on Obtainium →**](https://github.com/ImranR98/Obtainium)
 <br> *Just point Obtainium to `krelltunez/lifeGLANCE`!*
 
+### Which build am I running?
+
+The two Android builds differ in one way only: the **Play** build is a paid app
+(subscription or one-off lifetime unlock), the **GitHub APK is fully unlocked** —
+no paywall, no billing, every feature on. They otherwise share a package name,
+app name, icon and version, so once installed they look identical. Two ways to
+tell them apart:
+
+- **Settings → subscription.** The GitHub APK says *"This build is fully
+  unlocked."* The Play build shows a purchase status and a *Manage subscription*
+  button instead.
+- **The version.** The sideload APK's version ends in `-github`, e.g.
+  `3.3.1-github` (releases up to 3.3.1 do not carry this marker yet).
+
+**If you are seeing a paywall, you are running the Play build.** Third-party
+mirrors (APKPure, APKMirror, Aptoide and similar) republish the *Play* build
+under the same name and version — only the [Releases
+page](https://github.com/krelltunez/lifeGLANCE/releases) and Obtainium serve the
+ungated one. Switching from the Play build to the sideload APK needs an
+uninstall (the signing keys differ, so Android cannot update one into the
+other), and **uninstalling erases local data — export first**, or set up
+[sync](#sync--storage) before you switch.
+
+### Verifying the APK
+
+Every release publishes `SHA256SUMS.txt` next to the APK:
+
+```bash
+sha256sum -c SHA256SUMS.txt      # run in the folder you downloaded into
+```
+
+The APK is signed with this certificate — any APK claiming to be lifeGLANCE
+with a different fingerprint was not built by us:
+
+```
+SHA-256: 31:7B:61:C1:05:34:F6:6B:4A:51:37:5F:4C:00:43:90:4B:6C:08:C7:AA:AA:AF:24:17:D2:57:64:D0:F3:D0:D0
+```
+
+```bash
+apksigner verify --print-certs lifeglance-github.apk
+```
+
+(The Play copy is re-signed by Google Play App Signing, so it legitimately shows
+a *different* fingerprint — that is itself a way to tell the two apart.)
+
 The Android app ships the full web app in a WebView with native enhancements that aren't possible in a browser:
 
 | Feature | Details |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ apksigner verify --print-certs lifeglance-github.apk
 ```
 
 (The Play copy is re-signed by Google Play App Signing, so it legitimately shows
-a *different* fingerprint — that is itself a way to tell the two apart.)
+a *different* fingerprint — that is itself a way to tell the two apart. A
+single-engine antivirus flag on the sideload APK is the same story: the two
+signatures differ by design.)
 
 The Android app ships the full web app in a WebView with native enhancements that aren't possible in a browser:
 

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,9 @@ done
 
 # Opt-in inspectable WebView for billing/entitlement testing on Play-signed
 # release builds (capacitor.config.js reads CAP_WEBVIEW_DEBUG at cap sync).
-# See docs/paywall-billing-plan.md Lessons 7/8.
+# Play Billing only runs on the Play-signed release build, whose WebView is
+# otherwise not inspectable, so entitlement state can only be reset via
+# chrome://inspect on a build made with this flag.
 if $WEBVIEW_DEBUG; then
   export CAP_WEBVIEW_DEBUG=1
   echo "!!=========================================================================!!"
@@ -84,30 +86,57 @@ if $RELEASE; then
   # Release builds are signed when android/key.properties is present (see
   # android/key.properties.example); without it they fall back to UNSIGNED.
   #
-  # Web assets are built TWICE — the distribution channels differ on purpose
-  # (docs/paywall-billing-plan.md §5):
+  # Web assets are built TWICE — the two distribution channels differ on purpose:
   #   1. VITE_BUILD_CHANNEL=github → sideload APK, UNGATED (no paywall)
   #   2. VITE_BUILD_CHANNEL=play   → Play AAB, GATED (Play Billing paywall)
+  # The channel is baked in at Vite build time: src/billing/billing.js builds a
+  # billing adapter only for 'play' on Android, and @glance-apps/billing treats
+  # a null adapter as ungated, so any other value ships an unlocked app.
   # Each pass runs cap sync, so the native capacitor.config.json is rewritten
   # per build (including the CAP_WEBVIEW_DEBUG flag) without a clean.
+  #
+  # The two artifacts share an applicationId, app name, icon and versionCode —
+  # only the web assets and the signing key differ — so the sideload build is
+  # marked in the two places a user can actually look: the file name
+  # (lifeglance-github.apk, matching dayGLANCE's) and the versionName
+  # (3.3.1-github). Without that, "the GitHub APK is showing me the paywall"
+  # cannot be told apart from "I am running the Play build".
+
+  # The suffix is appended to package.json's version for the sideload APK only
+  # (the AAB must keep the clean x.y.z name Play expects). --version-suffix
+  # still wins for interim builds: 3.3.1-rc1-github.
+  GITHUB_VERSION_SUFFIX="${VERSION_SUFFIX:+$VERSION_SUFFIX-}github"
+
+  # Artifacts this script wrote under its pre-rename names. Left in place they
+  # are indistinguishable from a fresh build in outputs/ and are exactly the
+  # wrong file to attach to a release, so clear them (they were overwritten on
+  # every run anyway).
+  for stale in lifeglance.apk lifeglance-unsigned.apk; do
+    if [ -f "$OUT_DIR/$stale" ]; then
+      echo "==> Removing stale $stale from a pre-rename build..."
+      rm -f "$OUT_DIR/$stale"
+    fi
+  done
 
   echo "==> Building web assets (channel: github, ungated)..."
   cd "$SCRIPT_DIR"
   VITE_BUILD_CHANNEL=github npm run build:mobile
 
-  echo "==> Building sideload APK (ungated)..."
+  echo "==> Building sideload APK (ungated, versionName suffix: -$GITHUB_VERSION_SUFFIX)..."
   cd "$ANDROID_DIR"
-  ./gradlew assembleRelease
+  ./gradlew assembleRelease -PversionNameSuffix="$GITHUB_VERSION_SUFFIX"
 
   # assembleRelease emits app-release-unsigned.apk until signing is configured,
   # and app-release.apk once it is — copy whichever exists.
   APK_REL_DIR="app/build/outputs/apk/release"
   if [ -f "$APK_REL_DIR/app-release.apk" ]; then
-    cp "$APK_REL_DIR/app-release.apk" "$OUT_DIR/lifeglance.apk"
-    echo "    APK → outputs/lifeglance.apk (signed)"
+    APK_OUT="lifeglance-github.apk"
+    cp "$APK_REL_DIR/app-release.apk" "$OUT_DIR/$APK_OUT"
+    echo "    APK → outputs/$APK_OUT (signed)"
   else
-    cp "$APK_REL_DIR/app-release-unsigned.apk" "$OUT_DIR/lifeglance-unsigned.apk"
-    echo "    APK → outputs/lifeglance-unsigned.apk (UNSIGNED — configure signing to publish)"
+    APK_OUT="lifeglance-github-unsigned.apk"
+    cp "$APK_REL_DIR/app-release-unsigned.apk" "$OUT_DIR/$APK_OUT"
+    echo "    APK → outputs/$APK_OUT (UNSIGNED — configure signing to publish)"
   fi
 
   # Second web build produces a new content-hashed bundle; wipe the stale
@@ -124,6 +153,42 @@ if $RELEASE; then
 
   cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/lifeglance.aab"
   echo "    AAB → outputs/lifeglance.aab"
+
+  # Print the APK's signing certificate. The published fingerprint is in
+  # README.md ("Verifying the APK"); a mismatch means the artifact was not
+  # produced by this keystore. Also catches a missing/misconfigured
+  # key.properties that would otherwise ship an unsigned APK.
+  SDK_DIR="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
+  APKSIGNER="$(command -v apksigner || true)"
+  if [ -z "$APKSIGNER" ] && [ -n "$SDK_DIR" ]; then
+    APKSIGNER="$(ls "$SDK_DIR"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -1)"
+  fi
+  if [ "$APK_OUT" = "lifeglance-github-unsigned.apk" ]; then
+    echo "    (APK is unsigned; skipping signature check)"
+  elif [ -n "$APKSIGNER" ]; then
+    # No `|| true`: set -e is on, so a bad signature stops the release here
+    # rather than at the point someone tries to install the APK.
+    echo "==> Verifying APK signature..."
+    "$APKSIGNER" verify --print-certs "$OUT_DIR/$APK_OUT"
+  else
+    echo "    (apksigner not found on PATH or in \$ANDROID_HOME; skipping signature check)"
+  fi
+
+  # SHA-256 checksums for the release artifacts, written with bare filenames so
+  # `sha256sum -c SHA256SUMS.txt` works wherever they are downloaded to. Publish
+  # it alongside the APK on the GitHub release: it is the user-side proof that
+  # the APK they installed is this build and not a repack from a mirror site
+  # (mirrors redistribute the GATED Play build under the same name and version).
+  echo "==> Writing SHA-256 checksums..."
+  (
+    cd "$OUT_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$APK_OUT" lifeglance.aab > SHA256SUMS.txt
+    else
+      shasum -a 256 "$APK_OUT" lifeglance.aab > SHA256SUMS.txt
+    fi
+    sed 's/^/    /' SHA256SUMS.txt
+  )
 
   echo ""
   echo "==> Android release build complete. outputs/:"

--- a/capacitor.config.js
+++ b/capacitor.config.js
@@ -4,7 +4,18 @@
 // with require(); under this package's `"type": "module"` that returns the ES
 // module namespace, so top-level config keys must BE the named exports — a
 // default export would end up nested under `.default` and be ignored.
-export const appId = 'com.lifeglance'
+
+// appId is only a scaffold default — it is what `npx cap add <platform>` would
+// stamp into a NEWLY generated native project. The identifiers that actually
+// ship are set in the native projects and must not be changed:
+//   Android: applicationId "com.lifeglance.app"           (android/app/build.gradle)
+//   iOS:     PRODUCT_BUNDLE_IDENTIFIER = com.lifeglance   (ios/App/App.xcodeproj)
+// The two diverged historically. This file carries the ANDROID id because that
+// is the published one: regenerating android/ from a different value would
+// produce a package Play cannot update and that no existing install can be
+// upgraded over. Regenerating ios/ from here would need the bundle id (and the
+// widget/share extension ids) put back by hand.
+export const appId = 'com.lifeglance.app'
 export const appName = 'lifeGLANCE'
 export const webDir = 'dist'
 export const plugins = {
@@ -15,10 +26,10 @@ export const plugins = {
 
 // Play Billing only works on the Play-signed release build, whose WebView is
 // not inspectable by default. `build.sh --webview-debug` sets this env var so
-// entitlement state can be reset via chrome://inspect during billing tests
-// (see docs/paywall-billing-plan.md, Lessons 7/8). Default off — a debuggable
-// WebView in production would expose sync credentials to anyone with a USB
-// cable, so never promote a --webview-debug build.
+// entitlement state can be reset via chrome://inspect during billing tests.
+// Default off — a debuggable WebView in production would expose sync
+// credentials to anyone with a USB cable, so never promote a
+// --webview-debug build.
 export const android = {
   webContentsDebuggingEnabled: process.env.CAP_WEBVIEW_DEBUG === '1',
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,7 +71,7 @@ export default function App() {
   // A reviewer code unlocks the app but leaves no way back to the paywall — the
   // only surface that shows the in-app purchases. The billing engine exposes no
   // revoke, so clear the reviewer-unlock key directly and reload; with no
-  // entitlement the gate (and the IAPs) returns. See docs/reviewer-access-flow.md.
+  // entitlement the gate (and the IAPs) returns.
   const exitReviewerMode = () => {
     try { localStorage.removeItem('glance-billing.reviewer-unlock') } catch { /* storage unavailable */ }
     location.reload()
@@ -318,7 +318,12 @@ export default function App() {
       vaultSkipped={vaultSkipped}
       onOpenCloudSync={() => setCloudSyncOpen(true)}
       onOpenSubscription={billing.gated ? () => setSubscriptionOpen(true) : undefined}
-      licenseSource={billing.gated ? billing.entitlementSource : null}
+      licenseSource={
+        // Passed on every channel, not just gated ones: on an ungated build it
+        // reads 'channel' and settings then says "This build is fully unlocked"
+        // — the only in-app way to tell the sideload build from the Play one.
+        billing.entitlementSource
+      }
       demoLoaded={import.meta.env.VITE_DEMO && demoLoaded}
       onClearDemo={import.meta.env.VITE_DEMO ? handleClearDemo : undefined}
     />

--- a/src/components/billing/ReviewerBanner.jsx
+++ b/src/components/billing/ReviewerBanner.jsx
@@ -6,8 +6,9 @@ import { useTranslation } from 'react-i18next'
 // through the store. Its action returns to the paywall, which is the only surface
 // that shows the in-app purchases: without a way back, a reviewer who used the
 // code "cannot locate the IAPs" and the app is rejected under App Review 2.1(b).
-// See docs/reviewer-access-flow.md. Colours use --amber-rgb / --amber-bright,
-// which already adapt to light/dark.
+// Exiting clears the reviewer-unlock key and reloads (App.jsx
+// exitReviewerMode). Colours use --amber-rgb / --amber-bright, which already
+// adapt to light/dark.
 export default function ReviewerBanner({ onExit }) {
   const { t } = useTranslation('billing')
   return (

--- a/src/components/settings/SettingsModal.jsx
+++ b/src/components/settings/SettingsModal.jsx
@@ -461,26 +461,33 @@ export default function SettingsModal({
           </div>
         )}
 
-        {/* ── Subscription (gated Play builds only) — kept last so the
-            license state is always at the bottom of the sheet ───────────── */}
-        {onOpenSubscription && (
+        {/* ── Subscription — kept last so the license state is always at the
+            bottom of the sheet. Shown on EVERY channel: on an ungated build
+            (web/PWA, GitHub sideload APK, dev) licenseSource is 'channel' and
+            the line reads "This build is fully unlocked." Without it a sideload
+            user has no way to tell their build from the gated Play one — same
+            applicationId, name, icon and version — which is exactly how a
+            "the GitHub APK is showing me the paywall" report starts. The
+            manage/purchase button stays gated: ungated builds have no IAPs. */}
+        {licenseSource && (
           <div className="settings-section">
             <div className="settings-label">{tb('title')}</div>
-            {licenseSource && (
-              <div className="settings-license-line">
-                {tb({
-                  lifetime:     'statusLifetime',
-                  subscription: 'statusSubscription',
-                  reviewer:     'statusReviewer',
-                  none:         'statusNone',
-                }[licenseSource] ?? 'statusNone')}
+            <div className="settings-license-line">
+              {tb({
+                lifetime:     'statusLifetime',
+                subscription: 'statusSubscription',
+                reviewer:     'statusReviewer',
+                channel:      'statusChannel',
+                none:         'statusNone',
+              }[licenseSource] ?? 'statusNone')}
+            </div>
+            {onOpenSubscription && (
+              <div className="settings-backup-row">
+                <button className="btn"
+                  style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
+                  onClick={() => { onClose(); onOpenSubscription() }}>{tb('manage')}</button>
               </div>
             )}
-            <div className="settings-backup-row">
-              <button className="btn"
-                style={{ fontSize: '0.75rem', padding: '0.4rem 0.85rem' }}
-                onClick={() => { onClose(); onOpenSubscription() }}>{tb('manage')}</button>
-            </div>
           </div>
         )}
       </div>

--- a/src/config/reviewerAccess.test.js
+++ b/src/config/reviewerAccess.test.js
@@ -13,7 +13,7 @@ describe('reviewerAccess', () => {
 
   // Pinned vector: fails if REVIEWER_SECRET ever changes. That is the point —
   // rotating the secret after a build reaches store review invalidates the
-  // codes already in the review notes (docs/paywall-billing-plan.md Lesson 2).
+  // codes already in the review notes.
   // Only update this vector if the secret is changed deliberately, before any
   // reviewed build carries it.
   it('matches the pinned vector for this app secret', async () => {

--- a/src/lib/intentsOutbox.js
+++ b/src/lib/intentsOutbox.js
@@ -15,7 +15,7 @@
 // written to disk (structural, not a convention).
 //
 // Mirrors dayGLANCE's outbox shape so the send-side semantics are identical
-// across apps (see docs/glance-intents-transport-reference.md §2).
+// across apps.
 // =============================================================================
 
 const DB_NAME    = 'lifeglance-intents-outbox'

--- a/src/lib/intentsVaultTransport.js
+++ b/src/lib/intentsVaultTransport.js
@@ -17,7 +17,8 @@
 // reliably bootstrapped on every setup path (dbSync.js). Two GLANCE apps that feed the
 // same passphrase + the same server-owned vault salt derive the byte-identical
 // key and decrypt each other's envelopes. NEVER plaintext on the vault, send or
-// receive. See docs/glance-intents-transport-reference.md §3–§5.
+// receive. The envelope format is the one @glance-apps/intents implements and
+// every GLANCE app shares — change it here only in lockstep with that package.
 // =============================================================================
 
 import {


### PR DESCRIPTION
## Why

A GitHub-APK user reported hitting the paywall. They can't have:

- The gate needs a billing adapter. `src/billing/billing.js` builds one only for `VITE_BUILD_CHANNEL=play` on Android, `@glance-apps/billing` reports a null adapter as ungated (`engine.js`: `gated = this.adapter !== null`), and `App.jsx` renders the gate only on `gated && !isUnlocked`. The default fails *open* — a missing or typo'd channel var yields `'web'`.
- Every published `lifeglance.apk` — v3.0.0, v3.0.1, v3.1.0, v3.2.0, v3.3.0, v3.3.1 — has `adapter = null` inlined in its bundle. I downloaded and grepped all six.

The real problem is that nothing tells the two Android artifacts apart. They share an `applicationId`, app name, icon and `versionCode`; only the web assets and the signing key differ. So a Play install — or a mirror site's repack of one, which is the same binary — is indistinguishable from the sideload APK, and a report like this can't be triaged.

## What changed

**In-app indicator.** Settings now shows the license line on every channel, not only gated ones. On an ungated build `entitlementSource` is `'channel'` and the already-translated `statusChannel` copy reads *"This build is fully unlocked."* The manage/purchase button stays gated — ungated builds have no IAPs. This also means the line appears on web/PWA; say the word if you'd rather scope it to native.

**Artifact naming.** The release APK is now `outputs/lifeglance-github.apk` (matching dayGLANCE's `dayglance-github.apk`) and carries a `-github` versionName suffix, so Android's app info shows e.g. `3.3.1-github`. `--version-suffix` still composes: `3.3.1-rc1-github`. The versionCode is untouched, so updates work normally, and the AAB keeps the clean `x.y.z` name Play expects. Stale `lifeglance.apk` / `lifeglance-unsigned.apk` from pre-rename runs are cleared from `outputs/` so the wrong file can't be attached to a release.

**Verification.** `build.sh` now runs `apksigner verify --print-certs` (skipped when unsigned; no `|| true`, so a real mismatch stops the release under `set -e`) and writes `SHA256SUMS.txt` — both modeled on lastGLANCE, which already does this. README gains *"Which build am I running?"* and *"Verifying the APK"*: the signing fingerprint, `sha256sum -c` instructions, the mirror-site warning, and the export-before-you-switch caveat (the keys differ, so switching needs an uninstall, which erases local data).

**appId.** `capacitor.config.js` carried `com.lifeglance` while Gradle publishes `com.lifeglance.app`. Not a typo — `com.lifeglance` is the *iOS* bundle id (`project.pbxproj:747`), and Android is the outlier. The value is only a scaffold default for `cap add`, so it now carries the Android id (the published, unchangeable one — regenerating `android/` from the wrong value would orphan every Play install) and documents all three identifiers. iOS isn't on the App Store yet, so the mismatch there costs nothing today.

**Comments.** References to `docs/paywall-billing-plan.md`, `docs/reviewer-access-flow.md` and `docs/glance-intents-transport-reference.md` — none of which exist in this repo, or in lastGLANCE or dayGLANCE — are rewritten to stand alone.

## Verification

- `npm run lint` — 0 errors (27 pre-existing warnings)
- `npm test` — 820/820 pass
- Both channel builds still fold correctly: `VITE_BUILD_CHANNEL=github` inlines `adapter = null`; `play` keeps the platform-conditional adapter

## Note

The release-asset rename may prompt existing Obtainium users to re-pick the APK once. There's only one APK asset, so it should auto-resolve, but it's worth a line in the release notes.

The matching change for lastGLANCE is krelltunez/lastGLANCE#314.